### PR TITLE
exclude generated files from typechecking

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,8 @@
 src/**/__tests__/*
+public/generated/*
+/node_modules/*
+/coverage/*
+/.swc/*
+/.next/*
+/out/*
+/storybook-static/*

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,7 @@
       "error",
       {
         "devDependencies": [
-          "**/*.test.*",
+          "src/**/*.test.*",
           "test/*",
           "jest.config.js",
           "jest.setup.js",

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ certs/rootCA.pem
 docs/**/*
 
 /public/generated
+/public/data
 
 #allow
 !docs/**/*.md

--- a/scripts/setup-dev.js
+++ b/scripts/setup-dev.js
@@ -19,23 +19,36 @@ const cmsDataPath = path.resolve(__dirname, '..', 'public', 'data', 'cms')
       // eslint-disable-next-line no-console
       console.log('Symlink already exists.')
     }
-
-    // Grab data file populated by the cms
-    fetch('https://va.gov/data/cms/vamc-ehr.json')
-      .then((res) => res.json())
-      .then((data) => {
-        fs.mkdirp(cmsDataPath)
-          .then(() => {
-            fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data)
-          })
-          .catch((err) => {
-            console.error('Error with cms data directory: ', err)
-          })
-      })
-      .catch((err) => {
-        console.error('Error fetching cms data from va.gov: ', err)
-      })
   } catch (error) {
     console.error('Error creating symlink:', error)
+  }
+
+  try {
+    const vamcEhrExists = await fs.pathExists(cmsDataPath)
+
+    if (!vamcEhrExists) {
+      // Grab data file populated by the cms
+      await fetch('https://va.gov/data/cms/vamc-ehr.json')
+        .then((res) => res.json())
+        .then((data) => {
+          fs.mkdirp(cmsDataPath)
+            .then(() => {
+              fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data)
+              // eslint-disable-next-line no-console
+              console.log('vamc-ehr data fetched successfully!')
+            })
+            .catch((err) => {
+              console.error('Error with cms data directory: ', err)
+            })
+        })
+        .catch((err) => {
+          console.error('Error fetching cms data from va.gov: ', err)
+        })
+    } else {
+      // eslint-disable-next-line no-console
+      console.log('vamc-ehr data already exists.')
+    }
+  } catch (error) {
+    console.error('Error fetching vamc-ehr data file:', error)
   }
 })()

--- a/scripts/setup-dev.js
+++ b/scripts/setup-dev.js
@@ -4,6 +4,7 @@ const path = require('path')
 
 const target = path.resolve('../vets-website/build/localhost/generated')
 const symlinkPath = path.resolve(__dirname, '..', 'public', 'generated')
+const cmsDataPath = path.resolve(__dirname, '..', 'public', 'data', 'cms')
 
 ;(async () => {
   try {
@@ -18,6 +19,22 @@ const symlinkPath = path.resolve(__dirname, '..', 'public', 'generated')
       // eslint-disable-next-line no-console
       console.log('Symlink already exists.')
     }
+
+    // Grab data file populated by the cms
+    fetch('https://va.gov/data/cms/vamc-ehr.json')
+      .then((res) => res.json())
+      .then((data) => {
+        fs.mkdirp(cmsDataPath)
+          .then(() => {
+            fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data)
+          })
+          .catch((err) => {
+            console.error('Error with cms data directory: ', err)
+          })
+      })
+      .catch((err) => {
+        console.error('Error fetching cms data from va.gov: ', err)
+      })
   } catch (error) {
     console.error('Error creating symlink:', error)
   }

--- a/scripts/setup-dev.js
+++ b/scripts/setup-dev.js
@@ -2,8 +2,9 @@
 const fs = require('fs-extra')
 const path = require('path')
 
-// No __dirname here because we want it to reach the adjacent folder outside of next-build
 const target = path.resolve(
+  __dirname,
+  '..', // extra .. here to get out of next-build
   '..',
   'vets-website',
   'build',

--- a/scripts/setup-dev.js
+++ b/scripts/setup-dev.js
@@ -2,7 +2,14 @@
 const fs = require('fs-extra')
 const path = require('path')
 
-const target = path.resolve('../vets-website/build/localhost/generated')
+// No __dirname here because we want it to reach the adjacent folder outside of next-build
+const target = path.resolve(
+  '..',
+  'vets-website',
+  'build',
+  'localhost',
+  'generated'
+)
 const symlinkPath = path.resolve(__dirname, '..', 'public', 'generated')
 const cmsDataPath = path.resolve(__dirname, '..', 'public', 'data', 'cms')
 
@@ -28,22 +35,23 @@ const cmsDataPath = path.resolve(__dirname, '..', 'public', 'data', 'cms')
 
     if (!vamcEhrExists) {
       // Grab data file populated by the cms
-      await fetch('https://va.gov/data/cms/vamc-ehr.json')
-        .then((res) => res.json())
-        .then((data) => {
-          fs.mkdirp(cmsDataPath)
-            .then(() => {
-              fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data)
-              // eslint-disable-next-line no-console
-              console.log('vamc-ehr data fetched successfully!')
-            })
-            .catch((err) => {
-              console.error('Error with cms data directory: ', err)
-            })
-        })
-        .catch((err) => {
+      const data = await fetch('https://va.gov/data/cms/vamc-ehr.json').catch(
+        (err) => {
           console.error('Error fetching cms data from va.gov: ', err)
-        })
+        }
+      )
+      // eslint-disable-next-line no-console
+      console.log('vamc-ehr data fetched successfully!')
+
+      await fs
+        .mkdirp(cmsDataPath)
+        .catch((err) =>
+          console.error('Error creating cms data directory: ', err)
+        )
+
+      fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data).catch((err) =>
+        console.error('Error writing data file: ', err)
+      )
     } else {
       // eslint-disable-next-line no-console
       console.log('vamc-ehr data already exists.')

--- a/scripts/setup-dev.js
+++ b/scripts/setup-dev.js
@@ -41,7 +41,7 @@ const cmsDataPath = path.resolve(__dirname, '..', 'public', 'data', 'cms')
 
       await fs.mkdirp(cmsDataPath)
 
-      fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data)
+      await fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data)
 
       // eslint-disable-next-line no-console
       console.log('vamc-ehr data fetched successfully!')

--- a/scripts/setup-dev.js
+++ b/scripts/setup-dev.js
@@ -35,23 +35,15 @@ const cmsDataPath = path.resolve(__dirname, '..', 'public', 'data', 'cms')
 
     if (!vamcEhrExists) {
       // Grab data file populated by the cms
-      const data = await fetch('https://va.gov/data/cms/vamc-ehr.json').catch(
-        (err) => {
-          console.error('Error fetching cms data from va.gov: ', err)
-        }
-      )
+      const response = await fetch('https://va.gov/data/cms/vamc-ehr.json')
+      const data = await response.json()
+
+      await fs.mkdirp(cmsDataPath)
+
+      fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data)
+
       // eslint-disable-next-line no-console
       console.log('vamc-ehr data fetched successfully!')
-
-      await fs
-        .mkdirp(cmsDataPath)
-        .catch((err) =>
-          console.error('Error creating cms data directory: ', err)
-        )
-
-      fs.writeJson(`${cmsDataPath}/vamc-ehr.json`, data).catch((err) =>
-        console.error('Error writing data file: ', err)
-      )
     } else {
       // eslint-disable-next-line no-console
       console.log('vamc-ehr data already exists.')

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -20,7 +20,7 @@ import {
   getStaticPathsByResourceType,
 } from '@/lib/utils/staticPaths'
 
-export default function ResourcePage({ resource, globalElements, path }) {
+export default function ResourcePage({ resource, globalElements }) {
   if (!resource) return null
 
   const title = `${resource.title} | Veterans Affairs`
@@ -30,7 +30,7 @@ export default function ResourcePage({ resource, globalElements, path }) {
       <Head>
         <title>{title}</title>
         {/* todo: do all meta tags correctly, this fixes an error on news story */}
-        <meta property="og:url" content={path} />
+        <meta property="og:url" content="foo" />
       </Head>
       {resource.type === RESOURCE_TYPES.STORY_LISTING && (
         <StoryListing {...resource} />
@@ -128,7 +128,6 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         pathInfo.jsonapi?.entryPoint,
         path
       ),
-      path,
     },
   }
 }

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -20,7 +20,7 @@ import {
   getStaticPathsByResourceType,
 } from '@/lib/utils/staticPaths'
 
-export default function ResourcePage({ resource, globalElements }) {
+export default function ResourcePage({ resource, globalElements, path }) {
   if (!resource) return null
 
   const title = `${resource.title} | Veterans Affairs`
@@ -29,6 +29,8 @@ export default function ResourcePage({ resource, globalElements }) {
     <Wrapper bannerData={globalElements.bannerData}>
       <Head>
         <title>{title}</title>
+        {/* todo: do all meta tags correctly, this fixes an error on news story */}
+        <meta property="og:url" content={path} />
       </Head>
       {resource.type === RESOURCE_TYPES.STORY_LISTING && (
         <StoryListing {...resource} />
@@ -126,6 +128,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
         pathInfo.jsonapi?.entryPoint,
         path
       ),
+      path,
     },
   }
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -31,7 +31,7 @@ export default function MyApp({
   useEffect(() => {
     TagManager.initialize(TAG_MANAGER_ARGS)
     defineCustomElements()
-  })
+  }, [])
 
   return getLayout(<Component {...pageProps} key={router.asPath} />)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,7 +46,7 @@
     "**/*.js",
     "**/*.jsx"
   ],
-  "exclude": ["node_modules", "./src/__tests__"],
+  "exclude": ["node_modules", "./src/__tests__", "public/generated"],
   "typedocOptions": {
     "entryPoints": ["src/"],
     "out": "docs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,10 +41,8 @@
     "next-env.d.ts",
     "additional.d.ts",
     "src/**/*",
-    "**/*.ts",
-    "**/*.tsx",
-    "**/*.js",
-    "**/*.jsx"
+    "*/*.{ts|tsx|js|jsx}",
+    "scripts/*"
   ],
   "exclude": ["node_modules", "./src/__tests__", "public/generated"],
   "typedocOptions": {


### PR DESCRIPTION
## Description
After creating the symlink to vets-website (`yarn dev`), other commands would fail: name `yarn test:types` and `yarn build` or `yarn export` (both of which check types) due to typescript looking at all of the generated files from vets-website. We don't need to be checking those, they aren't ours. And they cause our stuff to break if we do.

```
yarn test:types
<--- Last few GCs --->

[8923:0x148040000]    15316 ms: Scavenge 4041.1 (4113.6) -> 4040.0 (4117.9) MB, 5.5 / 0.0 ms  (average mu = 0.564, current mu = 0.386) allocation failure;
[8923:0x148040000]    15330 ms: Scavenge 4045.1 (4118.1) -> 4043.6 (4136.1) MB, 7.5 / 0.0 ms  (average mu = 0.564, current mu = 0.386) allocation failure;
[8923:0x148040000]    15806 ms: Mark-sweep 4055.6 (4136.1) -> 4051.4 (4151.1) MB, 460.6 / 0.0 ms  (average mu = 0.428, current mu = 0.162) allocation failure; scavenge might not succeed


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0x104e966e4 node::Abort() [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
 2: 0x104e968c8 node::ModifyCodeGenerationFromStrings(v8::Local<v8::Context>, v8::Local<v8::Value>, bool) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
 3: 0x104fed60c v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
 4: 0x105197ec4 v8::internal::EmbedderStackStateScope::EmbedderStackStateScope(v8::internal::Heap*, v8::internal::EmbedderStackStateScope::Origin, cppgc::EmbedderStackState) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
 5: 0x10519686c v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
 6: 0x10518a900 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
 7: 0x10518b144 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
 8: 0x1051710c4 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
 9: 0x1055116c0 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
10: 0x10586104c Builtins_CEntry_Return1_DontSaveFPRegs_ArgvOnStack_NoBuiltinExit [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
11: 0x10a779904
12: 0x10a7ae51c
13: 0x10a76486c
14: 0x10a7a0494
15: 0x10a75c128
16: 0x10a7b87fc
17: 0x10a7ae6c0
18: 0x10a76486c
19: 0x10a7a0494
20: 0x10a75c128
21: 0x10a762890
22: 0x10a7733d8
23: 0x10a775c7c
24: 0x10a7631e0
25: 0x10a751cc0
26: 0x10a78a770
27: 0x10a774548
28: 0x10a75cb38
29: 0x10a7cfe0c
30: 0x10a77369c
31: 0x10a775c7c
32: 0x10a7631e0
33: 0x10a751cc0
34: 0x10a78a770
35: 0x10a774548
36: 0x10a75cb38
37: 0x10a848130
38: 0x10a76498c
39: 0x10a7a0494
40: 0x10a75c128
41: 0x10a762890
42: 0x10a7733d8
43: 0x10a775c7c
44: 0x10a7631e0
45: 0x10a751cc0
46: 0x10a78a770
47: 0x10a774548
48: 0x10a75cb38
49: 0x10a7cfe0c
50: 0x10a77369c
51: 0x10a775c7c
52: 0x10a7631e0
53: 0x10a751cc0
54: 0x10a78a770
55: 0x10a774548
56: 0x10a75cb38
57: 0x10a848130
58: 0x10a76498c
59: 0x10a7a0494
60: 0x10a75c128
61: 0x10a762890
62: 0x10a7733d8
63: 0x10a775c7c
64: 0x10a7631e0
65: 0x10a751cc0
66: 0x10a78a770
67: 0x10a774548
68: 0x10a75cb38
69: 0x10a7cfe0c
70: 0x10a77369c
71: 0x10a775c7c
72: 0x10a7631e0
73: 0x10a751cc0
74: 0x10a78a770
75: 0x10a774548
76: 0x10a7b85b8
77: 0x10a72d35c
78: 0x10a7773fc
79: 0x10a8a3f88
80: 0x10a8121f0
81: 0x10a773644
82: 0x10a775c7c
83: 0x10a7631e0
84: 0x10a751cc0
85: 0x10a78a770
86: 0x10a774548
87: 0x10a75cb38
88: 0x10a7cfe0c
89: 0x10a77369c
90: 0x10a775c7c
91: 0x10a7631e0
92: 0x10a751cc0
93: 0x10a78a770
94: 0x10a774548
95: 0x10a80f974
96: 0x10a7ba65c
97: 0x10a8a3f88
98: 0x10a80dae0
99: 0x10a750584
100: 0x10a764a18
101: 0x10a7a0494
102: 0x10a75c128
103: 0x10a762890
104: 0x10a7733d8
105: 0x10a775c7c
106: 0x10a7631e0
107: 0x10a751cc0
108: 0x10a78a770
109: 0x10a774548
110: 0x10a75cb38
111: 0x10a7cfe0c
112: 0x10a77369c
113: 0x10a775c7c
114: 0x10a7631e0
115: 0x10a751cc0
116: 0x10a78a770
117: 0x10a774548
118: 0x10a75cb38
119: 0x10a848130
120: 0x10a76498c
121: 0x10a7a0494
122: 0x10a3b337c
123: 0x10a817cbc
124: 0x10a3addc4
125: 0x10a3b0c68
126: 0x10a40a128
127: 0x10a86b760
128: 0x10a3b618c
129: 0x10a34bf84
130: 0x10a861098
131: 0x10a34c310
132: 0x10a890e70
133: 0x10a70d1c4
134: 0x10a35b894
135: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
136: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
137: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
138: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
139: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
140: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
141: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
142: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
143: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
144: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
145: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
146: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
147: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
148: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
149: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
150: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
151: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
152: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
153: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
154: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
155: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
156: 0x1057ec198 Builtins_InterpreterEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
157: 0x1057ea4d0 Builtins_JSEntryTrampoline [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
158: 0x1057ea164 Builtins_JSEntry [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
159: 0x105119d40 v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
160: 0x105119280 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
161: 0x1050094ac v8::Function::Call(v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
162: 0x104f02d64 node::Realm::ExecuteBootstrapper(char const*, std::__1::vector<v8::Local<v8::Value>, std::__1::allocator<v8::Local<v8::Value>>>*) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
163: 0x104e606d0 node::StartExecution(node::Environment*, char const*) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
164: 0x104e60630 node::StartExecution(node::Environment*, std::__1::function<v8::MaybeLocal<v8::Value> (node::StartExecutionCallbackInfo const&)>) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
165: 0x104de0708 node::LoadEnvironment(node::Environment*, std::__1::function<v8::MaybeLocal<v8::Value> (node::StartExecutionCallbackInfo const&)>) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
166: 0x104ed32a4 node::NodeMainInstance::Run() [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
167: 0x104e63338 node::LoadSnapshotDataAndRun(node::SnapshotData const**, node::InitializationResult const*) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
168: 0x104e635f0 node::Start(int, char**) [/Users/heffner/.nvm/versions/node/v18.17.1/bin/node]
169: 0x197cf3f28 start [/usr/lib/dyld]
```


I also added a small placeholder meta tag to fix an error thrown on individual news story pages. 
I also added a small fetch function for one more missing data file that was being logged in the console. That will probably need to be adjusted as part of the environment check too.

## Testing done
I was able to run `yarn test:types` and `yarn build` and `yarn export` without it throwing up on the typechecking step.


## QA steps
```[tasklist]
- [x] Automated tests have passed
- [x] Tugboat environment was generated without errors
- [ ] Run `yarn dev` locally to set up the symlink to the vets-website repo. Follow the directions in the readme if you do not have it set up in an adjacent folder already.
- [ ] Run `yarn build` and verify that it makes it past the lint & typechecking portion of the script.
- [ ] Navigate to an individual news story page and verify no errors are thrown.
- [ ] No message in the browser console log about `/public/data/vamc-ehr.json`
```