### PR TITLE
initial stab at building vets-web as part of our tugboat

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -33,19 +33,19 @@ services:
         # Install Node.js from the new repository
         - sudo apt-get install -y nodejs
 
-        # Install nvm
-        # - ./scripts/install-nvm.sh
-        # - nvm use 14.15.0 
-
         # Install yarn
         - corepack enable
+
+        # Install nvm
+        - chmod -R 775 "./scripts/"
+        - ./scripts/install-nvm.sh
+        # - nvm use 14.15.0 
 
         # Install VA Root CA
         - cp "${TUGBOAT_ROOT}"/certs/*.crt /usr/local/share/ca-certificates
         - update-ca-certificates
 
         # Clone vets-website
-        - chmod -R 775 "./scripts/"
         - ./scripts/install-repos.sh
         
         # Build vets-website so assets are available (various widgets, fonts, etc)

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -33,16 +33,34 @@ services:
         # Install Node.js from the new repository
         - sudo apt-get install -y nodejs
 
+        # Install nvm
+        # - ./scripts/install-nvm.sh
+        # - nvm use 14.15.0 
+
         # Install yarn
         - corepack enable
-        - corepack prepare yarn@stable --activate
 
         # Install VA Root CA
         - cp "${TUGBOAT_ROOT}"/certs/*.crt /usr/local/share/ca-certificates
         - update-ca-certificates
 
-        # Install github-status-updater
+        # Clone vets-website
         - chmod -R 775 "./scripts/"
+        - ./scripts/install-repos.sh
+
+        # Install & build vets-website so assets are available
+        - cd ../vets-website
+        # This is the version required by vets-website
+        - corepack prepare yarn@1.19.1 --activate
+        - yarn install
+        - yarn build
+
+        # Go back to next-build
+        - cd ${TUGBOAT_ROOT}
+        # Use our yarn version
+        - corepack prepare yarn@stable --activate
+
+        # Install github-status-updater
         - ./scripts/install_github_status_updater.sh
 
       # Load dependent libraries and assets to prepare the site for build.

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -72,6 +72,9 @@ services:
         # Set cypress tests as pending
         - github-status-updater -action=update_state -state="pending" -context="test:cypress" -description="Waiting for static site generation..." -owner=$TUGBOAT_GITHUB_OWNER -repo=$TUGBOAT_GITHUB_REPO -ref=$TUGBOAT_PREVIEW_SHA
 
+        # Create symlink between vets-website assets and local
+        ln -s ../vets-website/build/localhost/generated "${TUGBOAT_ROOT}/public/generated"
+
         # Build the static pages. Set for self-signed certs
         - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt yarn export
         # Generate sitemap

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -80,7 +80,7 @@ services:
         - ln -snf "${TUGBOAT_ROOT}/out" "${DOCROOT}"
 
         # Create symlink between vets-website assets and next-build
-        - ln -s "../vets-website/build/localhost/generated/" "${TUGBOAT_ROOT}/public/generated/"
+        - ln -snf "/var/lib/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/public/generated"
 
       # Run any commands after the site is built.
       online:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -47,16 +47,10 @@ services:
         # Clone vets-website
         - chmod -R 775 "./scripts/"
         - ./scripts/install-repos.sh
+        
+        # Build vets-website so assets are available (various widgets, fonts, etc)
+        - ./scripts/build-vets-website.sh
 
-        # Install & build vets-website so assets are available
-        - cd ../vets-website
-        # This is the version required by vets-website
-        - corepack prepare yarn@1.19.1 --activate
-        - yarn install
-        - yarn build
-
-        # Go back to next-build
-        - cd ${TUGBOAT_ROOT}
         # Use our yarn version
         - corepack prepare yarn@stable --activate
 

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -73,7 +73,7 @@ services:
         - github-status-updater -action=update_state -state="pending" -context="test:cypress" -description="Waiting for static site generation..." -owner=$TUGBOAT_GITHUB_OWNER -repo=$TUGBOAT_GITHUB_REPO -ref=$TUGBOAT_PREVIEW_SHA
 
         # Create symlink between vets-website assets and local
-        ln -s ../vets-website/build/localhost/generated "${TUGBOAT_ROOT}/public/generated"
+        - ln -s "../vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/public/generated"
 
         # Build the static pages. Set for self-signed certs
         - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt yarn export

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -72,15 +72,15 @@ services:
         # Set cypress tests as pending
         - github-status-updater -action=update_state -state="pending" -context="test:cypress" -description="Waiting for static site generation..." -owner=$TUGBOAT_GITHUB_OWNER -repo=$TUGBOAT_GITHUB_REPO -ref=$TUGBOAT_PREVIEW_SHA
 
-        # Create symlink between vets-website assets and local
-        - ln -s "../vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/public/generated"
-
         # Build the static pages. Set for self-signed certs
         - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt yarn export
         # Generate sitemap
         - SITE_URL=${TUGBOAT_DEFAULT_SERVICE_URL} yarn postbuild
         # Set the webroot to the output folder.
         - ln -snf "${TUGBOAT_ROOT}/out" "${DOCROOT}"
+
+        # Create symlink between vets-website assets and next-build
+        - ln -s "../vets-website/build/localhost/generated/" "${TUGBOAT_ROOT}/public/generated/"
 
       # Run any commands after the site is built.
       online:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -33,13 +33,9 @@ services:
         # Install Node.js from the new repository
         - sudo apt-get install -y nodejs
 
-        # Install yarn
-        - corepack enable
-
         # Install nvm
         - chmod -R 775 "./scripts/"
         - ./scripts/install-nvm.sh
-        # - nvm use 14.15.0 
 
         # Install VA Root CA
         - cp "${TUGBOAT_ROOT}"/certs/*.crt /usr/local/share/ca-certificates
@@ -51,7 +47,8 @@ services:
         # Build vets-website so assets are available (various widgets, fonts, etc)
         - ./scripts/build-vets-website.sh
 
-        # Use our yarn version
+        # Install and use our yarn version
+        - corepack enable
         - corepack prepare yarn@stable --activate
 
         # Install github-status-updater

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -72,15 +72,15 @@ services:
         # Set cypress tests as pending
         - github-status-updater -action=update_state -state="pending" -context="test:cypress" -description="Waiting for static site generation..." -owner=$TUGBOAT_GITHUB_OWNER -repo=$TUGBOAT_GITHUB_REPO -ref=$TUGBOAT_PREVIEW_SHA
 
+        # Create symlink between vets-website assets and next-build
+        - ln -snf "/var/lib/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/public/generated"
+
         # Build the static pages. Set for self-signed certs
         - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt yarn export
         # Generate sitemap
         - SITE_URL=${TUGBOAT_DEFAULT_SERVICE_URL} yarn postbuild
         # Set the webroot to the output folder.
         - ln -snf "${TUGBOAT_ROOT}/out" "${DOCROOT}"
-
-        # Create symlink between vets-website assets and next-build
-        - ln -snf "/var/lib/vets-website/build/localhost/generated" "${TUGBOAT_ROOT}/public/generated"
 
       # Run any commands after the site is built.
       online:

--- a/envs/.env.tugboat
+++ b/envs/.env.tugboat
@@ -3,3 +3,6 @@ NEXT_IMAGE_DOMAIN=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.
 
 # Used for sitemap generation + Cypress tests
 SITE_URL=${TUGBOAT_DEFAULT_SERVICE_URL}
+
+# Where to source vets-website assets from
+NEXT_PUBLIC_ASSETS_URL=/generated/

--- a/scripts/build-vets-website.sh
+++ b/scripts/build-vets-website.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 cd ../vets-website
 
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
 nvm use 14.15.1
 
 echo "Node $(node -v)"

--- a/scripts/build-vets-website.sh
+++ b/scripts/build-vets-website.sh
@@ -1,14 +1,11 @@
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-
+#!/bin/sh
 cd ../vets-website
 
 echo "Node $(node -v)"
 echo "NPM $(npm -v)"
 echo "Yarn $(yarn -v)"
 
-yarn install
 export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
+yarn install
 yarn build

--- a/scripts/build-vets-website.sh
+++ b/scripts/build-vets-website.sh
@@ -1,0 +1,16 @@
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+source ~/.bashrc
+
+pushd "../vets-website"
+
+echo "Node $(node -v)"
+echo "NPM $(npm -v)"
+echo "Yarn $(yarn -v)"
+
+yarn install
+export NODE_EXTRA_CA_CERTS=/etc/pki/tls/certs/ca-bundle.crt
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
+yarn build
+popd

--- a/scripts/build-vets-website.sh
+++ b/scripts/build-vets-website.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 cd ../vets-website
 
+nvm use 14.15.1
+
 echo "Node $(node -v)"
 echo "NPM $(npm -v)"
 echo "Yarn $(yarn -v)"
@@ -9,3 +11,5 @@ export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
 yarn install
 yarn build
+
+nvm use 18.18.0

--- a/scripts/build-vets-website.sh
+++ b/scripts/build-vets-website.sh
@@ -6,6 +6,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
 nvm use 14.15.1
+npm install -g yarn
 
 echo "Node $(node -v)"
 echo "NPM $(npm -v)"

--- a/scripts/build-vets-website.sh
+++ b/scripts/build-vets-website.sh
@@ -1,16 +1,14 @@
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-source ~/.bashrc
 
-pushd "../vets-website"
+cd ../vets-website
 
 echo "Node $(node -v)"
 echo "NPM $(npm -v)"
 echo "Yarn $(yarn -v)"
 
 yarn install
-export NODE_EXTRA_CA_CERTS=/etc/pki/tls/certs/ca-bundle.crt
+export NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=TRUE
 yarn build
-popd

--- a/scripts/install-nvm.sh
+++ b/scripts/install-nvm.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Install NVM.
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+
+# Make sure we can run it.
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+
+nvm install 14.15.1

--- a/scripts/install-nvm.sh
+++ b/scripts/install-nvm.sh
@@ -8,5 +8,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
-
+# our version managed by nvm
+nvm install 18.18.0
+# version vets-website needs
 nvm install 14.15.1

--- a/scripts/install-repos.sh
+++ b/scripts/install-repos.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+if [ ! -d ../vets-website ]; then
+  git clone --single-branch --depth 1 https://github.com/department-of-veterans-affairs/vets-website.git ../vets-website
+else
+  echo "Repo vets-website already cloned."
+fi


### PR DESCRIPTION
## Description
Relates to #[#14977](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14977).

We were sourcing the main entry point from the correct place before, but then the bundle looked for local asset paths anyways. So now I am providing those local asset paths on tugboat.

This should unblock #183 to be tested on tugboat, because the asset paths for the side nav widget will able to properly load.

## Testing done
Checked the generated tugboat environment and saw that assets from vets-website were present and available to the build:
![Screenshot 2023-10-03 at 4 48 11 PM](https://github.com/department-of-veterans-affairs/next-build/assets/11279744/dc3a0a92-18aa-4275-a73a-fe48f22dc6fd)


Compare with the main preview tugboat environment, which has a ton of additional errors in the browser console:
![Screenshot 2023-10-03 at 4 48 30 PM](https://github.com/department-of-veterans-affairs/next-build/assets/11279744/d5fdd2ca-5b00-4921-a52b-99ed79e0178f)


## Screenshots
https://pr184-6ojykrqnalsqywbph3phj1v1lvlufaqq.tugboat.vfs.va.gov/butler-health-care/stories/



## QA steps
```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
- [ ] Header megamenu should work as expected on tugboat
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
