### PR TITLE
updating ci action & yarn versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
 
       - name: Install Npm Dependencies
-        run: yarn install
+        run: |
+          yarn policies set-version
+          yarn install --frozen-lockfile
 
       - name: Check TypeScript
         run: yarn test:types


### PR DESCRIPTION
## Description
I suspect some of the CI failures we are seeing are due to yarn version. I see a lot of failures with this signature:

```
Run yarn test:examples
yarn run v1.22.19
$ NODE_ENV=test jest --rootDir ./example_tests --config ./example_tests/jest.config.js
info  - Loaded env from /home/runner/work/next-build/next-build/.env.test
PASS example_tests/03_more_matchers/index.test.js
FAIL example_tests/0[6](https://github.com/department-of-veterans-affairs/next-build/actions/runs/5682467811/job/15400908178#step:9:7)_accessibility_tests/index.test.jsx
  ● <Component3/> › renders without accessibility errors
  ...
  
  Test Suites: 1 failed, 6 passed, 7 total
Tests:       1 failed, 2 skipped, 21 passed, 24 total
Snapshots:   0 total
Time:        11.212 s
Ran all test suites.
error Command failed with exit code 1.
```

Locally, I don't have any errors when I run test:examples:
```
yarn test:examples
info  - Loaded env from /Users/heffner/dev/next-build/.env.test
 PASS  example_tests/01_hello_world/index.test.js
 PASS  example_tests/02_hello_world_async/index.test.js
 PASS  example_tests/07_tests_with_mock_data/index.test.jsx
 PASS  example_tests/04_hello_world_react/index.test.jsx
 PASS  example_tests/03_more_matchers/index.test.js
 PASS  example_tests/05_interactive_components/index.test.jsx
 PASS  example_tests/06_accessibility_tests/index.test.jsx

Test Suites: 7 passed, 7 total
Tests:       2 skipped, 22 passed, 24 total
Snapshots:   0 total
Time:        2.505 s
Ran all test suites.
```

I am also on a much newer yarn version:
```
yarn -v
3.6.0
```

I also bumped the versions of the github actions we are using. 

## Testing done
will this PR use the new .ci file?

## QA steps
What needs to be checked to prove this works?  
automated CI should pass if using this updated .ci file
