### PR TITLE
15063 - CSS and layout fixes for next-build

### DIFF
--- a/public/importHeaderData.js
+++ b/public/importHeaderData.js
@@ -203,13 +203,6 @@ const headerData = {
       "title": "All VA social media"
     },
     {
-      "column": 3,
-      "href": "https://www.va.gov/performance-dashboard/",
-      "order": 10,
-      "target": null,
-      "title": "VA performance dashboard"
-    },
-    {
       "column": 4,
       "href": "https://www.va.gov/resources/",
       "order": 1,

--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -5,8 +5,6 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 
 * {

--- a/src/data/queries/storyListing.ts
+++ b/src/data/queries/storyListing.ts
@@ -51,7 +51,7 @@ export const data: QueryData<DataOpts, StoryListingData> = async (opts) => {
       params: queries
         .getParams('node--news_story--teaser')
         .addFilter('field_listing.id', entity.id)
-        .addSort('-changed')
+        .addSort('-created')
         .addPageLimit(PAGE_SIZE)
         .addPageOffset(((opts?.page || 1) - 1) * PAGE_SIZE)
         .getQueryObject(),

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -8,12 +8,16 @@ export function truncateWordsOrChar(
   suffix = '...'
 ) {
   if (truncateWords) {
-    return str.split(' ').splice(0, length).join(' ') + suffix
-  } else {
-    if (str.length < length) {
-      return str
+    const words = str.split(' ');
+    if (words.length <= length) {
+      return str;
     }
-    return str.slice(0, length) + suffix
+    return words.splice(0, length).join(' ') + suffix;
+  } else {
+    if (str.length <= length) {
+      return str;
+    }
+    return str.slice(0, length) + suffix;
   }
 }
 

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -8,16 +8,16 @@ export function truncateWordsOrChar(
   suffix = '...'
 ) {
   if (truncateWords) {
-    const words = str.split(' ');
+    const words = str.split(' ')
     if (words.length <= length) {
-      return str;
+      return str
     }
-    return words.splice(0, length).join(' ') + suffix;
+    return words.splice(0, length).join(' ') + suffix
   } else {
     if (str.length <= length) {
-      return str;
+      return str
     }
-    return str.slice(0, length) + suffix;
+    return str.slice(0, length) + suffix
   }
 }
 

--- a/src/templates/globals/banners/promoBanner/index.tsx
+++ b/src/templates/globals/banners/promoBanner/index.tsx
@@ -13,6 +13,7 @@ export const PromoBanner = ({
       role="va-promoBanner"
       href={href}
       alertType={alertType}
+      className={alertType}
     >
       {title}
     </VaPromoBanner>

--- a/src/templates/globals/banners/promoBanner/index.tsx
+++ b/src/templates/globals/banners/promoBanner/index.tsx
@@ -8,12 +8,7 @@ export const PromoBanner = ({
   alertType,
 }: PromoBannerType): JSX.Element => {
   return (
-    <VaPromoBanner
-      id={id}
-      role="va-promoBanner"
-      href={href}
-      type={alertType}
-    >
+    <VaPromoBanner id={id} role="va-promoBanner" href={href} type={alertType}>
       {title}
     </VaPromoBanner>
   )

--- a/src/templates/globals/banners/promoBanner/index.tsx
+++ b/src/templates/globals/banners/promoBanner/index.tsx
@@ -12,8 +12,7 @@ export const PromoBanner = ({
       id={id}
       role="va-promoBanner"
       href={href}
-      alertType={alertType}
-      className={alertType}
+      type={alertType}
     >
       {title}
     </VaPromoBanner>

--- a/src/templates/layouts/storyListing/index.tsx
+++ b/src/templates/layouts/storyListing/index.tsx
@@ -45,9 +45,9 @@ export function StoryListing({
             <div className="va-introtext">
               {introText && <p className="events-show">{introText}</p>}
             </div>
-            <Container className="container">
+            <div className="vads-l-grid-container--full">
               <ul className="usa-unstyled-list">{storyTeasers}</ul>
-            </Container>
+            </div>
 
             {totalPages > 1 && (
               <VaPagination

--- a/src/templates/layouts/storyListing/index.tsx
+++ b/src/templates/layouts/storyListing/index.tsx
@@ -65,7 +65,6 @@ export function StoryListing({
                 }}
               />
             )}
-
           </div>
         </article>
       </div>

--- a/src/templates/layouts/storyListing/index.tsx
+++ b/src/templates/layouts/storyListing/index.tsx
@@ -14,6 +14,7 @@ import { NewsStoryTeaserType, StoryListingType } from '@/types/index'
 import Container from '@/templates/common/container'
 import { NewsStoryTeaser } from '@/templates/components/newsStoryTeaser'
 import { FacilityMenu } from '@/templates/components/facilityMenu'
+import { ContentFooter } from '@/templates/common/contentFooter'
 
 export function StoryListing({
   id,
@@ -66,6 +67,7 @@ export function StoryListing({
               />
             )}
           </div>
+          <ContentFooter />
         </article>
       </div>
     </div>

--- a/src/templates/layouts/storyListing/index.tsx
+++ b/src/templates/layouts/storyListing/index.tsx
@@ -39,32 +39,35 @@ export function StoryListing({
     <div key={id} className="usa-grid usa-grid-full">
       <FacilityMenu {...menu} />
       <div className="usa-width-three-fourths">
-        <h1>{title}</h1>
-        <div className="vads-l-grid-container--full">
-          <div className="va-introtext">
-            {introText && <p className="events-show">{introText}</p>}
+        <article className="usa-content">
+          <h1>{title}</h1>
+          <div className="vads-l-grid-container--full">
+            <div className="va-introtext">
+              {introText && <p className="events-show">{introText}</p>}
+            </div>
             <Container className="container">
               <ul className="usa-unstyled-list">{storyTeasers}</ul>
             </Container>
-          </div>
 
-          {totalPages > 1 && (
-            <VaPagination
-              page={currentPage}
-              pages={totalPages}
-              maxPageListLength={3}
-              onPageSelect={(page) => {
-                const newPage =
-                  page.detail.page > 1 ? `page-${page.detail.page}` : ''
-                const newUrl = window.location.href.replace(
-                  /(?<=stories\/).*/, // everything after /stories/
-                  newPage
-                )
-                window.location.assign(newUrl)
-              }}
-            />
-          )}
-        </div>
+            {totalPages > 1 && (
+              <VaPagination
+                page={currentPage}
+                pages={totalPages}
+                maxPageListLength={3}
+                onPageSelect={(page) => {
+                  const newPage =
+                    page.detail.page > 1 ? `page-${page.detail.page}` : ''
+                  const newUrl = window.location.href.replace(
+                    /(?<=stories\/).*/, // everything after /stories/
+                    newPage
+                  )
+                  window.location.assign(newUrl)
+                }}
+              />
+            )}
+
+          </div>
+        </article>
       </div>
     </div>
   )


### PR DESCRIPTION
## Description
Relates to #[15063](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15063). (or closes?)
Fixes:
- width in main layout div
- image sizes
- Font size differences
- Incorrect font in teaser text
- truncate function always adding '...' even when not truncating

Note:
- Does not address padding discrepancies in the facility side-nav as we will be switching to using the vets-website side-nav
- The main visual difference is that breadcrumbs are not yet in next-build, this ticket does not address that

## Testing done
Local visual testing

## Screenshots
<img width="1201" alt="image" src="https://github.com/department-of-veterans-affairs/next-build/assets/61624970/18b69a0c-2e19-4d5e-999f-edd8dfdb69ca">


## QA steps
Navigate to story listing page or story page and verify that it looks like the live site 



## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
