### PR TITLE
use string.match() instead of array.includes() to check hostname

### DIFF
--- a/src/lib/utils/drupalClient.ts
+++ b/src/lib/utils/drupalClient.ts
@@ -7,11 +7,9 @@ export const baseUrl = process.env.NEXT_PUBLIC_DRUPAL_BASE_URL || 'cms.va.gov'
 const url = new URL(baseUrl)
 const host = url.host
 
-const allowedHosts = ['cms.va.gov']
-
 // tugboat env doesn't need the SOCKS proxy. APP_ENV set in tugboat
 export const useProxy =
-  allowedHosts.includes(host) && process.env.APP_ENV != 'tugboat'
+  host.match('cms.va.gov') && process.env.APP_ENV != 'tugboat'
 
 export const fetcher = async (input: RequestInfo, init?: RequestInit) => {
   if (useProxy) {

--- a/src/lib/utils/drupalClient.ts
+++ b/src/lib/utils/drupalClient.ts
@@ -37,4 +37,5 @@ export const fetcher = async (input: RequestInfo, init?: RequestInit) => {
 
 export const drupalClient = new DrupalClient(baseUrl, {
   fetcher,
+  useDefaultResourceTypeEntry: true,
 })

--- a/src/lib/utils/drupalClient.ts
+++ b/src/lib/utils/drupalClient.ts
@@ -9,7 +9,7 @@ const host = url.host
 
 // tugboat env doesn't need the SOCKS proxy. APP_ENV set in tugboat
 export const useProxy =
-  host.match('cms.va.gov') && process.env.APP_ENV != 'tugboat'
+  host.match(/cms\.va\.gov$/) && process.env.APP_ENV != 'tugboat'
 
 export const fetcher = async (input: RequestInfo, init?: RequestInit) => {
   if (useProxy) {


### PR DESCRIPTION
## Description
should fix the problem when building locally using the https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov endpoint. if the codeQL check is okay with it 🤞 

## Testing done

## Screenshots

## QA steps

[ ] - does the site resolve correctly locally when using the content build endpoint?
[ ] - when using the local ddev cms endpoint?
[ ] - on tugboat environments?