### PR TITLE
switch from apache to nginx

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,8 +1,8 @@
 services:
   # Configure a standard apache webserver to host our site.
-  apache:
-    # Use the most recent version of httpd service.
-    image: tugboatqa/httpd:latest
+  web:
+    # Use the most recent version of nginx.
+    image: tugboatqa/nginx:latest
 
     # Explicitly set this as the default service
     #   1. Clones the git repository into the service container

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -82,6 +82,7 @@ export async function getStaticProps(context) {
   return {
     props: {
       resource,
+      bannerData: [],
       // ...(await getGlobalElements(context)),
     },
   }

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -4,7 +4,7 @@ import Head from 'next/head'
 
 import { drupalClient } from '@/lib/utils/drupalClient'
 import { queries } from '@/data/queries'
-import { getGlobalElements } from '@/lib/context/getGlobalElements'
+// import { getGlobalElements } from '@/lib/context/getGlobalElements'
 import { Wrapper } from '@/templates/globals/wrapper'
 import { NewsStory } from '@/templates/layouts/newsStory'
 import { StoryListing } from '@/templates/layouts/storyListing'
@@ -82,7 +82,7 @@ export async function getStaticProps(context) {
   return {
     props: {
       resource,
-      ...(await getGlobalElements(context)),
+      // ...(await getGlobalElements(context)),
     },
   }
 }


### PR DESCRIPTION
## Description
Right now, Tugboat builds are consistently failing on random urls. There are 3 main sources of failures:

- "Bad Gateway" 
- "Unexpected < in JSON" coming from the banner endpoint
- "absolute urls are not allowed", sporadic, but almost always a request or two after one of the other errors

I turned off the banner endpoint to eliminate that second source, which eliminates many instances of the third one. The banner endpoint should be turned back on as part of https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14779

The "Bad Gateway" error I am still investigating, I think it is related to the response header size but I am not 100% on that yet.

It happens much more sparingly with banners turned off as well, but it still happens 1-2x a run. 

## Testing done

## Screenshots

## QA steps

