### PR TITLE
VACMS-14744: Lovell switcher and business logic

### DIFF
--- a/additional.d.ts
+++ b/additional.d.ts
@@ -21,3 +21,10 @@ declare module '@department-of-veterans-affairs/component-library/PromoBanner'
 declare module '@department-of-veterans-affairs/component-library/dist/react-bindings'
 declare module 'mq-polyfill'
 declare module 'debug'
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    'va-alert'
+    'va-link'
+  }
+}

--- a/src/data/queries/newsStory.ts
+++ b/src/data/queries/newsStory.ts
@@ -8,6 +8,7 @@ import { drupalClient } from '@/lib/drupal/drupalClient'
 import { queries } from '.'
 import { NodeNewsStory } from '@/types/dataTypes/drupal/node'
 import { NewsStoryType } from '@/types/index'
+import { isLovellFederalResource } from '@/lib/drupal/lovell'
 
 // Define the query params for fetching node--news_story.
 export const params: QueryParams<null> = () => {
@@ -18,6 +19,7 @@ export const params: QueryParams<null> = () => {
       'field_media.image',
       'field_author',
       'field_listing',
+      'field_administration',
     ])
 }
 
@@ -44,6 +46,11 @@ export const data: QueryData<DataOpts, NodeNewsStory> = async (
 export const formatter: QueryFormatter<NodeNewsStory, NewsStoryType> = (
   entity: NodeNewsStory
 ) => {
+  const administration = {
+    id: entity.field_administration?.drupal_internal__tid || null,
+    name: entity.field_administration?.name || null,
+  }
+
   return {
     id: entity.id,
     entityId: entity.drupal_internal__nid,
@@ -65,5 +72,6 @@ export const formatter: QueryFormatter<NodeNewsStory, NewsStoryType> = (
       title: entity.title,
     },
     listing: entity.field_listing.path.alias,
+    administration,
   }
 }

--- a/src/data/queries/newsStory.ts
+++ b/src/data/queries/newsStory.ts
@@ -8,7 +8,6 @@ import { drupalClient } from '@/lib/drupal/drupalClient'
 import { queries } from '.'
 import { NodeNewsStory } from '@/types/dataTypes/drupal/node'
 import { NewsStoryType } from '@/types/index'
-import { isLovellFederalResource } from '@/lib/drupal/lovell'
 
 // Define the query params for fetching node--news_story.
 export const params: QueryParams<null> = () => {
@@ -24,12 +23,12 @@ export const params: QueryParams<null> = () => {
 }
 
 // Define the option types for the data loader.
-type DataOpts = QueryOpts<{
+export type NewsStoryDataOpts = QueryOpts<{
   id: string
 }>
 
 // Implement the data loader.
-export const data: QueryData<DataOpts, NodeNewsStory> = async (
+export const data: QueryData<NewsStoryDataOpts, NodeNewsStory> = async (
   opts
 ): Promise<NodeNewsStory> => {
   const entity = await drupalClient.getResource<NodeNewsStory>(
@@ -46,11 +45,6 @@ export const data: QueryData<DataOpts, NodeNewsStory> = async (
 export const formatter: QueryFormatter<NodeNewsStory, NewsStoryType> = (
   entity: NodeNewsStory
 ) => {
-  const administration = {
-    id: entity.field_administration?.drupal_internal__tid || null,
-    name: entity.field_administration?.name || null,
-  }
-
   return {
     id: entity.id,
     entityId: entity.drupal_internal__nid,
@@ -72,6 +66,9 @@ export const formatter: QueryFormatter<NodeNewsStory, NewsStoryType> = (
       title: entity.title,
     },
     listing: entity.field_listing.path.alias,
-    administration,
+    administration: {
+      id: entity.field_administration?.drupal_internal__tid || null,
+      name: entity.field_administration?.name || null,
+    },
   }
 }

--- a/src/data/queries/staticPathResources.ts
+++ b/src/data/queries/staticPathResources.ts
@@ -23,7 +23,7 @@ export const params: QueryParams<ResourceTypeType> = (
       // See:
       //  https://next-drupal.org/guides/page-limit
       //  https://dsva.slack.com/archives/C01SR56755H/p1695244241079879?thread_ts=1695070010.697129&cid=C01SR56755H
-      .addFields(resourceType, ['field_administration,title,path'])
+      .addFields(resourceType, ['field_administration', 'title', 'path'])
       .addInclude(['field_administration'])
       .addPageLimit(PAGE_SIZE)
   )

--- a/src/data/queries/staticPathResources.ts
+++ b/src/data/queries/staticPathResources.ts
@@ -8,6 +8,7 @@ import { JsonApiResponse, JsonApiResourceWithPath } from 'next-drupal'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { ResourceTypeType } from '@/lib/constants/resourceTypes'
 import { StaticPathResourceType } from '@/types/index'
+import { FieldAdministration } from '@/types/dataTypes/drupal/field_type'
 import { queries } from '.'
 
 const PAGE_SIZE = 50 as const //must be <= 50 due to JSON:API limit
@@ -35,10 +36,7 @@ type DataOpts = QueryOpts<{
 }>
 
 type JsonApiResourceWithPathAndFieldAdmin = JsonApiResourceWithPath & {
-  field_administration: {
-    drupal_internal__tid: number
-    name: string
-  }
+  field_administration: FieldAdministration
 }
 
 // Implement the data loader.

--- a/src/data/queries/storyListing.ts
+++ b/src/data/queries/storyListing.ts
@@ -1,9 +1,4 @@
-import {
-  QueryData,
-  QueryFormatter,
-  QueryOpts,
-  QueryParams,
-} from 'next-drupal-query'
+import { QueryData, QueryFormatter, QueryParams } from 'next-drupal-query'
 import { deserialize } from 'next-drupal'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { queries } from '.'
@@ -13,6 +8,7 @@ import { Menu } from '@/types/dataTypes/drupal/menu'
 import { StoryListingType } from '@/types/index'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
+import { ListingPageDataOpts } from '@/lib/drupal/listingPages'
 
 export const PAGE_SIZE = 10 as const
 
@@ -20,12 +16,6 @@ export const PAGE_SIZE = 10 as const
 export const params: QueryParams<null> = () => {
   return queries.getParams().addInclude(['field_office'])
 }
-
-// Define the option types for the data loader.
-type DataOpts = QueryOpts<{
-  id: string
-  page?: number
-}>
 
 type StoryListingData = {
   entity: NodeStoryListing
@@ -36,7 +26,9 @@ type StoryListingData = {
 }
 
 // Implement the data loader.
-export const data: QueryData<DataOpts, StoryListingData> = async (opts) => {
+export const data: QueryData<ListingPageDataOpts, StoryListingData> = async (
+  opts
+) => {
   const entity = await drupalClient.getResource<NodeStoryListing>(
     'node--story_listing',
     opts?.id,

--- a/src/data/queries/tests/__snapshots__/newsStory.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/newsStory.test.tsx.snap
@@ -2,6 +2,10 @@
 
 exports[`node--news_story formatData outputs formatted data 1`] = `
 Object {
+  "administration": Object {
+    "id": 12,
+    "name": "VA Pittsburgh health care",
+  },
   "author": Object {
     "changed": "2019-08-27T17:50:21+00:00",
     "created": "2019-05-14T16:10:51+00:00",

--- a/src/lib/drupal/listingPages.test.ts
+++ b/src/lib/drupal/listingPages.test.ts
@@ -1,0 +1,70 @@
+import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
+import {
+  isListingResourceType,
+  getListingPageExpandedStaticPropsContext,
+} from './listingPages'
+import { slugToPath } from '@/lib/utils/slug'
+
+const listingPageFirstPageSlug = ['some-health-care', 'stories']
+
+const listingPageSecondPageSlug = ['some-health-care', 'stories', 'page-2']
+
+const nonListingPageSlug = ['some-health-care', 'stories', 'story-title']
+
+describe('isListingResourceType', () => {
+  test('should return true when listing resource type', () => {
+    const storyListingResult = isListingResourceType(
+      RESOURCE_TYPES.STORY_LISTING
+    )
+    expect(storyListingResult).toBe(true)
+  })
+
+  test('should return false when not listing resource type', () => {
+    const storyResult = isListingResourceType(RESOURCE_TYPES.STORY)
+    expect(storyResult).toBe(false)
+  })
+})
+
+describe('getListingPageExpandedStaticPropsContext', () => {
+  test('should properly handle first listing page', () => {
+    const context = {
+      params: {
+        slug: listingPageFirstPageSlug,
+      },
+    }
+    const result = getListingPageExpandedStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: true,
+      firstPagePath: slugToPath(listingPageFirstPageSlug),
+      page: 1,
+    })
+  })
+
+  test('should properly handle subsequent listing page', () => {
+    const context = {
+      params: {
+        slug: listingPageSecondPageSlug,
+      },
+    }
+    const result = getListingPageExpandedStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: true,
+      firstPagePath: slugToPath(listingPageFirstPageSlug),
+      page: 2,
+    })
+  })
+
+  test('should return null/false listing values when not listing page', () => {
+    const context = {
+      params: {
+        slug: nonListingPageSlug,
+      },
+    }
+    const result = getListingPageExpandedStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: false,
+      firstPagePath: null,
+      page: null,
+    })
+  })
+})

--- a/src/lib/drupal/lovell.test.ts
+++ b/src/lib/drupal/lovell.test.ts
@@ -1,8 +1,8 @@
 import {
   LOVELL,
-  isLovellFederalPathResource,
-  isLovellTricarePathResource,
-  isLovellVaPathResource,
+  isLovellFederalResource,
+  isLovellTricareResource,
+  isLovellVaResource,
   bifurcateLovellFederalPathResources,
   removeLovellFederalPathResources,
 } from './lovell'
@@ -46,68 +46,68 @@ const otherResource = {
   },
 }
 
-describe('isLovellFederalPathResource', () => {
+describe('isLovellFederalResource', () => {
   test('should return true when Federal resource', () => {
-    const result = isLovellFederalPathResource(lovellFederalResource)
+    const result = isLovellFederalResource(lovellFederalResource)
     expect(result).toBe(true)
   })
 
   test('should return false when TRICARE resource', () => {
-    const result = isLovellFederalPathResource(lovellTricareResource)
+    const result = isLovellFederalResource(lovellTricareResource)
     expect(result).toBe(false)
   })
 
   test('should return false when VA resource', () => {
-    const result = isLovellFederalPathResource(lovellVaResource)
+    const result = isLovellFederalResource(lovellVaResource)
     expect(result).toBe(false)
   })
 
   test('should return false when any other resource', () => {
-    const result = isLovellFederalPathResource(otherResource)
+    const result = isLovellFederalResource(otherResource)
     expect(result).toBe(false)
   })
 })
 
-describe('isLovellTricarePathResource', () => {
+describe('isLovellTricareResource', () => {
   test('should return true when TRICARE resource', () => {
-    const result = isLovellTricarePathResource(lovellTricareResource)
+    const result = isLovellTricareResource(lovellTricareResource)
     expect(result).toBe(true)
   })
 
   test('should return false when Federal resource', () => {
-    const result = isLovellTricarePathResource(lovellFederalResource)
+    const result = isLovellTricareResource(lovellFederalResource)
     expect(result).toBe(false)
   })
 
   test('should return false when VA resource', () => {
-    const result = isLovellTricarePathResource(lovellVaResource)
+    const result = isLovellTricareResource(lovellVaResource)
     expect(result).toBe(false)
   })
 
   test('should return false when any other resource', () => {
-    const result = isLovellTricarePathResource(otherResource)
+    const result = isLovellTricareResource(otherResource)
     expect(result).toBe(false)
   })
 })
 
-describe('isLovellVaPathResource', () => {
+describe('isLovellVaResource', () => {
   test('should return true when VA resource', () => {
-    const result = isLovellVaPathResource(lovellVaResource)
+    const result = isLovellVaResource(lovellVaResource)
     expect(result).toBe(true)
   })
 
   test('should return false when Federal resource', () => {
-    const result = isLovellVaPathResource(lovellFederalResource)
+    const result = isLovellVaResource(lovellFederalResource)
     expect(result).toBe(false)
   })
 
   test('should return false when TRICARE resource', () => {
-    const result = isLovellVaPathResource(lovellTricareResource)
+    const result = isLovellVaResource(lovellTricareResource)
     expect(result).toBe(false)
   })
 
   test('should return false when any other resource', () => {
-    const result = isLovellVaPathResource(otherResource)
+    const result = isLovellVaResource(otherResource)
     expect(result).toBe(false)
   })
 })
@@ -124,17 +124,13 @@ describe('bifurcateLovellFederalPathResources', () => {
     const modifiedResources = bifurcateLovellFederalPathResources(resources)
     expect(modifiedResources.length).toBe(5)
 
-    const federalResources = modifiedResources.filter(
-      isLovellFederalPathResource
-    )
+    const federalResources = modifiedResources.filter(isLovellFederalResource)
     expect(federalResources.length).toBe(0)
 
-    const tricareResources = modifiedResources.filter(
-      isLovellTricarePathResource
-    )
+    const tricareResources = modifiedResources.filter(isLovellTricareResource)
     expect(tricareResources.length).toBe(2)
 
-    const vaResources = modifiedResources.filter(isLovellVaPathResource)
+    const vaResources = modifiedResources.filter(isLovellVaResource)
     expect(vaResources.length).toBe(2)
   })
 
@@ -158,17 +154,13 @@ describe('removeLovellFederalPathResources', () => {
     const modifiedResources = removeLovellFederalPathResources(resources)
     expect(modifiedResources.length).toBe(3)
 
-    const federalResources = modifiedResources.filter(
-      isLovellFederalPathResource
-    )
+    const federalResources = modifiedResources.filter(isLovellFederalResource)
     expect(federalResources.length).toBe(0)
 
-    const tricareResources = modifiedResources.filter(
-      isLovellTricarePathResource
-    )
+    const tricareResources = modifiedResources.filter(isLovellTricareResource)
     expect(tricareResources.length).toBe(1)
 
-    const vaResources = modifiedResources.filter(isLovellVaPathResource)
+    const vaResources = modifiedResources.filter(isLovellVaResource)
     expect(vaResources.length).toBe(1)
   })
 

--- a/src/lib/drupal/lovell.test.ts
+++ b/src/lib/drupal/lovell.test.ts
@@ -9,7 +9,7 @@ import {
 
 const lovellFederalResource = {
   path: {
-    alias: `/${LOVELL.federal.slug}/stories/story-1`,
+    alias: `/${LOVELL.federal.pathSegment}/stories/story-1`,
     pid: null,
     langcode: null,
   },
@@ -18,7 +18,7 @@ const lovellFederalResource = {
 
 const lovellTricareResource = {
   path: {
-    alias: `/${LOVELL.tricare.slug}/stories/story-1`,
+    alias: `/${LOVELL.tricare.pathSegment}/stories/story-1`,
     pid: null,
     langcode: null,
   },
@@ -27,7 +27,7 @@ const lovellTricareResource = {
 
 const lovellVaResource = {
   path: {
-    alias: `/${LOVELL.va.slug}/stories/story-1`,
+    alias: `/${LOVELL.va.pathSegment}/stories/story-1`,
     pid: null,
     langcode: null,
   },

--- a/src/lib/drupal/lovell.test.ts
+++ b/src/lib/drupal/lovell.test.ts
@@ -1,15 +1,36 @@
+import { NewsStoryType } from '@/types/index'
+import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 import {
   LOVELL,
+  isLovellResourceType,
+  isLovellBifurcatedResourceType,
   isLovellFederalResource,
   isLovellTricareResource,
   isLovellVaResource,
+  isLovellTricarePath,
+  isLovellTricareSlug,
+  isLovellVaSlug,
+  isLovellVaPath,
   bifurcateLovellFederalPathResources,
   removeLovellFederalPathResources,
+  getOppositeVariant,
+  getLovellPageExpandedStaticPropsContext,
+  getLovellPageExpandedStaticPropsResource,
+  LovellExpandedResourceTypeType,
 } from './lovell'
+import { slugToPath } from '@/lib/utils/slug'
+
+const lovellFederalSlug = [LOVELL.federal.pathSegment, 'stories', 'story-1']
+
+const lovellTricareSlug = [LOVELL.tricare.pathSegment, 'stories', 'story-1']
+
+const lovellVaSlug = [LOVELL.va.pathSegment, 'stories', 'story-1']
+
+const otherSlug = ['some-other-health-care', 'stories', 'story-1']
 
 const lovellFederalResource = {
   path: {
-    alias: `/${LOVELL.federal.pathSegment}/stories/story-1`,
+    alias: slugToPath(lovellFederalSlug),
     pid: null,
     langcode: null,
   },
@@ -18,7 +39,7 @@ const lovellFederalResource = {
 
 const lovellTricareResource = {
   path: {
-    alias: `/${LOVELL.tricare.pathSegment}/stories/story-1`,
+    alias: slugToPath(lovellTricareSlug),
     pid: null,
     langcode: null,
   },
@@ -27,7 +48,7 @@ const lovellTricareResource = {
 
 const lovellVaResource = {
   path: {
-    alias: `/${LOVELL.va.pathSegment}/stories/story-1`,
+    alias: slugToPath(lovellVaSlug),
     pid: null,
     langcode: null,
   },
@@ -36,15 +57,43 @@ const lovellVaResource = {
 
 const otherResource = {
   path: {
-    alias: '/some-other-health-care-1/stories/story-1',
+    alias: slugToPath(otherSlug),
     pid: null,
     langcode: null,
   },
   administration: {
-    id: 1,
-    name: 'Some Other health care 1',
+    id: 123,
+    name: 'Some Other health care',
   },
 }
+
+describe('isLovellResourceType', () => {
+  test('should return true when Lovell resource type', () => {
+    const storyResult = isLovellResourceType(RESOURCE_TYPES.STORY)
+    expect(storyResult).toBe(true)
+  })
+
+  test('should return false when not Lovell resource type', () => {
+    const storyListingResult = isLovellResourceType(
+      RESOURCE_TYPES.STORY_LISTING
+    )
+    expect(storyListingResult).toBe(false)
+  })
+})
+
+describe('isLovellBifurcatedResourceType', () => {
+  test('should return true when Lovell bifurcated resource type', () => {
+    const storyResult = isLovellBifurcatedResourceType(RESOURCE_TYPES.STORY)
+    expect(storyResult).toBe(true)
+  })
+
+  test('should return false when not Lovell bifurcated resource type', () => {
+    const storyListingResult = isLovellBifurcatedResourceType(
+      RESOURCE_TYPES.STORY_LISTING
+    )
+    expect(storyListingResult).toBe(false)
+  })
+})
 
 describe('isLovellFederalResource', () => {
   test('should return true when Federal resource', () => {
@@ -112,6 +161,86 @@ describe('isLovellVaResource', () => {
   })
 })
 
+describe('isLovellTricarePath', () => {
+  test('should return true when TRICARE path', () => {
+    const result = isLovellTricarePath(lovellTricareResource.path.alias)
+    expect(result).toBe(true)
+  })
+
+  test('should return false when VA path', () => {
+    const result = isLovellTricarePath(lovellVaResource.path.alias)
+    expect(result).toBe(false)
+  })
+
+  test('should return false when any other path', () => {
+    const result = isLovellTricarePath(otherResource.path.alias)
+    expect(result).toBe(false)
+  })
+})
+
+describe('isLovellVaPath', () => {
+  test('should return true when VA path', () => {
+    const result = isLovellVaPath(lovellVaResource.path.alias)
+    expect(result).toBe(true)
+  })
+
+  test('should return false when TRICARE path', () => {
+    const result = isLovellVaPath(lovellTricareResource.path.alias)
+    expect(result).toBe(false)
+  })
+
+  test('should return false when any other path', () => {
+    const result = isLovellVaPath(otherResource.path.alias)
+    expect(result).toBe(false)
+  })
+})
+
+describe('isLovellTricareSlug', () => {
+  test('should return true when TRICARE slug', () => {
+    const result = isLovellTricareSlug(lovellTricareSlug)
+    expect(result).toBe(true)
+  })
+
+  test('should return false when VA slug', () => {
+    const result = isLovellTricareSlug(lovellVaSlug)
+    expect(result).toBe(false)
+  })
+
+  test('should return false when any other slug', () => {
+    const result = isLovellTricareSlug(otherSlug)
+    expect(result).toBe(false)
+  })
+})
+
+describe('isLovellVaSlug', () => {
+  test('should return true when VA slug', () => {
+    const result = isLovellVaSlug(lovellVaSlug)
+    expect(result).toBe(true)
+  })
+
+  test('should return false when TRICARE path', () => {
+    const result = isLovellVaSlug(lovellTricareSlug)
+    expect(result).toBe(false)
+  })
+
+  test('should return false when any other path', () => {
+    const result = isLovellTricareSlug(otherSlug)
+    expect(result).toBe(false)
+  })
+})
+
+describe('getOppositeVariant', () => {
+  test('should return VA when TRICARE passed in', () => {
+    const result = getOppositeVariant(LOVELL.tricare.variant)
+    expect(result).toBe(LOVELL.va.variant)
+  })
+
+  test('should return TRICARE when VA passed in', () => {
+    const result = getOppositeVariant(LOVELL.va.variant)
+    expect(result).toBe(LOVELL.tricare.variant)
+  })
+})
+
 describe('bifurcateLovellFederalPathResources', () => {
   test('should return one additional TRICARE resource and one additional VA resource when one Federal resource is present', () => {
     const resources = [
@@ -169,5 +298,224 @@ describe('removeLovellFederalPathResources', () => {
 
     const modifiedResources = removeLovellFederalPathResources(resources)
     expect(modifiedResources).toEqual(resources)
+  })
+})
+
+describe('getLovellPageExpandedStaticPropsContext', () => {
+  test('should return TRICARE-populated Lovell values when TRICARE page', () => {
+    const context = {
+      params: {
+        slug: lovellTricareSlug,
+      },
+    }
+    const result = getLovellPageExpandedStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isLovellVariantPage: true,
+      variant: LOVELL.tricare.variant,
+    })
+  })
+
+  test('should return VA-populated Lovell values when VA page', () => {
+    const context = {
+      params: {
+        slug: lovellVaSlug,
+      },
+    }
+    const result = getLovellPageExpandedStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isLovellVariantPage: true,
+      variant: LOVELL.va.variant,
+    })
+  })
+
+  test('should return null/false Lovell values when not Lovell page', () => {
+    const context = {
+      params: {
+        slug: otherSlug,
+      },
+    }
+    const result = getLovellPageExpandedStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isLovellVariantPage: false,
+      variant: null,
+    })
+  })
+})
+
+describe('getLovellPageExpandedStaticPropsResource', () => {
+  describe(`${RESOURCE_TYPES.STORY}`, () => {
+    const newsStoryPartialResource = {
+      id: 'some-unique-id',
+      type: RESOURCE_TYPES.STORY,
+      published: true,
+      title: 'Title',
+      image: {
+        src: 'image/src',
+        alt: 'alt-text',
+      },
+      caption: 'caption',
+      author: {
+        title: 'Author Name',
+      },
+      introText: 'intro-text',
+      bodyContent: 'story-body',
+      date: '2020-01-01',
+      socialLinks: {
+        title: 'Social Network',
+      },
+      listing: 'listing',
+      entityId: 12345,
+    }
+
+    test('should properly handle TRICARE bifurcated news story page', () => {
+      const tricarePath = lovellTricareResource.path.alias
+      const vaPath = lovellVaResource.path.alias
+      const expandedContext = {
+        params: {
+          slug: lovellTricareSlug,
+        },
+        path: tricarePath,
+        drupalPath: tricarePath,
+        lovell: {
+          isLovellVariantPage: true,
+          variant: LOVELL.tricare.variant,
+        },
+        listing: {
+          isListingPage: false,
+          firstPagePath: null,
+          page: null,
+        },
+      }
+      const resource: NewsStoryType = {
+        ...newsStoryPartialResource,
+        entityPath: vaPath, //Bifurcated pages get VA version's path from Drupal
+        socialLinks: {
+          ...newsStoryPartialResource.socialLinks,
+          vaPath,
+        },
+        administration: LOVELL.federal.administration, //This indicates bifurcation
+      }
+
+      const result: LovellExpandedResourceTypeType<NewsStoryType> =
+        getLovellPageExpandedStaticPropsResource(resource, expandedContext)
+
+      expect(result.entityPath).toBe(tricarePath)
+      expect(result.socialLinks.path).toBe(tricarePath)
+      expect(result.administration).toStrictEqual(LOVELL.tricare.administration)
+      expect(result.lovellVariant).toBe(LOVELL.tricare.variant)
+      expect(result.canonicalLink).toBe(vaPath)
+      expect(result.lovellSwitchPath).toBe(vaPath)
+    })
+
+    test('should properly handle VA bifurcated news story page', () => {
+      const vaPath = lovellVaResource.path.alias
+      const tricarePath = lovellTricareResource.path.alias
+      const expandedContext = {
+        params: {
+          slug: lovellVaSlug,
+        },
+        path: vaPath,
+        drupalPath: vaPath,
+        lovell: {
+          isLovellVariantPage: true,
+          variant: LOVELL.va.variant,
+        },
+        listing: {
+          isListingPage: false,
+          firstPagePath: null,
+          page: null,
+        },
+      }
+      const resource: NewsStoryType = {
+        ...newsStoryPartialResource,
+        entityPath: vaPath,
+        socialLinks: {
+          ...newsStoryPartialResource.socialLinks,
+          path: vaPath,
+        },
+        administration: LOVELL.federal.administration, //This indicates bifurcation
+      }
+
+      const result: LovellExpandedResourceTypeType<NewsStoryType> =
+        getLovellPageExpandedStaticPropsResource(resource, expandedContext)
+
+      expect(result.entityPath).toBe(vaPath)
+      expect(result.socialLinks.path).toBe(vaPath)
+      expect(result.administration).toStrictEqual(LOVELL.va.administration)
+      expect(result.lovellVariant).toBe(LOVELL.va.variant)
+      expect(result.canonicalLink).toBe(vaPath)
+      expect(result.lovellSwitchPath).toBe(tricarePath)
+    })
+
+    test('should return original page resource when Lovell but not bifurcated', () => {
+      const path = otherResource.path.alias
+      const expandedContext = {
+        params: {
+          slug: otherSlug,
+        },
+        path,
+        drupalPath: path,
+        lovell: {
+          isLovellVariantPage: true,
+          variant: LOVELL.tricare.variant,
+        },
+        listing: {
+          isListingPage: false,
+          firstPagePath: null,
+          page: null,
+        },
+      }
+      const resource: NewsStoryType = {
+        ...newsStoryPartialResource,
+        entityPath: path, //Non-bifurcated TRICARE pages get TRICARE path
+        socialLinks: {
+          ...newsStoryPartialResource.socialLinks,
+          path,
+        },
+        administration: LOVELL.tricare.administration, //Not bifurcated because not federal
+      }
+
+      const result: LovellExpandedResourceTypeType<NewsStoryType> =
+        getLovellPageExpandedStaticPropsResource(resource, expandedContext)
+
+      expect(result).toStrictEqual(resource)
+    })
+
+    test('should return original page resource when not Lovell page', () => {
+      const path = otherResource.path.alias
+      const expandedContext = {
+        params: {
+          slug: otherSlug,
+        },
+        path,
+        drupalPath: path,
+        lovell: {
+          isLovellVariantPage: false,
+          variant: null,
+        },
+        listing: {
+          isListingPage: false,
+          firstPagePath: null,
+          page: null,
+        },
+      }
+      const resource: NewsStoryType = {
+        ...newsStoryPartialResource,
+        entityPath: path,
+        socialLinks: {
+          ...newsStoryPartialResource.socialLinks,
+          path,
+        },
+        administration: {
+          id: 123,
+          name: 'Some Other Health Care',
+        },
+      }
+      const result = getLovellPageExpandedStaticPropsResource(
+        resource,
+        expandedContext
+      )
+      expect(result).toStrictEqual(resource)
+    })
   })
 })

--- a/src/lib/drupal/lovell.ts
+++ b/src/lib/drupal/lovell.ts
@@ -6,6 +6,7 @@ import {
 } from '@/types/index'
 import { ExpandedStaticPropsContextType } from '@/lib/drupal/staticProps'
 import { RESOURCE_TYPES, ResourceTypeType } from '@/lib/constants/resourceTypes'
+import { slugToPath } from '@/lib/utils/slug'
 
 export const LOVELL = {
   federal: {
@@ -123,37 +124,30 @@ export function isLovellResource(
   )
 }
 
-function isLovellVariantPath(
-  variant: LovellVariant
-): (path: string) => boolean {
-  return (path) => {
-    return new RegExp(`^\/?${LOVELL[variant].pathSegment}`).test(path)
-  }
+function isLovellVariantPath(variant: LovellVariant, path: string): boolean {
+  return new RegExp(`^\/?${LOVELL[variant].pathSegment}`).test(path)
 }
 export function isLovellTricarePath(path: string) {
-  return isLovellVariantPath(LOVELL.tricare.variant)(path)
+  return isLovellVariantPath(LOVELL.tricare.variant, path)
 }
 export function isLovellVaPath(path: string) {
-  return isLovellVariantPath(LOVELL.va.variant)(path)
+  return isLovellVariantPath(LOVELL.va.variant, path)
 }
 
 function isLovellVariantSlug(
-  variant: LovellVariant
-): (slug: string | string[]) => boolean {
-  return (slug) => {
-    const path = typeof slug === 'string' ? slug : slug.join('/')
-    const leadingSlashPath = path.substring(0, 1) === '/' ? path : `/${path}`
-
-    return variant === LOVELL.tricare.variant
-      ? isLovellTricarePath(leadingSlashPath)
-      : isLovellVaPath(leadingSlashPath)
-  }
+  variant: LovellVariant,
+  slug: string | string[]
+): boolean {
+  const path = slugToPath(slug)
+  return variant === LOVELL.tricare.variant
+    ? isLovellTricarePath(path)
+    : isLovellVaPath(path)
 }
 export function isLovellTricareSlug(slug: string | string[]) {
-  return isLovellVariantSlug(LOVELL.tricare.variant)(slug)
+  return isLovellVariantSlug(LOVELL.tricare.variant, slug)
 }
 export function isLovellVaSlug(slug: string | string[]) {
-  return isLovellVariantSlug(LOVELL.va.variant)(slug)
+  return isLovellVariantSlug(LOVELL.va.variant, slug)
 }
 
 export function getOppositeVariant(variant: LovellVariant): LovellVariant {

--- a/src/lib/drupal/lovell.ts
+++ b/src/lib/drupal/lovell.ts
@@ -24,22 +24,16 @@ export const LOVELL = {
   },
 } as const
 
-export function isLovellFederalPathResource(
-  resource: StaticPathResourceType
-): boolean {
-  return resource.administration.id === LOVELL.federal.administration.id
+export function isLovellFederalResource(resource): boolean {
+  return resource?.administration?.id === LOVELL.federal.administration.id
 }
 
-export function isLovellTricarePathResource(
-  resource: StaticPathResourceType
-): boolean {
-  return resource.administration.id === LOVELL.tricare.administration.id
+export function isLovellTricareResource(resource): boolean {
+  return resource?.administration?.id === LOVELL.tricare.administration.id
 }
 
-export function isLovellVaPathResource(
-  resource: StaticPathResourceType
-): boolean {
-  return resource.administration.id === LOVELL.va.administration.id
+export function isLovellVaResource(resource): boolean {
+  return resource?.administration?.id === LOVELL.va.administration.id
 }
 
 /**
@@ -94,7 +88,7 @@ export function bifurcateLovellFederalPathResources(
   // but that would require two passes over the array.
   const { lovellFederalResources, otherResources } = resources.reduce(
     (acc, resource) => {
-      if (isLovellFederalPathResource(resource)) {
+      if (isLovellFederalResource(resource)) {
         acc.lovellFederalResources.push(resource)
       } else {
         acc.otherResources.push(resource)
@@ -116,5 +110,5 @@ export function bifurcateLovellFederalPathResources(
 export function removeLovellFederalPathResources(
   resources: StaticPathResourceType[]
 ): StaticPathResourceType[] {
-  return resources.filter((resource) => !isLovellFederalPathResource(resource))
+  return resources.filter((resource) => !isLovellFederalResource(resource))
 }

--- a/src/lib/drupal/lovell.ts
+++ b/src/lib/drupal/lovell.ts
@@ -2,7 +2,6 @@ import { GetStaticPropsContext } from 'next'
 import {
   NewsStoryType,
   StaticPathResourceType,
-  StaticPropsResourceType,
   StoryListingType,
 } from '@/types/index'
 import { ExpandedStaticPropsContextType } from '@/lib/drupal/staticProps'

--- a/src/lib/drupal/lovell.ts
+++ b/src/lib/drupal/lovell.ts
@@ -1,4 +1,12 @@
-import { StaticPathResourceType } from '@/types/index'
+import { GetStaticPropsContext } from 'next'
+import {
+  NewsStoryType,
+  StaticPathResourceType,
+  StaticPropsResourceType,
+  StoryListingType,
+} from '@/types/index'
+import { ExpandedStaticPropsContextType } from '@/lib/drupal/staticProps'
+import { RESOURCE_TYPES, ResourceTypeType } from '@/lib/constants/resourceTypes'
 
 export const LOVELL = {
   federal: {
@@ -6,50 +14,199 @@ export const LOVELL = {
       id: 347,
       name: 'Lovell Federal health care',
     },
-    slug: 'lovell-federal-health-care',
+    pathSegment: 'lovell-federal-health-care',
   },
   tricare: {
     administration: {
       id: 1039,
       name: 'Lovell - TRICARE',
     },
-    slug: 'lovell-federal-health-care-tricare',
+    pathSegment: 'lovell-federal-health-care-tricare',
+    variant: 'tricare',
   },
   va: {
     administration: {
       id: 1040,
       name: 'Lovell - VA',
     },
-    slug: 'lovell-federal-health-care-va',
+    pathSegment: 'lovell-federal-health-care-va',
+    variant: 'va',
   },
 } as const
 
-export function isLovellFederalResource(resource): boolean {
-  return resource?.administration?.id === LOVELL.federal.administration.id
+const LOVELL_RESOURCE_TYPES = [
+  RESOURCE_TYPES.STORY,
+  // RESOURCE_TYPES.STORY_LISTING,
+]
+
+const LOVELL_BIFURCATED_RESOURCE_TYPES = [RESOURCE_TYPES.STORY]
+
+export type LovellVariant =
+  | typeof LOVELL.tricare.variant
+  | typeof LOVELL.va.variant
+
+type LovellResourceTypeMap = {
+  [K in (typeof LOVELL_RESOURCE_TYPES)[number]]: K extends typeof RESOURCE_TYPES.STORY
+    ? NewsStoryType
+    : K extends typeof RESOURCE_TYPES.STORY_LISTING
+    ? StoryListingType
+    : never
 }
 
-export function isLovellTricareResource(resource): boolean {
-  return resource?.administration?.id === LOVELL.tricare.administration.id
+export type LovellResourceTypeType =
+  LovellResourceTypeMap[keyof LovellResourceTypeMap]
+
+type LovellBifurcatedResourceTypeMap = Pick<
+  LovellResourceTypeMap,
+  (typeof LOVELL_BIFURCATED_RESOURCE_TYPES)[number]
+>
+
+export type LovellBifurcatedResourceTypeType =
+  LovellBifurcatedResourceTypeMap[keyof LovellBifurcatedResourceTypeMap]
+
+export type LovellPageExpandedStaticPropsContextType = {
+  isLovellVariantPage: boolean
+  variant: LovellVariant
 }
 
-export function isLovellVaResource(resource): boolean {
-  return resource?.administration?.id === LOVELL.va.administration.id
+export type LovellPageExpandedStaticPropsResourceType = {
+  canonicalLink?: string
+  lovellVariant?: LovellVariant
+  lovellSwitchPath?: string
+}
+
+export type LovellExpandedResourceTypeType<T extends LovellResourceTypeType> =
+  T & LovellPageExpandedStaticPropsResourceType
+
+export function isLovellResourceType(resourceType: ResourceTypeType): boolean {
+  return (LOVELL_RESOURCE_TYPES as readonly string[]).includes(resourceType)
+}
+
+export function isLovellBifurcatedResourceType(
+  resourceType: ResourceTypeType
+): boolean {
+  return (LOVELL_BIFURCATED_RESOURCE_TYPES as readonly string[]).includes(
+    resourceType
+  )
+}
+
+export function isLovellFederalResource(
+  resource: LovellResourceTypeType | StaticPathResourceType
+): boolean {
+  return (
+    'administration' in resource &&
+    resource?.administration?.id === LOVELL.federal.administration.id
+  )
+}
+export function isLovellTricareResource(
+  resource: LovellResourceTypeType | StaticPathResourceType
+): boolean {
+  return (
+    'administration' in resource &&
+    resource?.administration?.id === LOVELL.tricare.administration.id
+  )
+}
+export function isLovellVaResource(
+  resource: LovellResourceTypeType | StaticPathResourceType
+): boolean {
+  return (
+    'administration' in resource &&
+    resource?.administration?.id === LOVELL.va.administration.id
+  )
+}
+export function isLovellResource(
+  resource: LovellResourceTypeType | StaticPathResourceType
+): boolean {
+  return (
+    isLovellFederalResource(resource) ||
+    isLovellTricareResource(resource) ||
+    isLovellVaResource(resource)
+  )
+}
+
+function isLovellVariantPath(
+  variant: LovellVariant
+): (path: string) => boolean {
+  return (path) => {
+    return new RegExp(`^\/?${LOVELL[variant].pathSegment}`).test(path)
+  }
+}
+export function isLovellTricarePath(path: string) {
+  return isLovellVariantPath(LOVELL.tricare.variant)(path)
+}
+export function isLovellVaPath(path: string) {
+  return isLovellVariantPath(LOVELL.va.variant)(path)
+}
+
+function isLovellVariantSlug(
+  variant: LovellVariant
+): (slug: string | string[]) => boolean {
+  return (slug) => {
+    const path = typeof slug === 'string' ? slug : slug.join('/')
+    const leadingSlashPath = path.substring(0, 1) === '/' ? path : `/${path}`
+
+    return variant === LOVELL.tricare.variant
+      ? isLovellTricarePath(leadingSlashPath)
+      : isLovellVaPath(leadingSlashPath)
+  }
+}
+export function isLovellTricareSlug(slug: string | string[]) {
+  return isLovellVariantSlug(LOVELL.tricare.variant)(slug)
+}
+export function isLovellVaSlug(slug: string | string[]) {
+  return isLovellVariantSlug(LOVELL.va.variant)(slug)
+}
+
+export function getOppositeVariant(variant: LovellVariant): LovellVariant {
+  return variant === LOVELL.tricare.variant
+    ? LOVELL.va.variant
+    : LOVELL.tricare.variant
 }
 
 /**
- * Replaces first slug (system name) in a path with the passed-in slug.
+ * Replaces first segment (system name) in a path according to `variant`.
  * E.g.
  * Input:
  *   path: `/lovell-federal-health-care-va/stories/story-title`
- *   slug: `lovell-federal-health-care-tricare`
+ *   variant: `tricare`
  * Output: `/lovell-federal-health-care-tricare/stories/story-title`
  */
-function replaceLovellSystemSlugInPath(path: string, slug: string): string {
-  return `/${slug}/${path
+function getLovellVariantOfUrl(path: string, variant: LovellVariant): string {
+  return `/${LOVELL[variant].pathSegment}/${path
     .split('/')
     .filter((slug) => slug !== '')
     .slice(1)
     .join('/')}`
+}
+
+/**
+ * Converts resource properties according to variant
+ * and adds lovell-specific properties.
+ *
+ * @param resource
+ * @param variant
+ */
+function getLovellVariantOfResource(
+  resource: LovellBifurcatedResourceTypeType,
+  variant: LovellVariant
+): LovellExpandedResourceTypeType<typeof resource> {
+  const variantPaths = {
+    tricare: getLovellVariantOfUrl(resource.entityPath, LOVELL.tricare.variant),
+    va: getLovellVariantOfUrl(resource.entityPath, LOVELL.va.variant),
+  }
+
+  return {
+    ...resource,
+    entityPath: variantPaths[variant],
+    socialLinks: {
+      ...resource.socialLinks,
+      path: variantPaths[variant],
+    },
+    administration: LOVELL[variant].administration,
+    canonicalLink: variantPaths.va,
+    lovellVariant: variant,
+    lovellSwitchPath: variantPaths[getOppositeVariant(variant)],
+  }
 }
 
 /**
@@ -62,10 +219,7 @@ function bifurcateLovellFederalPathResource(
   const tricareResource = {
     path: {
       ...resource.path,
-      alias: replaceLovellSystemSlugInPath(
-        resource.path.alias,
-        LOVELL.tricare.slug
-      ),
+      alias: getLovellVariantOfUrl(resource.path.alias, LOVELL.tricare.variant),
     },
     administration: LOVELL.tricare.administration,
   }
@@ -73,7 +227,7 @@ function bifurcateLovellFederalPathResource(
   const vaResource = {
     path: {
       ...resource.path,
-      alias: replaceLovellSystemSlugInPath(resource.path.alias, LOVELL.va.slug),
+      alias: getLovellVariantOfUrl(resource.path.alias, LOVELL.va.variant),
     },
     administration: LOVELL.va.administration,
   }
@@ -111,4 +265,56 @@ export function removeLovellFederalPathResources(
   resources: StaticPathResourceType[]
 ): StaticPathResourceType[] {
   return resources.filter((resource) => !isLovellFederalResource(resource))
+}
+
+export function getLovellPageExpandedStaticPropsContext(
+  context: GetStaticPropsContext
+): LovellPageExpandedStaticPropsContextType {
+  const slug = context.params?.slug
+  if (isLovellTricareSlug(slug)) {
+    return {
+      isLovellVariantPage: true,
+      variant: LOVELL.tricare.variant,
+    }
+  }
+
+  if (isLovellVaSlug(slug)) {
+    return {
+      isLovellVariantPage: true,
+      variant: LOVELL.va.variant,
+    }
+  }
+
+  return {
+    isLovellVariantPage: false,
+    variant: null,
+  }
+}
+
+export function getLovellPageExpandedStaticPropsResource<
+  T extends LovellResourceTypeType
+>(
+  resource: T,
+  context: ExpandedStaticPropsContextType
+): LovellExpandedResourceTypeType<LovellResourceTypeType> | T {
+  const isBifurcatedPage =
+    isLovellBifurcatedResourceType(resource.type as ResourceTypeType) &&
+    context.lovell.isLovellVariantPage &&
+    isLovellFederalResource(resource as LovellBifurcatedResourceTypeType)
+  if (isBifurcatedPage) {
+    return getLovellVariantOfResource(
+      resource as LovellBifurcatedResourceTypeType,
+      context.lovell.variant
+    )
+  }
+
+  // const isLovellListingPage =
+  //   isLovellResourceType(resource.type as ResourceTypeType) &&
+  //   context.lovell.isLovellVariantPage &&
+  //   context.listing.isListingPage
+  // if (isLovellListingPage) {
+  //   return mergeFederalListingPage(resource)
+  // }
+
+  return resource
 }

--- a/src/lib/drupal/staticProps.ts
+++ b/src/lib/drupal/staticProps.ts
@@ -1,0 +1,122 @@
+import { GetStaticPropsContext } from 'next'
+import { QueryOpts } from 'next-drupal-query'
+import { drupalClient } from '@/lib/drupal/drupalClient'
+import {
+  ListingPageExpandedStaticPropsContextType,
+  getListingPageExpandedStaticPropsContext,
+} from './listingPages'
+import {
+  LovellPageExpandedStaticPropsContextType,
+  getLovellPageExpandedStaticPropsContext,
+  getLovellPageExpandedStaticPropsResource,
+  LovellPageExpandedStaticPropsResourceType,
+  isLovellResourceType,
+  LovellExpandedResourceTypeType,
+  LovellResourceTypeType,
+} from './lovell'
+import { StaticPropsResourceType } from '@/types/index'
+import { RESOURCE_TYPES, ResourceTypeType } from '@/lib/constants/resourceTypes'
+import { ListingPageDataOpts } from '@/lib/drupal/listingPages'
+import { NewsStoryDataOpts } from '@/data/queries/newsStory'
+
+export type ExpandedStaticPropsContextType = GetStaticPropsContext & {
+  path: string
+  drupalPath: string
+  listing: ListingPageExpandedStaticPropsContextType
+  lovell: LovellPageExpandedStaticPropsContextType
+}
+
+export type ExpandedStaticPropsResourceType<T extends StaticPropsResourceType> =
+  T | LovellExpandedResourceTypeType<LovellResourceTypeType>
+
+/**
+ * Decorates the original context with expanded details:
+ * - LISTING PAGES
+ *   -Determines if the requested page is a listing page. If so:
+ *     - Sets drupalPath to the actual drupal resource (path with page number stripped).
+ *     - Determines the page number.
+ * - LOVELL
+ *   - Determines if the requested page is a Lovell page. If so:
+ *     - Determines the variant (TRICARE/VA).
+ *
+ * @param context
+ * @returns Original context with added props
+ */
+export function getExpandedStaticPropsContext(
+  context: GetStaticPropsContext
+): ExpandedStaticPropsContextType {
+  const path = drupalClient.getPathFromContext(context)
+  const listing = getListingPageExpandedStaticPropsContext(context)
+  const lovell = getLovellPageExpandedStaticPropsContext(context)
+
+  return {
+    ...context,
+    path,
+    drupalPath: listing.isListingPage ? listing.firstPagePath : path,
+    listing,
+    lovell,
+  }
+}
+
+/**
+ * Decorates the original resource according to business logic:
+ * - LOVELL:
+ *   - If original resource is a Lovell page, adjust accordingly (see: getLovellPageStaticPropsResourceDetails)
+ *
+ * @param resource
+ * @param context
+ * @returns Original context conditionally adjusted according to business logic
+ */
+export function getExpandedStaticPropsResource(
+  resource: StaticPropsResourceType,
+  context: ExpandedStaticPropsContextType
+): ExpandedStaticPropsResourceType<typeof resource> {
+  const isLovellPage =
+    isLovellResourceType(resource.type as ResourceTypeType) &&
+    context.lovell.isLovellVariantPage
+  if (isLovellPage) {
+    return getLovellPageExpandedStaticPropsResource(
+      resource as LovellResourceTypeType,
+      context
+    )
+  }
+
+  return resource
+}
+
+/**
+ * Gets query options object used to fetch data for
+ * generating static props
+ *
+ * @param resourceType
+ * @param id
+ * @param context
+ * @returns A query options object whose shape is determined by the resource type
+ */
+export function getStaticPropsQueryOpts(
+  resourceType: ResourceTypeType,
+  id: string,
+  context: ExpandedStaticPropsContextType
+):
+  | NewsStoryDataOpts
+  | ListingPageDataOpts
+  | QueryOpts<{
+      id: string
+    }> {
+  if (resourceType === RESOURCE_TYPES.STORY) {
+    return {
+      id,
+    }
+  }
+
+  if (resourceType === RESOURCE_TYPES.STORY_LISTING) {
+    return {
+      id,
+      page: context.listing.page,
+    }
+  }
+
+  return {
+    id,
+  }
+}

--- a/src/lib/drupal/staticProps.ts
+++ b/src/lib/drupal/staticProps.ts
@@ -9,7 +9,6 @@ import {
   LovellPageExpandedStaticPropsContextType,
   getLovellPageExpandedStaticPropsContext,
   getLovellPageExpandedStaticPropsResource,
-  LovellPageExpandedStaticPropsResourceType,
   isLovellResourceType,
   LovellExpandedResourceTypeType,
   LovellResourceTypeType,

--- a/src/lib/utils/slug.test.ts
+++ b/src/lib/utils/slug.test.ts
@@ -1,0 +1,21 @@
+import { slugToPath } from './slug'
+
+describe('slugToPath', () => {
+  test('should properly handle string with leading slash', () => {
+    const slug = '/some/path'
+    const result = slugToPath(slug)
+    expect(result).toBe(slug)
+  })
+
+  test('should properly handle string without leading slash', () => {
+    const slug = 'some/path'
+    const result = slugToPath(slug)
+    expect(result).toBe(`/${slug}`)
+  })
+
+  test('shold properly handle array', () => {
+    const slug = ['some', 'path']
+    const result = slugToPath(slug)
+    expect(result).toBe(`/${slug[0]}/${slug[1]}`)
+  })
+})

--- a/src/lib/utils/slug.ts
+++ b/src/lib/utils/slug.ts
@@ -1,0 +1,5 @@
+export function slugToPath(slug: string | string[]): string {
+  const path = typeof slug === 'string' ? slug : slug.join('/')
+  const leadingSlashPath = path.substring(0, 1) === '/' ? path : `/${path}`
+  return leadingSlashPath
+}

--- a/src/mocks/newsStory.mock.json
+++ b/src/mocks/newsStory.mock.json
@@ -54,11 +54,8 @@
     }
   },
   "field_administration": {
-    "type": "taxonomy_term--administration",
-    "id": "87832236-1e54-4ce3-8141-8dec27c8a9a7",
-    "resourceIdObjMeta": {
-      "drupal_internal__target_id": 12
-    }
+    "drupal_internal__tid": 12,
+    "name": "VA Pittsburgh health care"
   },
   "field_author": {
     "type": "node--person_profile",

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -141,7 +141,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     // This will be cached in the future so the header isn't re-requested a million times.
     const { bannerData, headerFooterData } = await getGlobalElements(
       pathInfo.jsonapi?.entryPoint,
-      expandedContext.drupalPath,
+      expandedContext.drupalPath
     )
 
     return {

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -5,7 +5,6 @@ import {
   GetStaticPropsContext,
 } from 'next'
 import Head from 'next/head'
-import { QueryOpts } from 'next-drupal-query'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { getGlobalElements } from '@/lib/drupal/getGlobalElements'
 import { queries } from '@/data/queries'
@@ -15,14 +14,20 @@ import { StoryListing } from '@/templates/layouts/storyListing'
 import { QuestionAnswer } from '@/templates/layouts/questionAnswer'
 import HTMLComment from '@/templates/globals/util/HTMLComment'
 import { getStaticPathsByResourceType } from '@/lib/drupal/staticPaths'
-import { RESOURCE_TYPES, ResourceTypeType } from '@/lib/constants/resourceTypes'
-import { isListingPageSlug } from '@/lib/drupal/listingPages'
+import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
+import {
+  getExpandedStaticPropsContext,
+  getExpandedStaticPropsResource,
+  getStaticPropsQueryOpts,
+} from '@/lib/drupal/staticProps'
 
 const RESOURCE_TYPES_TO_BUILD = [
   RESOURCE_TYPES.STORY_LISTING,
   RESOURCE_TYPES.STORY,
   // RESOURCE_TYPES.QA,
 ] as const
+
+export type BuiltResourceTypeType = (typeof RESOURCE_TYPES_TO_BUILD)[number]
 
 // [[...slug]] is a catchall route. We build the appropriate layout based on the resource returned for a given path.
 export default function ResourcePage({
@@ -85,73 +90,70 @@ export async function getStaticPaths(
 
 // Given some context (path, slug, locale, etc), get all props for the path.
 export async function getStaticProps(context: GetStaticPropsContext) {
-  // Listing pages require extra handling for generating paginated pages statically.
-  const isListingPage: { path: string; page: number } | false =
-    isListingPageSlug(context.params?.slug)
-  const path =
-    isListingPage === false
-      ? drupalClient.getPathFromContext(context)
-      : isListingPage.path
+  try {
+    const expandedContext = getExpandedStaticPropsContext(context)
 
-  // Now that we have a path, translate for resource endpoint
-  const pathInfo = await drupalClient.translatePath(path)
-  if (!pathInfo) {
-    return {
-      notFound: true,
+    // Now that we have a path, translate for resource endpoint
+    const pathInfo = await drupalClient.translatePath(
+      expandedContext.drupalPath
+    )
+    if (!pathInfo) {
+      return {
+        notFound: true,
+      }
     }
-  }
 
-  // If the requested path isn't a type we're building, 404
-  const resourceType = pathInfo.jsonapi.resourceName as ResourceTypeType
-  if (!Object.values(RESOURCE_TYPES).includes(resourceType)) {
-    return {
-      notFound: true,
+    // If the requested path isn't a type we're building, 404
+    const resourceType = pathInfo.jsonapi.resourceName as BuiltResourceTypeType
+    if (!Object.values(RESOURCE_TYPES).includes(resourceType)) {
+      return {
+        notFound: true,
+      }
     }
-  }
 
-  // Set up query for resource at the given path
-  const id = pathInfo.entity?.uuid
-  const queryOpts: QueryOpts<{
-    id: string
-    page?: number
-  }> =
-    isListingPage === false
-      ? {
-          context,
-          id,
-        }
-      : {
-          context,
-          id,
-          page: isListingPage.page,
-        }
+    // Set up query for resource at the given path
+    const id = pathInfo.entity?.uuid
+    const queryOpts = getStaticPropsQueryOpts(resourceType, id, expandedContext)
 
-  // Request resource based on type
-  const resource = await queries.getData(resourceType, queryOpts)
-  if (!resource) {
-    throw new Error(`Failed to fetch resource: ${pathInfo.jsonapi.individual}`)
-  }
-
-  // If we're not in preview mode and the resource is not published,
-  // Return page not found.
-  if (!context.preview && resource?.published === false) {
-    return {
-      notFound: true,
+    // Request resource based on type
+    const resource = await queries.getData(resourceType, queryOpts)
+    if (!resource) {
+      throw new Error(
+        `Failed to fetch resource: ${pathInfo.jsonapi.individual}`
+      )
     }
-  }
 
-  // If resource is good, gather additional data for global elements.
-  // This will be cached in the future so the header isn't re-requested a million times.
-  const { bannerData, headerFooterData } = await getGlobalElements(
-    pathInfo.jsonapi?.entryPoint,
-    path
-  )
+    // If we're not in preview mode and the resource is not published,
+    // Return page not found.
+    if (!context.preview && resource?.published === false) {
+      return {
+        notFound: true,
+      }
+    }
 
-  return {
-    props: {
+    // Apply business logic to resource (e.g. Lovell)
+    const expandedResource = getExpandedStaticPropsResource(
       resource,
-      bannerData,
-      headerFooterData,
-    },
+      expandedContext
+    )
+
+    // If resource is good, gather additional data for global elements.
+    // This will be cached in the future so the header isn't re-requested a million times.
+    const { bannerData, headerFooterData } = await getGlobalElements(
+      pathInfo.jsonapi?.entryPoint,
+      expandedContext.drupalPath,
+    )
+
+    return {
+      props: {
+        resource: expandedResource,
+        bannerData,
+        headerFooterData,
+      },
+    }
+  } catch (err) {
+    return {
+      notFound: true,
+    }
   }
 }

--- a/src/templates/components/lovellSwitcher/index.tsx
+++ b/src/templates/components/lovellSwitcher/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import {
+  LOVELL,
+  LovellVariant,
+  getOppositeVariant,
+  isLovellTricarePath,
+  isLovellVaPath,
+} from '@/lib/drupal/lovell'
+import { LovellSwitcherType } from '@/types/index'
+
+export function LovellSwitcher({
+  currentVariant,
+  switchPath,
+}: LovellSwitcherType) {
+  if (!switchPath || !currentVariant) {
+    return <></>
+  }
+
+  const switchVariant = getOppositeVariant(currentVariant)
+
+  return (
+    <va-alert
+      status="warning"
+      className="vads-u-margin-bottom--2"
+      id="va-info-alert"
+    >
+      <h2 slot="headline">
+        You are viewing this page as a {currentVariant.toUpperCase()}{' '}
+        beneficiary.
+      </h2>
+      <div>
+        <p className="vads-u-margin-y--0">
+          <>
+            <va-link
+              active="true"
+              href={switchPath}
+              text={`View this page as a ${switchVariant.toUpperCase()} beneficiary`}
+            />
+          </>
+        </p>
+      </div>
+    </va-alert>
+  )
+}

--- a/src/templates/components/lovellSwitcher/index.tsx
+++ b/src/templates/components/lovellSwitcher/index.tsx
@@ -1,11 +1,5 @@
 import React from 'react'
-import {
-  LOVELL,
-  LovellVariant,
-  getOppositeVariant,
-  isLovellTricarePath,
-  isLovellVaPath,
-} from '@/lib/drupal/lovell'
+import { getOppositeVariant } from '@/lib/drupal/lovell'
 import { LovellSwitcherType } from '@/types/index'
 
 export function LovellSwitcher({

--- a/src/templates/components/lovellSwitcher/lovellSwitcher.stories.tsx
+++ b/src/templates/components/lovellSwitcher/lovellSwitcher.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { LovellSwitcher } from './index'
+import { LOVELL } from '@/lib/drupal/lovell'
+
+export default {
+  title: 'Components/LovellSwitcher',
+  component: LovellSwitcher,
+} as ComponentMeta<typeof LovellSwitcher>
+
+const Template: ComponentStory<typeof LovellSwitcher> = (args) => (
+  <LovellSwitcher {...args} />
+)
+
+export const TricareToVa = Template.bind({})
+TricareToVa.args = {
+  currentVariant: LOVELL.tricare.variant,
+}
+
+export const VaToTricare = Template.bind({})
+VaToTricare.args = {
+  currentVariant: LOVELL.va.variant,
+}

--- a/src/templates/layouts/newsStory/index.test.tsx
+++ b/src/templates/layouts/newsStory/index.test.tsx
@@ -45,6 +45,10 @@ const data = {
     title: 'We honor outstanding doctors',
   },
   listing: '/pittsburgh-health-care/stories',
+  administration: {
+    id: 12,
+    name: 'VA Pittsburgh health care',
+  },
 }
 
 describe('<newsStory> with valid data', () => {

--- a/src/templates/layouts/newsStory/index.tsx
+++ b/src/templates/layouts/newsStory/index.tsx
@@ -5,6 +5,8 @@ import { SocialLinks } from '@/templates/common/socialLinks'
 import { StoryListingLink } from '@/templates/components/storyListingLink'
 import { NewsStoryType } from '@/types/index'
 import { ContentFooter } from '@/templates/common/contentFooter'
+import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
+import { LovellExpandedResourceTypeType } from '@/lib/drupal/lovell'
 
 export const NewsStory = ({
   title,
@@ -16,7 +18,9 @@ export const NewsStory = ({
   date,
   socialLinks,
   listing,
-}: NewsStoryType) => {
+  lovellVariant,
+  lovellSwitchPath,
+}: LovellExpandedResourceTypeType<NewsStoryType>) => {
   return (
     <>
       <div id="content" className="interior">
@@ -25,6 +29,12 @@ export const NewsStory = ({
             {/* nav here */}
             <div className="usa-width-three-fourths">
               <article className="usa-content">
+                {lovellVariant && lovellSwitchPath && (
+                  <LovellSwitcher
+                    currentVariant={lovellVariant}
+                    switchPath={lovellSwitchPath}
+                  />
+                )}
                 <h1>{title}</h1>
                 <MediaImage {...image} imageStyle="2_1_large" />
                 <div className="vads-u-font-size--sm vads-u-margin-bottom--2p5">

--- a/src/types/dataTypes/drupal/field_type.d.ts
+++ b/src/types/dataTypes/drupal/field_type.d.ts
@@ -59,3 +59,8 @@ export interface FieldTable {
   value: [string[]]
   caption: string
 }
+
+export interface FieldAdministration {
+  drupal_internal__tid: number
+  name: string
+}

--- a/src/types/dataTypes/drupal/node.ts
+++ b/src/types/dataTypes/drupal/node.ts
@@ -9,6 +9,7 @@ import {
   FieldOfficeHours,
   FieldSocialMediaLinks,
   FieldTable,
+  FieldAdministration,
 } from './field_type'
 import { MediaImage } from './media'
 import {
@@ -216,6 +217,8 @@ export interface NodeNewsStory extends DrupalNode {
   field_order: number
   /** Which Story Listing page this story should display on. */
   field_listing: NodeStoryListing
+  /** Administration */
+  field_administration: FieldAdministration
   /** When the node was created. */
   created: string
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -11,6 +11,11 @@ export interface PublishedEntity {
   published: boolean
 }
 
+export type Administration = {
+  id: number
+  name: string
+}
+
 export type Path = {
   pid?: number
   alias?: string
@@ -85,6 +90,7 @@ export type NewsStoryType = PublishedEntity & {
   listing: string
   entityId: number
   entityPath: string
+  administration: Administration
 }
 
 export type NewsStoryTeaserType = PublishedEntity & {
@@ -170,10 +176,7 @@ export type ContentFooterType = {
 
 export type StaticPathResourceType = {
   path: PathAlias
-  administration: {
-    id: number
-    name: string
-  }
+  administration: Administration
 }
 
 // These SideNav types are what the vets-website widget expects

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -4,7 +4,7 @@ import {
   NodeHealthCareRegionPage,
 } from '@/types/dataTypes/drupal/node'
 import { PathAlias } from 'next-drupal'
-
+import { LovellVariant } from '@/lib/drupal/lovell'
 export interface PublishedEntity {
   id: string
   type: string
@@ -174,10 +174,17 @@ export type ContentFooterType = {
   lastUpdated?: string | number
 }
 
+export type LovellSwitcherType = {
+  currentVariant: LovellVariant
+  switchPath: string
+}
+
 export type StaticPathResourceType = {
   path: PathAlias
   administration: Administration
 }
+
+export type StaticPropsResourceType = NewsStoryType | StoryListingType
 
 // These SideNav types are what the vets-website widget expects
 export type SideNavItem = {


### PR DESCRIPTION
## Description
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14744

## Screenshots
![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/88ea55e7-302f-4252-b237-27585cf12251)

![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/707c9cdd-b849-4a49-a448-bbeac6928d85)

## Testing done/QA Steps
- [ ] Ensure listing pages still work (visit a few, like [this one](https://pr188-dci9tepk531peayd02x7dnslxjuylvra.tugboat.vfs.va.gov/minneapolis-health-care/stories/))
- [ ] Ensure a Lovell bifurcated page (like [this one](https://pr188-dci9tepk531peayd02x7dnslxjuylvra.tugboat.vfs.va.gov/lovell-federal-health-care-va/stories/fleet-medicine-provides-comprehensive-care-to-navy-recruits/)) shows the Lovell switcher.
- [ ] Ensure the Lovell switcher works VA->TRICARE *and* TRICARE->VA
