### PR TITLE
VACMS-0000 wysiwyg as string type

### DIFF
--- a/src/components/paragraph/wysiwyg/index.tsx
+++ b/src/components/paragraph/wysiwyg/index.tsx
@@ -14,7 +14,7 @@ function Wysiwyg({ paragraph, className }: ParagraphProps) {
     const filteredData = filters.reduce((d, f) => d.filter(f), data)
 
     return {
-      __html: filteredData || [filteredData[0]] || '',
+      __html: (filteredData || [filteredData[0]] || '') as string,
     }
   }
 


### PR DESCRIPTION
After pulling main I was seeing this error when running storybook in the other branch... the demo still appeared to render correctly, holler if this is breaking things / the wrong way to go about it

```
ERROR in src/components/paragraph/wysiwyg/index.tsx:25:7
TS2322: Type '{ __html: string | any[]; }' is not assignable to type '{ __html: string; }'.
  Types of property '__html' are incompatible.
    Type 'string | any[]' is not assignable to type 'string'.
      Type 'any[]' is not assignable to type 'string'.
    23 |       key={paragraph.id}
    24 |       className={className}
  > 25 |       dangerouslySetInnerHTML={createMarkup()}
       |       ^^^^^^^^^^^^^^^^^^^^^^^
    26 |     />
    27 |   )
    28 | }
```