### PR TITLE
Tugboat sitemaps

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -34,6 +34,6 @@ services:
         # Build the static pages. Set for self-signed certs
         - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt yarn export
         # Generate sitemap
-        - yarn postbuild
+        - SITE_URL=${TUGBOAT_DEFAULT_SERVICE_URL} yarn postbuild
         # Set the webroot to the output folder.
         - ln -snf "${TUGBOAT_ROOT}/out" "${DOCROOT}"


### PR DESCRIPTION
## Description
Relates to #138 

sitemap is correctly generated for tugboat envs now

## Testing done
I had to rebuild the pr environment a lot before the command didn't work. something feels flaky on the endpoint when building, the failed slugs are rarely the same from run to run.

## Screenshots
before
![Screenshot 2023-08-11 at 4 36 11 PM](https://github.com/department-of-veterans-affairs/next-build/assets/11279744/93a2dc1b-5995-48bb-af83-4c7cc364feef)

after
![Screenshot 2023-08-11 at 4 35 43 PM](https://github.com/department-of-veterans-affairs/next-build/assets/11279744/fac5f1f3-8a61-4a9a-8d08-810eab9eafe2)


## QA steps
visit https://pr140-pbomutnnzidvsnpkvota2cfpndh290bv.tugboat.vfs.va.gov/sitemap.xml
