### PR TITLE
VACMS-9185: Add tests for ImageComponent

### DIFF
--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -1,0 +1,73 @@
+import { axe, faker, render, screen, waitFor } from 'test-utils'
+import Image from '.'
+import mediaImageIndividual from './mediaImageIndividual.json'
+
+const getUrl = (data) => data.included.filter((obj) => obj.type == 'file--file')[0].attributes.uri.url
+
+const getAltText = (data) => data.data.relationships.image.data.meta.alt
+const getWidth = (data) => data.data.relationships.image.data.meta.width
+const getHeight = (data) => data.data.relationships.image.data.meta.height
+
+describe('Image Component', () => {
+  test('throws an error if no URL is passed in', () => {
+    const originalError = console.error
+    console.error = jest.fn()
+    // eslint-disable-next-line
+    expect(() => render(<Image />)).toThrow(/image is missing required "src" property/i)
+    console.error = originalError
+  })
+  test('throws an error if no height/width properties are passed in', async () => {
+    const originalError = console.error
+    console.error = jest.fn()
+    let url = getUrl(mediaImageIndividual)
+    // eslint-disable-next-line
+    expect(() => render(<Image src={url} />)).toThrow(/image with src "([^"]*)" must use "width" and "height" properties/i)
+    console.error = originalError
+  })
+  test('triggers an accessibility error if no alt text is passed in', async () => {
+    let url = getUrl(mediaImageIndividual)
+    // eslint-disable-next-line
+    const { container } = render(<Image src={url} layout={"fill"} />)
+    await waitFor(async () =>
+      expect(await axe(container)).toEqual(
+        expect.objectContaining({
+          violations: expect.arrayContaining([
+            expect.objectContaining({
+              help: expect.stringMatching(/images must have alternate text/i),
+              id: 'image-alt',
+              impact: 'critical',
+            }),
+          ]),
+        })
+      )
+    )
+  })
+  test('renders if sufficient properties are provided', async () => {
+    let url = getUrl(mediaImageIndividual)
+    let altText = getAltText(mediaImageIndividual)
+    let props = {
+      alt: altText,
+      src: url,
+      width: 600,
+      height: 400,
+    }
+    // eslint-disable-next-line
+    const { container } = render(<Image {...props} />)
+    await waitFor(async () => expect(await axe(container)).toHaveNoViolations())
+    let imgElement;
+
+    // Loading element
+    imgElement = document.querySelector('img[alt=""]')
+    expect(imgElement).toHaveAttribute('alt', '')
+    expect(imgElement).toHaveAttribute('aria-hidden', 'true')
+    expect(imgElement).toHaveAttribute('src', expect.stringContaining('data:image/svg+xml'))
+    expect(imgElement).toHaveAttribute('style', expect.any(String))
+
+    // Actual element
+    imgElement = document.querySelector('img[data-nimg="intrinsic"]')
+    expect(imgElement).toHaveAttribute('alt', altText)
+    expect(imgElement).toHaveAttribute('data-nimg', 'intrinsic')
+    expect(imgElement).toHaveAttribute('src', expect.any(String))
+    expect(imgElement).toHaveAttribute('style', expect.any(String))
+  })
+})

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -2,7 +2,8 @@ import { axe, faker, render, screen, waitFor } from 'test-utils'
 import Image from '.'
 import mediaImageIndividual from './mediaImageIndividual.json'
 
-const getUrl = (data) => data.included.filter((obj) => obj.type == 'file--file')[0].attributes.uri.url
+const getUrl = (data) =>
+  data.included.filter((obj) => obj.type == 'file--file')[0].attributes.uri.url
 
 const getAltText = (data) => data.data.relationships.image.data.meta.alt
 const getWidth = (data) => data.data.relationships.image.data.meta.width
@@ -13,7 +14,9 @@ describe('Image Component', () => {
     const originalError = console.error
     console.error = jest.fn()
     // eslint-disable-next-line
-    expect(() => render(<Image />)).toThrow(/image is missing required "src" property/i)
+    expect(() => render(<Image />)).toThrow(
+      /image is missing required "src" property/i
+    )
     console.error = originalError
   })
   test('throws an error if no height/width properties are passed in', async () => {
@@ -21,13 +24,15 @@ describe('Image Component', () => {
     console.error = jest.fn()
     let url = getUrl(mediaImageIndividual)
     // eslint-disable-next-line
-    expect(() => render(<Image src={url} />)).toThrow(/image with src "([^"]*)" must use "width" and "height" properties/i)
+    expect(() => render(<Image src={url} />)).toThrow(
+      /image with src "([^"]*)" must use "width" and "height" properties/i
+    )
     console.error = originalError
   })
   test('triggers an accessibility error if no alt text is passed in', async () => {
     let url = getUrl(mediaImageIndividual)
     // eslint-disable-next-line
-    const { container } = render(<Image src={url} layout={"fill"} />)
+    const { container } = render(<Image src={url} layout={'fill'} />)
     await waitFor(async () =>
       expect(await axe(container)).toEqual(
         expect.objectContaining({
@@ -54,13 +59,16 @@ describe('Image Component', () => {
     // eslint-disable-next-line
     const { container } = render(<Image {...props} />)
     await waitFor(async () => expect(await axe(container)).toHaveNoViolations())
-    let imgElement;
+    let imgElement
 
     // Loading element
     imgElement = document.querySelector('img[alt=""]')
     expect(imgElement).toHaveAttribute('alt', '')
     expect(imgElement).toHaveAttribute('aria-hidden', 'true')
-    expect(imgElement).toHaveAttribute('src', expect.stringContaining('data:image/svg+xml'))
+    expect(imgElement).toHaveAttribute(
+      'src',
+      expect.stringContaining('data:image/svg+xml')
+    )
     expect(imgElement).toHaveAttribute('style', expect.any(String))
 
     // Actual element

--- a/src/components/image/mediaImageIndividual.json
+++ b/src/components/image/mediaImageIndividual.json
@@ -1,0 +1,294 @@
+{
+  "jsonapi": {
+    "version": "1.0",
+    "meta": {
+      "links": {
+        "self": {
+          "href": "http://jsonapi.org/format/1.0/"
+        }
+      }
+    }
+  },
+  "data": {
+    "type": "media--image",
+    "id": "ffd0a3fd-1a61-4d4e-b275-6af6882168ab",
+    "links": {
+      "self": {
+        "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab?resourceVersion=id%3A15904"
+      }
+    },
+    "attributes": {
+      "drupal_internal__mid": 15070,
+      "drupal_internal__vid": 15904,
+      "langcode": "en",
+      "revision_created": "2022-06-23T13:41:05+00:00",
+      "revision_log_message": null,
+      "status": true,
+      "name": "Wilmington VA Mobile Clinic ",
+      "created": "2022-06-23T13:40:48+00:00",
+      "changed": "2022-06-23T13:41:05+00:00",
+      "default_langcode": true,
+      "revision_translation_affected": true,
+      "metatag": null,
+      "path": {
+        "alias": "/media/image/15070",
+        "pid": 63231,
+        "langcode": "en"
+      },
+      "field_description": "Mobile Clinic",
+      "field_media_in_library": true,
+      "field_media_submission_guideline": null
+    },
+    "relationships": {
+      "bundle": {
+        "data": {
+          "type": "media_type--media_type",
+          "id": "92f64a34-81e5-4094-82a9-4fe61d7f2227",
+          "meta": {
+            "drupal_internal__target_id": "image"
+          }
+        },
+        "links": {
+          "related": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/bundle?resourceVersion=id%3A15904"
+          },
+          "self": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/relationships/bundle?resourceVersion=id%3A15904"
+          }
+        }
+      },
+      "revision_user": {
+        "data": {
+          "type": "user--user",
+          "id": "412272ee-6e47-4d26-9e46-b424d1d390d8",
+          "meta": {
+            "drupal_internal__target_id": 1486
+          }
+        },
+        "links": {
+          "related": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/revision_user?resourceVersion=id%3A15904"
+          },
+          "self": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/relationships/revision_user?resourceVersion=id%3A15904"
+          }
+        }
+      },
+      "uid": {
+        "data": {
+          "type": "user--user",
+          "id": "412272ee-6e47-4d26-9e46-b424d1d390d8",
+          "meta": {
+            "drupal_internal__target_id": 1486
+          }
+        },
+        "links": {
+          "related": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/uid?resourceVersion=id%3A15904"
+          },
+          "self": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/relationships/uid?resourceVersion=id%3A15904"
+          }
+        }
+      },
+      "thumbnail": {
+        "data": {
+          "type": "file--file",
+          "id": "79e21eb7-9b34-421a-a4b2-7b6626814ce0",
+          "meta": {
+            "alt": "Wilmington VA Mobile Clinic ",
+            "title": null,
+            "width": 1430,
+            "height": 950,
+            "drupal_internal__target_id": 17425
+          }
+        },
+        "links": {
+          "related": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/thumbnail?resourceVersion=id%3A15904"
+          },
+          "self": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/relationships/thumbnail?resourceVersion=id%3A15904"
+          }
+        }
+      },
+      "field_owner": {
+        "data": {
+          "type": "taxonomy_term--administration",
+          "id": "f55a34b8-f0cc-41f1-a6a3-8375160003ab",
+          "meta": {
+            "drupal_internal__target_id": 188
+          }
+        },
+        "links": {
+          "related": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/field_owner?resourceVersion=id%3A15904"
+          },
+          "self": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/relationships/field_owner?resourceVersion=id%3A15904"
+          }
+        }
+      },
+      "image": {
+        "data": {
+          "type": "file--file",
+          "id": "79e21eb7-9b34-421a-a4b2-7b6626814ce0",
+          "meta": {
+            "alt": "Wilmington VA Mobile Clinic ",
+            "title": "",
+            "width": 1430,
+            "height": 950,
+            "drupal_internal__target_id": 17425
+          }
+        },
+        "links": {
+          "related": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/image?resourceVersion=id%3A15904"
+          },
+          "self": {
+            "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab/relationships/image?resourceVersion=id%3A15904"
+          }
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "file--file",
+      "id": "79e21eb7-9b34-421a-a4b2-7b6626814ce0",
+      "links": {
+        "1_1_square_medium_thumbnail": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/1_1_square_medium_thumbnail/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "240",
+            "height": "240",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        },
+        "2_1_large": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/2_1_large/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "1024",
+            "height": "512",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        },
+        "2_1_medium_thumbnail": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/2_1_medium_thumbnail/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "480",
+            "height": "240",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        },
+        "2_3_medium_thumbnail": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/2_3_medium_thumbnail/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "320",
+            "height": "480",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        },
+        "3_2_medium_thumbnail": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/3_2_medium_thumbnail/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "480",
+            "height": "320",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        },
+        "7_2_medium_thumbnail": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/7_2_medium_thumbnail/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "1050",
+            "height": "300",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        },
+        "full_content_width": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/full_content_width/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "1400",
+            "height": "930",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        },
+        "large": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/large/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "480",
+            "height": "319",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        },
+        "self": {
+          "href": "https://prod.cms.va.gov/jsonapi/file/file/79e21eb7-9b34-421a-a4b2-7b6626814ce0"
+        },
+        "viewport_width": {
+          "href": "https://prod.cms.va.gov/sites/default/files/styles/viewport_width/public/2022-06/mobile_clinic.jpg",
+          "meta": {
+            "width": "1430",
+            "height": "950",
+            "rel": [
+              "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
+            ]
+          }
+        }
+      },
+      "attributes": {
+        "drupal_internal__fid": 17425,
+        "langcode": "en",
+        "filename": "mobile_clinic.jpg",
+        "uri": {
+          "value": "public://2022-06/mobile_clinic.jpg",
+          "url": "/sites/default/files/2022-06/mobile_clinic.jpg"
+        },
+        "filemime": "image/jpeg",
+        "filesize": 370481,
+        "status": true,
+        "created": "2022-06-23T13:40:48+00:00",
+        "changed": "2022-06-23T13:41:05+00:00"
+      },
+      "relationships": {
+        "uid": {
+          "data": {
+            "type": "user--user",
+            "id": "412272ee-6e47-4d26-9e46-b424d1d390d8",
+            "meta": {
+              "drupal_internal__target_id": 1486
+            }
+          },
+          "links": {
+            "related": {
+              "href": "https://prod.cms.va.gov/jsonapi/file/file/79e21eb7-9b34-421a-a4b2-7b6626814ce0/uid"
+            },
+            "self": {
+              "href": "https://prod.cms.va.gov/jsonapi/file/file/79e21eb7-9b34-421a-a4b2-7b6626814ce0/relationships/uid"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "links": {
+    "self": {
+      "href": "https://prod.cms.va.gov/jsonapi/media/image/ffd0a3fd-1a61-4d4e-b275-6af6882168ab?include=image"
+    }
+  }
+}


### PR DESCRIPTION
Focused on testing the Image side of things, since the Media side is actually already covered [here](https://github.com/department-of-veterans-affairs/next-build/blob/main/src/components/media/index.test.tsx).