### PR TITLE
VACMS 8639 Component - Paragraph Rich Text Char Limit 1000

### DIFF
--- a/src/components/paragraph/index.tsx
+++ b/src/components/paragraph/index.tsx
@@ -11,6 +11,7 @@ import { Meta as ExpandableTextMeta } from '@/components/paragraph/expandable_te
 import { Meta as StaffProfileMeta } from '@/components/paragraph/staff_profile'
 import { Meta as LinkTeaserMeta } from '@/components/paragraph/link_teaser'
 import { Meta as WysiwygMeta } from '@/components/paragraph/wysiwyg'
+import { Meta as RichTextCharLimit1000Meta } from '@/components/paragraph/rich_text_char_limit_1000'
 /** Collect all imported paragraph meta information. */
 const paragraphMetaIn: ParagraphMetaInfo[] = [
   AudienceTopicsMeta,
@@ -20,6 +21,7 @@ const paragraphMetaIn: ParagraphMetaInfo[] = [
   StaffProfileMeta,
   LinkTeaserMeta,
   WysiwygMeta,
+  RichTextCharLimit1000Meta,
 ]
 
 /** Converts the meta information into a form indexed by resource type. */

--- a/src/components/paragraph/rich_text_char_limit_1000/index.test.tsx
+++ b/src/components/paragraph/rich_text_char_limit_1000/index.test.tsx
@@ -22,7 +22,9 @@ const paragraph: ParagraphRichTextCharLimit1000 = {
 
 describe('ParagraphWysiwyg with valid data', () => {
   test('correctly renders ParagraphWysiwyg component', () => {
-    render(<RichTextCharLimit1000 paragraph={paragraph} />)
+    if (paragraph.type === 'paragraph--rich_text_char_limit_1000') {
+      render(<RichTextCharLimit1000 paragraph={paragraph} />)
+    }
     expect(
       screen.queryByText(
         /A medical record that shows you have an Agent Orange‒related/
@@ -34,7 +36,9 @@ describe('ParagraphWysiwyg with valid data', () => {
 describe('ParagraphWysiwyg with invalid data', () => {
   test('does not render ParagraphWysiwyg when data is null', () => {
     paragraph.field_wysiwyg = null
-    render(<RichTextCharLimit1000 paragraph={paragraph} />)
+    if (paragraph.type === 'paragraph--rich_text_char_limit_1000') {
+      render(<RichTextCharLimit1000 paragraph={paragraph} />)
+    }
     expect(
       screen.queryByText(
         /A medical record that shows you have an Agent Orange‒related/

--- a/src/components/paragraph/rich_text_char_limit_1000/index.test.tsx
+++ b/src/components/paragraph/rich_text_char_limit_1000/index.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { ParagraphRichTextCharLimit1000 } from '@/types/paragraph'
+import RichTextCharLimit1000 from '@/components/paragraph/rich_text_char_limit_1000/index'
+
+const paragraph: ParagraphRichTextCharLimit1000 = {
+  type: 'paragraph--rich_text_char_limit_1000',
+  id: 'c4d10aa1-3bb9-4f39-99fd-f110b465603f',
+  created: '2020-10-16T20:09:53+00:00',
+  parent_id: '6887',
+  parent_type: 'node',
+  field_wysiwyg: {
+    format: 'rich_text_limited',
+    processed:
+      "You'll need to submit:\n\n\nA medical record that shows you have an Agent Orange‒related illness, and\nMilitary records to show how you came into contact with Agent orange during your service\n\n\nIf the illness you’re claiming isn’t a presumptive disease, you’ll also need to: \n\nShow that the problem started during—or got worse because of—your military service, or\nProvide scientific and medical evidence that the illness is related to contact with Agent Orange. Scientific proof may include an article from a medical journal or a published research study. \n\nGet your VA medical records online\nRequest your military service records\n",
+    value: 'null',
+  },
+  drupal_internal__id: 123,
+  drupal_internal__revision_id: 1,
+  langcode: 'en',
+  status: true,
+}
+
+describe('ParagraphWysiwyg with valid data', () => {
+  test('correctly renders ParagraphWysiwyg component', () => {
+    render(<RichTextCharLimit1000 paragraph={paragraph} />)
+    expect(
+      screen.queryByText(
+        /A medical record that shows you have an Agent Orange‒related/
+      )
+    ).toBeInTheDocument()
+  })
+})
+
+describe('ParagraphWysiwyg with invalid data', () => {
+  test('does not render ParagraphWysiwyg when data is null', () => {
+    paragraph.field_wysiwyg = null
+    render(<RichTextCharLimit1000 paragraph={paragraph} />)
+    expect(
+      screen.queryByText(
+        /A medical record that shows you have an Agent Orange‒related/
+      )
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/paragraph/rich_text_char_limit_1000/index.test.tsx
+++ b/src/components/paragraph/rich_text_char_limit_1000/index.test.tsx
@@ -20,8 +20,8 @@ const paragraph: ParagraphRichTextCharLimit1000 = {
   status: true,
 }
 
-describe('ParagraphWysiwyg with valid data', () => {
-  test('correctly renders ParagraphWysiwyg component', () => {
+describe('ParagraphRichTextCharLimit1000 with valid data', () => {
+  test('correctly renders ParagraphRichTextCharLimit1000 component', () => {
     if (paragraph.type === 'paragraph--rich_text_char_limit_1000') {
       render(<RichTextCharLimit1000 paragraph={paragraph} />)
     }
@@ -33,8 +33,8 @@ describe('ParagraphWysiwyg with valid data', () => {
   })
 })
 
-describe('ParagraphWysiwyg with invalid data', () => {
-  test('does not render ParagraphWysiwyg when data is null', () => {
+describe('ParagraphRichTextCharLimit1000 with invalid data', () => {
+  test('does not render ParagraphRichTextCharLimit1000 when data is null', () => {
     paragraph.field_wysiwyg = null
     if (paragraph.type === 'paragraph--rich_text_char_limit_1000') {
       render(<RichTextCharLimit1000 paragraph={paragraph} />)

--- a/src/components/paragraph/rich_text_char_limit_1000/index.tsx
+++ b/src/components/paragraph/rich_text_char_limit_1000/index.tsx
@@ -1,0 +1,28 @@
+import {
+  ParagraphProps,
+  ParagraphResourceType,
+  ParagraphMetaInfo,
+} from '@/types/paragraph'
+
+import { isValidData } from '@/utils/helpers'
+import Wysiwyg from '@/components/paragraph/wysiwyg'
+
+function RichTextCharLimit1000({ paragraph, className }: ParagraphProps) {
+  if (!isValidData(paragraph)) return
+
+  return (
+    <div
+      data-template="paragraphs/rich_text_char_limit_1000"
+      data-entity-id={paragraph.id}
+    >
+      <Wysiwyg key={paragraph.id} className={className} paragraph={paragraph} />
+    </div>
+  )
+}
+
+export const Meta: ParagraphMetaInfo = {
+  resource: ParagraphResourceType.RichTextCharLimit1000,
+  component: RichTextCharLimit1000,
+}
+
+export default RichTextCharLimit1000

--- a/src/components/paragraph/rich_text_char_limit_1000/index.tsx
+++ b/src/components/paragraph/rich_text_char_limit_1000/index.tsx
@@ -11,10 +11,7 @@ function RichTextCharLimit1000({ paragraph, className }: ParagraphProps) {
   if (!isValidData(paragraph)) return
 
   return (
-    <div
-      data-template="paragraphs/rich_text_char_limit_1000"
-      data-entity-id={paragraph.id}
-    >
+    <div data-entity-id={paragraph.id}>
       <Wysiwyg key={paragraph.id} className={className} paragraph={paragraph} />
     </div>
   )

--- a/src/pages/demo/richTextCharLimit1000/index.tsx
+++ b/src/pages/demo/richTextCharLimit1000/index.tsx
@@ -1,0 +1,56 @@
+import { drupalClient } from '@/utils/drupalClient'
+import { GetStaticPropsContext, GetStaticPropsResult } from 'next'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+import Container from '@/components/container'
+import {
+  ParagraphRichTextCharLimit1000,
+  ParagraphResourceType,
+} from '@/types/paragraph'
+import { Paragraph } from '@/components/paragraph'
+
+interface RichTextCharLimit1000PageProps {
+  richTextCharLimit1000Collection: ParagraphRichTextCharLimit1000[]
+  className: string
+}
+
+const RichTextCharLimit1000Page = ({
+  richTextCharLimit1000Collection,
+  className,
+}: RichTextCharLimit1000PageProps) => {
+  if (!richTextCharLimit1000Collection) richTextCharLimit1000Collection = []
+
+  return (
+    <Container className="container">
+      {richTextCharLimit1000Collection.map((fieldWysiwyg) => (
+        <Paragraph
+          key={fieldWysiwyg.id}
+          className={className}
+          paragraph={fieldWysiwyg}
+        />
+      ))}
+    </Container>
+  )
+}
+
+export default RichTextCharLimit1000Page
+
+export async function getStaticProps(
+  context: GetStaticPropsContext
+): Promise<GetStaticPropsResult<RichTextCharLimit1000PageProps>> {
+  const params = new DrupalJsonApiParams()
+  params.addPageLimit(20)
+
+  const richTextCharLimit1000Collection =
+    await drupalClient.getResourceCollectionFromContext<
+      ParagraphRichTextCharLimit1000[]
+    >(ParagraphResourceType.RichTextCharLimit1000, context, {
+      params: params.getQueryObject(),
+    })
+
+  return {
+    props: {
+      richTextCharLimit1000Collection,
+      className: 'processed-content',
+    },
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -61,6 +61,11 @@ export const Core = () => {
         <li>
           <Link href="/demo/wysiwyg">Wysiwyg example</Link>
         </li>
+        <li>
+          <Link href="/demo/richTextCharLimit1000">
+            Rich Text Char Limit 1000 example
+          </Link>
+        </li>
         <NodeListOnly />
       </ul>
     </Container>
@@ -77,7 +82,7 @@ const DemoPage = ({ footerData }) => {
 
 export default DemoPage
 
-export async function getStaticProps(context) {
+export async function getStaticProps() {
   const res = await fetch(`https://www.va.gov/generated/headerFooter.json`)
   const data = await res.json()
 

--- a/src/types/paragraph.ts
+++ b/src/types/paragraph.ts
@@ -59,6 +59,7 @@ export const enum ParagraphResourceType {
   StaffProfile = 'paragraph--staff_profile',
   Table = 'paragraph--table',
   Wysiwyg = 'paragraph--wysiwyg',
+  RichTextCharLimit1000 = 'paragraph--rich_text_char_limit_1000',
 }
 
 export interface ParagraphAlert extends DrupalParagraph {


### PR DESCRIPTION
 ### Component - Paragraph Rich Text Char Limit 1000
--------------------

- [x] A component exists that can render a `paragraph--rich_text_char_limit_1000` data structure
- [x] A page exists within the next-build repo that demonstrates the rendering of all `paragraph--rich_text_char_limit_1000`
- [x] That component's output is consistent with the existing output of content-build (visually, markup structure


![Screen Shot 2022-07-08 at 1 14 05 PM](https://user-images.githubusercontent.com/3916436/178063975-1c632722-5adc-4699-9fd1-000fa81d8e8b.png)
)