### PR TITLE
mock console errors in jest tests where logs arent needed

### DIFF
--- a/src/templates/common/image/index.test.jsx
+++ b/src/templates/common/image/index.test.jsx
@@ -10,6 +10,17 @@ const getWidth = (data) => data.data.relationships.image.data.meta.width
 const getHeight = (data) => data.data.relationships.image.data.meta.height
 
 describe('Image Component', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error')
+    jest.spyOn(console, 'warn')
+    console.error.mockImplementation(() => null)
+    console.warn.mockImplementation(() => null)
+  })
+
+  afterEach(() => {
+    console.error.mockRestore()
+    console.warn.mockRestore()
+  })
   test('throws an error if URL is empty', async () => {
     const originalError = console.error
     console.error = jest.fn()

--- a/src/templates/components/newsStoryTeaser/index.test.tsx
+++ b/src/templates/components/newsStoryTeaser/index.test.tsx
@@ -34,6 +34,13 @@ const teaserData = {
 }
 
 describe('<NewsStoryTeaser> with valid data', () => {
+  let spy: jest.SpyInstance
+  beforeEach(() => {
+    spy = jest.spyOn(console, 'error').mockImplementation(() => null)
+  })
+  afterEach(() => {
+    spy.mockRestore()
+  })
   test('renders component', () => {
     const { container } = render(<NewsStoryTeaser {...teaserData} />)
     const imgEl = container.querySelectorAll('img')

--- a/src/templates/layouts/newsStory/index.test.tsx
+++ b/src/templates/layouts/newsStory/index.test.tsx
@@ -46,6 +46,13 @@ const data = {
 }
 
 describe('<newsStory> with valid data', () => {
+  let spy: jest.SpyInstance
+  beforeEach(() => {
+    spy = jest.spyOn(console, 'error').mockImplementation(() => null)
+  })
+  afterEach(() => {
+    spy.mockRestore()
+  })
   test('renders component', () => {
     const { container } = render(<NewsStory {...data} />)
     const imgEl = container.querySelectorAll('img')


### PR DESCRIPTION
## Description
Cleans up console for tests. Mocks console warning and errors in files where they are not needed.

## Testing done
Local
## Screenshots
<img width="1068" alt="image" src="https://github.com/department-of-veterans-affairs/next-build/assets/61624970/7331db8d-1a2c-47b4-b048-89f978d37de8">

## QA steps

What needs to be checked to prove this works?  
- Verify tests still pass
- Verify that console doesnt have any unnecessary logs when running unit tests


### Definition of Done

- [ ] Documentation has been updated, if applicable.
- [ ] Tests have been added if necessary.
- [ ] Automated tests have passed.
- [ ] Code Quality Tests have passed.
- [ ] Acceptance Criteria in related issue are met.
- [ ] Manual Code Review Approved.

### Is this PR blocked by another PR?

- [ ] `DO NOT MERGE`
