### PR TITLE
VACMS-15122: Fetches all resources by gluing pages together.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,8 +27,7 @@
     "ecmaFeatures": {
       "modules": true
     },
-    "sourceType": "module",
-    "project": ["./tsconfig.json"]
+    "sourceType": "module"
   },
   "plugins": ["testing-library", "unused-imports"],
   "rules": {
@@ -60,6 +59,12 @@
       "files": ["**/*.stories.*"],
       "rules": {
         "import/no-anonymous-default-export": "off"
+      }
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
       }
     }
   ]

--- a/next.config.js
+++ b/next.config.js
@@ -20,12 +20,13 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   trailingSlash: true,
-  experimental: {
-    // This is experimental but can
-    // be enabled to allow parallel threads
-    // with nextjs automatic static generation
-    workerThreads: false,
-    cpus: 1,
-  },
+  staticPageGenerationTimeout: 180, //arbitrary; 60 is default but it's too small
+  // experimental: {
+  //   // This is experimental but can
+  //   // be enabled to allow parallel threads
+  //   // with nextjs automatic static generation
+  //   workerThreads: false,
+  //   cpus: 1,
+  // },
 }
 module.exports = nextConfig

--- a/src/lib/utils/staticPaths.ts
+++ b/src/lib/utils/staticPaths.ts
@@ -1,42 +1,59 @@
-import { GetStaticPathsContext } from 'next'
 import { drupalClient } from '@/lib/utils/drupalClient'
 import { getAllPagedListingPaths } from '@/lib/utils/listingPages'
 import RESOURCE_TYPES from '@/lib/constants/resourceTypes'
 import { JsonApiResponse, JsonApiResourceWithPath } from 'next-drupal'
 
-async function appendAllSubsequentPages(currentPage: JsonApiResponse) {
-  if (!currentPage) {
-    return []
-  }
-
-  const currentPageData = drupalClient.deserialize(
-    currentPage
-  ) as JsonApiResourceWithPath[]
-  const nextPageLink = currentPage.links?.next
-  const nextPageUrl =
-    typeof nextPageLink === 'string' ? nextPageLink : nextPageLink?.href
-  if (nextPageUrl) {
-    try {
-      const nextPageResponse = await drupalClient.fetch(nextPageUrl)
-      const nextPage = await nextPageResponse.json()
-      return [...currentPageData, ...(await appendAllSubsequentPages(nextPage))]
-    } catch (err) {
-      return currentPageData
-    }
-  } else {
-    return currentPageData
-  }
-}
-
 async function getAllResourcesByResourceType(resourceType: string) {
+  const pageSize = 50 //must be <= 50 due to JSON:API limit
+  const params = {
+    // Note: we only need `path`, but we can't put it first:
+    // See:
+    //  https://next-drupal.org/guides/page-limit
+    //  https://dsva.slack.com/archives/C01SR56755H/p1695244241079879?thread_ts=1695070010.697129&cid=C01SR56755H
+    [`fields[${resourceType}]`]: 'title,path',
+    'page[limit]': pageSize,
+  }
+
+  // 1. Fetch first page.
   const firstPage = await drupalClient.getResourceCollection<JsonApiResponse>(
     resourceType,
     {
+      params,
       deserialize: false,
     }
   )
 
-  return appendAllSubsequentPages(firstPage)
+  // 2. Determine number of pages to fetch.
+  const totalResourceCount = firstPage.meta.count
+  const firstPageData = drupalClient.deserialize(
+    firstPage
+  ) as JsonApiResourceWithPath[]
+  const pageCount = Math.ceil(totalResourceCount / pageSize)
+
+  // 3. If more pages, fetch them in parallel.
+  // Note: If we used JSON:API `next` links, we'd have to fetch in series.
+  if (pageCount <= 1) {
+    return firstPageData
+  }
+  const subsequentPageData = await Promise.all(
+    Array.from({
+      length: pageCount - 1,
+    }).map((_, i) => {
+      const pageNum = i + 2
+      return drupalClient.getResourceCollection<JsonApiResourceWithPath[]>(
+        resourceType,
+        {
+          params: {
+            ...params,
+            'page[offset]': (pageNum - 1) * pageSize,
+          },
+        }
+      )
+    })
+  )
+
+  // 4. Glue all pages together.
+  return [firstPageData, ...subsequentPageData].flat()
 }
 
 export async function getStaticPathsByResourceType(

--- a/src/lib/utils/staticPaths.ts
+++ b/src/lib/utils/staticPaths.ts
@@ -2,20 +2,55 @@ import { GetStaticPathsContext } from 'next'
 import { drupalClient } from '@/lib/utils/drupalClient'
 import { getAllPagedListingPaths } from '@/lib/utils/listingPages'
 import RESOURCE_TYPES from '@/lib/constants/resourceTypes'
+import { JsonApiResponse, JsonApiResourceWithPath } from 'next-drupal'
 
-export async function getStaticPathsByResourceType(
-  resourceType,
-  context: GetStaticPathsContext
-): ReturnType<typeof drupalClient.getStaticPathsFromContext> {
-  return await drupalClient.getStaticPathsFromContext([resourceType], context)
+async function appendAllSubsequentPages(currentPage: JsonApiResponse) {
+  if (!currentPage) {
+    return []
+  }
+
+  const currentPageData = drupalClient.deserialize(
+    currentPage
+  ) as JsonApiResourceWithPath[]
+  const nextPageLink = currentPage.links?.next
+  const nextPageUrl =
+    typeof nextPageLink === 'string' ? nextPageLink : nextPageLink?.href
+  if (nextPageUrl) {
+    try {
+      const nextPageResponse = await drupalClient.fetch(nextPageUrl)
+      const nextPage = await nextPageResponse.json()
+      return [...currentPageData, ...(await appendAllSubsequentPages(nextPage))]
+    } catch (err) {
+      return currentPageData
+    }
+  } else {
+    return currentPageData
+  }
 }
 
-export async function getAllStoryListingStaticPaths(
-  context: GetStaticPathsContext
+async function getAllResourcesByResourceType(resourceType: string) {
+  const firstPage = await drupalClient.getResourceCollection<JsonApiResponse>(
+    resourceType,
+    {
+      deserialize: false,
+    }
+  )
+
+  return appendAllSubsequentPages(firstPage)
+}
+
+export async function getStaticPathsByResourceType(
+  resourceType: string
 ): ReturnType<typeof drupalClient.getStaticPathsFromContext> {
+  const resources = await getAllResourcesByResourceType(resourceType)
+  return drupalClient.buildStaticPathsFromResources(resources)
+}
+
+export async function getAllStoryListingStaticPaths(): ReturnType<
+  typeof drupalClient.getStaticPathsFromContext
+> {
   const storyListingPaths = await getStaticPathsByResourceType(
-    RESOURCE_TYPES.STORY_LISTING,
-    context
+    RESOURCE_TYPES.STORY_LISTING
   )
 
   // Setup paging for listing pages

--- a/src/lib/utils/staticPaths.ts
+++ b/src/lib/utils/staticPaths.ts
@@ -3,7 +3,9 @@ import { getAllPagedListingPaths } from '@/lib/utils/listingPages'
 import RESOURCE_TYPES from '@/lib/constants/resourceTypes'
 import { JsonApiResponse, JsonApiResourceWithPath } from 'next-drupal'
 
-async function getAllResourcesByResourceType(resourceType: string) {
+async function getAllResourcesByResourceType(
+  resourceType: string
+): Promise<JsonApiResourceWithPath[]> {
   const pageSize = 50 //must be <= 50 due to JSON:API limit
   const params = {
     // Note: we only need `path`, but we can't put it first:

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -30,7 +30,7 @@ export default function ResourcePage({ resource, globalElements }) {
       | resourceType: ${resource?.type || 'N/A'}
       | path: ${resource?.entityPath || 'N/A'}
       | entityId: ${resource?.entityId || 'N/A'}
-      | 
+      |
     `
 
   return (
@@ -64,12 +64,9 @@ export async function getStaticPaths(
     }
   }
 
-  const storyListingPaths = await getAllStoryListingStaticPaths(context)
-  const storyPaths = await getStaticPathsByResourceType(
-    RESOURCE_TYPES.STORY,
-    context
-  )
-  const qaPaths = await getStaticPathsByResourceType(RESOURCE_TYPES.QA, context)
+  const storyListingPaths = await getAllStoryListingStaticPaths()
+  const storyPaths = await getStaticPathsByResourceType(RESOURCE_TYPES.STORY)
+  const qaPaths = await getStaticPathsByResourceType(RESOURCE_TYPES.QA)
 
   return {
     paths: [...storyListingPaths, ...storyPaths, ...qaPaths],


### PR DESCRIPTION
Overcomes previous limit of 2000. The previous limit was made possible by a mechanism provided by next-drupal that overrides the limit of 50. This PR uses the individual page limit of 50, but fetches all pages (in parallel, other than the first, which is fetched before all others to determine the total number of pages to be fetched) and glues them together.

## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15122

## Testing done
Built on Tugboat. Resources that were previously missing are now present. Built page count increases by ~1000.

## Screenshots
### Before
![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/4ebe680b-aaf5-41f3-afdb-baa6bf4e8b9a)
### After
![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/4fcc3bb0-116f-4e85-855c-60dcd570f00f)

## QA steps
The successful build on this PR is really the QA. We can spot check that some pages exist. Notably, this page exists and it doesn't exist on the main build as of this writing (before this PR): https://pr171-g7n6873xmk17g4fitznzmw89ondeln9k.tugboat.vfs.va.gov/minneapolis-health-care/stories/challenging-advanced-dementia-patients-often-need-a-bro/