### PR TITLE
Teaser News Story Pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-fontawesome": "^0.1.18",
     "@testing-library/jest-dom": "^5.16.4",
+    "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "cross-fetch": "^3.1.5",
     "drupal-jsonapi-params": "^2.0.0",

--- a/src/components/node/news_story/index.tsx
+++ b/src/components/node/news_story/index.tsx
@@ -24,7 +24,7 @@ import { NodeNewsStory } from '@/types/node'
 /**
  * These components expect NodeNewsStory as their input.
  */
-type NodeNewsStoryProps = {
+export type NodeNewsStoryProps = {
   node: NodeNewsStory
   viewMode?: string
 }
@@ -84,13 +84,56 @@ export const NewsStoryFull = ({ node }: NodeNewsStoryProps) => {
   )
 }
 
+export const NewsStoryTeaser = ({ node }: NodeNewsStoryProps) => {
+  return (
+    <article
+      data-template="teasers/news_story_page_feature"
+      id={`featured-content-${node.id}`}
+      className="featured-story
+      usa-grid
+      usa-grid-full
+      vads-u-margin-bottom--3
+      medium-screen:vads-u-margin-bottom--4
+      vads-u-display--flex
+      vads-u-flex-direction--column
+      medium-screen:vads-u-flex-direction--row
+      vads-u-border-left--7px
+      vads-u-border-color--primary-alt-lightest"
+    >
+      <div className="usa-width-one-half medium-screen:vads-u-padding-left--2">
+        <span className="vads-u-font-weight--bold vads-u-display--block">
+          In the spotlight at
+        </span>
+        <h2 className="vads-u-font-size--md medium-screen:vads-u-font-size--lg vads-u-margin-top--0 medium-screen:vads-u-margin-bottom--0p5">
+          {node.title}
+        </h2>
+        <div className="vads-l-grid-container--full">
+          <div className="va-introtext">
+            <p className="events-show" id="office-events-description">
+              {node.field_intro_text}
+            </p>
+          </div>
+        </div>
+        <div className="usa-width-one-half vads-u-order--first medium-screen:vads-u-order--initial vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0">
+          <MediaImageComponent
+            image={node.field_media}
+            imageStyle={'1_1_square_medium_thumbnail'}
+          />
+        </div>
+      </div>
+    </article>
+  )
+}
+
 /** General News Story component. Allows choice of different display components by the caller. */
 export const NewsStory = ({ node, viewMode, ...props }: NodeNewsStoryProps) => {
   switch (viewMode) {
     case 'full':
       return <NewsStoryFull node={node} {...props} />
       break
-
+    case 'teaser':
+      return <NewsStoryTeaser node={node} {...props} />
+      break
     default:
       return null
   }

--- a/src/pages/demo/newsStory/[page].tsx
+++ b/src/pages/demo/newsStory/[page].tsx
@@ -1,0 +1,92 @@
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
+import { drupalClient } from '@/utils/drupalClient'
+import { GetStaticPathsResult } from 'next'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+import Container from '@/components/container'
+import { NewsStory } from '@/components/node/news_story'
+import Pagination from '@department-of-veterans-affairs/component-library/Pagination'
+
+export const NUMBER_OF_POSTS_PER_PAGE = 3
+export const TOTAL = 20
+
+const NewsStoryPage = ({ node, page }) => {
+  const router = useRouter()
+  if (!node) node = []
+
+  return (
+    <>
+      <Container className="container">
+        {node.map((news) => (
+          <NewsStory key={news.id} node={news} viewMode="teaser" />
+        ))}
+
+        {page ? (
+          <Pagination
+            page={page?.current}
+            pages={page?.total}
+            onPageSelect={(paginate) =>
+              router.push(`/demo/newsStory/${paginate}`)
+            }
+          />
+        ) : null}
+      </Container>
+    </>
+  )
+}
+
+export default NewsStoryPage
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  // Use SSG for the first pages, then fallback to SSR for other pages.
+
+  const paths = Array(TOTAL)
+    .fill(0)
+    .map((_, page) => ({
+      params: {
+        page: `${page + 1}`,
+      },
+    }))
+
+  return {
+    paths,
+    fallback: 'blocking',
+  }
+}
+
+export async function getStaticProps(context) {
+  const current = parseInt(context?.params?.page)
+  const params = new DrupalJsonApiParams()
+    .addInclude([
+      'field_media',
+      'field_media.image',
+      'field_author',
+      'field_listing',
+    ])
+    .addPageLimit(TOTAL)
+
+  const node = await drupalClient.getResourceCollectionFromContext(
+    'node--news_story',
+    context,
+    {
+      params: {
+        ...params.getQueryObject(),
+        page: {
+          limit: NUMBER_OF_POSTS_PER_PAGE,
+          offset: context.params?.page ? NUMBER_OF_POSTS_PER_PAGE * current : 0,
+        },
+      },
+    }
+  )
+
+  return {
+    props: {
+      node: node || null,
+      current: current,
+      page: {
+        current,
+        total: Math.ceil(TOTAL / NUMBER_OF_POSTS_PER_PAGE),
+      },
+    },
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -46,6 +46,11 @@ export const Core = () => {
             News Story Example 3
           </Link>
         </li>
+        <li>
+          <Link href="/demo/newsStory/0">
+            News story teaser with paginiation
+          </Link>
+        </li>
       </ul>
     </Container>
   )


### PR DESCRIPTION
Pagination on news story listing spike. I was able to get this working using the component library 
`@department-of-veterans-affairs/component-library/Pagination`

The news story teaser component will be replaced by @penny-lischer's work on Component: node--story_listing #8652

![Screen Shot 2022-05-23 at 4 53 05 PM](https://user-images.githubusercontent.com/3916436/169922525-f9c32457-d258-4afa-95e4-e9671bc75ec3.png)
 