### PR TITLE
clean up header queries

### DIFF
--- a/src/data/queries/headerFooter.ts
+++ b/src/data/queries/headerFooter.ts
@@ -7,14 +7,13 @@ import {
 import { queries } from '.'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { Menu, HeaderMegaMenu } from '@/types/dataTypes/drupal/menu'
-import { HeaderFooterData, MegaMenuPromoColumn } from '@/types/index'
+import { HeaderFooterData } from '@/types/index'
 import { buildHeaderFooterData } from '@/lib/utils/headerFooter'
 
 export type RawHeaderFooterData = {
   footerColumns: Menu
   footerBottomRail: Menu
   headerMegaMenu: HeaderMegaMenu
-  promoBlocks: MegaMenuPromoColumn[]
 }
 
 // Define the query params for fetching footer menu data.
@@ -22,67 +21,54 @@ export const params: QueryParams<null> = () => {
   return queries.getParams().addFields('menu_items', ['title,url'])
 }
 
-// Define the query params for fetching header megamenu data.
+// Define the query params for fetching header megamenu data. Include referenced promo block data, if present
 export const megaMenuParams: QueryParams<null> = () => {
-  return queries.getParams().addInclude(['field_promo_reference'])
-}
-
-export const promoBlockParams: QueryParams<null> = () => {
   return queries
     .getParams()
-    .addInclude(['field_image', 'field_image.media', 'field_promo_link'])
+    .addInclude([
+      'field_promo_reference',
+      'field_promo_reference.field_image',
+      'field_promo_reference.field_image.image',
+      'field_promo_reference.field_promo_link',
+    ])
 }
 
 // Define the option types for the data loader.
 type DataOpts = QueryOpts<{
   params?: object
   megaMenuParams?: object
-  promoBlockParams?: object
 }>
 
 export const data: QueryData<DataOpts, RawHeaderFooterData> = async (opts) => {
   // Gather data from the different menus for the headerFooter data object
-  const footerColumns = await drupalClient.getMenu('va-gov-footer', opts.params)
-  const footerBottomRail = await drupalClient.getMenu(
-    'footer-bottom-rail',
-    opts.params
-  )
+  const footerColumns = await drupalClient.getMenu('va-gov-footer', {
+    params: params().getQueryObject(),
+  })
+  const footerBottomRail = await drupalClient.getMenu('footer-bottom-rail', {
+    params: params().getQueryObject(),
+  })
   const headerMegaMenu: HeaderMegaMenu = await drupalClient.getMenu(
     'header-megamenu',
-    opts.megaMenuParams
+    {
+      params: megaMenuParams().getQueryObject(),
+    }
   )
-
-  // promo blocks only exist on certain items in the menu
-  const blocksToGather = headerMegaMenu.items.filter(
-    (item) => item.field_promo_reference !== null || undefined
-  )
-  const promoBlocks = []
-
-  // query actual block data from reference
-  for (const block of blocksToGather) {
-    const promo = await queries.getData('block_content--promo', {
-      id: block.field_promo_reference.id,
-    })
-    promoBlocks.push(promo)
-  }
 
   return {
     footerColumns,
     footerBottomRail,
     headerMegaMenu,
-    promoBlocks,
   }
 }
 
 export const formatter: QueryFormatter<
   RawHeaderFooterData,
   HeaderFooterData
-> = ({ footerColumns, footerBottomRail, headerMegaMenu, promoBlocks }) => {
+> = ({ footerColumns, footerBottomRail, headerMegaMenu }) => {
   const { footerData, megaMenuData } = buildHeaderFooterData({
     footerBottomRail,
     footerColumns,
     headerMegaMenu,
-    promoBlocks,
   })
 
   // Data assembled into shape front-end widget expects

--- a/src/data/queries/headerFooter.ts
+++ b/src/data/queries/headerFooter.ts
@@ -1,9 +1,4 @@
-import {
-  QueryData,
-  QueryFormatter,
-  QueryOpts,
-  QueryParams,
-} from 'next-drupal-query'
+import { QueryData, QueryFormatter, QueryParams } from 'next-drupal-query'
 import { queries } from '.'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { Menu, HeaderMegaMenu } from '@/types/dataTypes/drupal/menu'
@@ -33,13 +28,7 @@ export const megaMenuParams: QueryParams<null> = () => {
     ])
 }
 
-// Define the option types for the data loader.
-type DataOpts = QueryOpts<{
-  params?: object
-  megaMenuParams?: object
-}>
-
-export const data: QueryData<DataOpts, RawHeaderFooterData> = async (opts) => {
+export const data: QueryData<null, RawHeaderFooterData> = async () => {
   // Gather data from the different menus for the headerFooter data object
   const footerColumns = await drupalClient.getMenu('va-gov-footer', {
     params: params().getQueryObject(),

--- a/src/lib/utils/header.test.ts
+++ b/src/lib/utils/header.test.ts
@@ -4,13 +4,8 @@ import { formatHeaderData } from './header'
 describe('header megamenu', () => {
   test('should format the drupal menu tree into shape FE widget expects', () => {
     const headerMegaMenu = { items: [], tree: [] }
-    const promoBlocks = []
 
-    const result = formatHeaderData(
-      headerMegaMenu,
-      'https://va.gov',
-      promoBlocks
-    )
+    const result = formatHeaderData(headerMegaMenu, 'https://va.gov')
 
     expect(result).toBeInstanceOf(Array<MegaMenuSection>)
   })

--- a/src/lib/utils/headerFooter.test.ts
+++ b/src/lib/utils/headerFooter.test.ts
@@ -6,13 +6,11 @@ describe('headerFooter', () => {
     const headerMegaMenu = { items: [], tree: [] }
     const footerBottomRail = { items: [], tree: [] }
     const footerColumns = { items: [], tree: [] }
-    const promoBlocks = []
 
     const result = buildHeaderFooterData({
       footerBottomRail,
       footerColumns,
       headerMegaMenu,
-      promoBlocks,
     })
 
     expect(result.footerData).toBeInstanceOf(Array<FooterLink>)

--- a/src/lib/utils/headerFooter.ts
+++ b/src/lib/utils/headerFooter.ts
@@ -34,7 +34,6 @@ export const buildHeaderFooterData = ({
   footerBottomRail,
   footerColumns,
   headerMegaMenu,
-  promoBlocks,
 }: RawHeaderFooterData): HeaderFooterData => {
   // todo: target env handling for what hostUrl should map to
   const hostUrl = 'https://va.gov/'
@@ -51,7 +50,7 @@ export const buildHeaderFooterData = ({
   ]
 
   // Assemble header megamenu data from Drupal
-  const megaMenuData = formatHeaderData(headerMegaMenu, hostUrl, promoBlocks)
+  const megaMenuData = formatHeaderData(headerMegaMenu, hostUrl)
 
   // Data shaped into what front-end widgets expect
   return {


### PR DESCRIPTION
## Description
Relates to #183. @ryguyk pointed out how to use addInclude properly, so we don't need to make additional queries for the promo blocks. They correctly come along for the ride with the menu data, which simplifies some of the logic when constructing the data into shape. Nice! 

## Testing done
- visit any story or story listing page, check the megamenu and footer and see that promo blocks are present on sections that have them in the cms (top-level `About VA`, or the `Disability`, `Education` hubs underneath the first item)

## Screenshots


## QA steps
```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
