### PR TITLE
Vacms 15825 lovell breadcrumbs

### DIFF
--- a/src/lib/drupal/lovell/constants.ts
+++ b/src/lib/drupal/lovell/constants.ts
@@ -2,6 +2,7 @@ import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 
 export const LOVELL = {
   federal: {
+    title: 'Lovell Federal health care',
     administration: {
       id: 347,
       name: 'Lovell Federal health care',
@@ -10,6 +11,7 @@ export const LOVELL = {
     variant: 'federal',
   },
   tricare: {
+    title: 'Lovell Federal health care - TRICARE',
     administration: {
       id: 1039,
       name: 'Lovell - TRICARE',
@@ -18,6 +20,7 @@ export const LOVELL = {
     variant: 'tricare',
   },
   va: {
+    title: 'Lovell Federal health care - VA',
     administration: {
       id: 1040,
       name: 'Lovell - VA',

--- a/src/lib/drupal/lovell/staticProps.ts
+++ b/src/lib/drupal/lovell/staticProps.ts
@@ -27,6 +27,7 @@ import {
   getLovellVariantOfUrl,
   getOppositeChildVariant,
   isLovellBifurcatedResource,
+  getLovellVariantOfBreadcrumbs,
 } from './utils'
 
 export function getLovellStaticPropsContext(
@@ -71,6 +72,7 @@ export function getLovellChildVariantOfResource(
 
   return {
     ...resource,
+    breadcrumbs: getLovellVariantOfBreadcrumbs(resource.breadcrumbs, variant),
     entityPath: variantPaths[variant],
     socialLinks: {
       ...resource.socialLinks,
@@ -99,12 +101,19 @@ async function getLovellListingPageStaticPropsResource(
       // so we can merge and then calculate page data
     }
   )) as LovellListingPageFormattedResource
+  const childVariantPageWithProperBreadcrumbs = {
+    ...childVariantPage,
+    breadcrumbs: getLovellVariantOfBreadcrumbs(
+      childVariantPage.breadcrumbs,
+      context.lovell.variant
+    ),
+  }
 
   const federalPagePathInfo = await drupalClient.translatePath(
     getLovellVariantOfUrl(context.drupalPath, LOVELL.federal.variant)
   )
   if (!federalPagePathInfo) {
-    return childVariantPage
+    return childVariantPageWithProperBreadcrumbs
   }
   const federalPageId = federalPagePathInfo.entity?.uuid
   const federalPage = (await fetchSingleStaticPropsResource(
@@ -132,7 +141,7 @@ async function getLovellListingPageStaticPropsResource(
   const totalPages = Math.ceil(totalItems / pageSize) || 0
 
   return {
-    ...childVariantPage,
+    ...childVariantPageWithProperBreadcrumbs,
     [itemProp]: pagedMergedItems,
     currentPage: context.listing.page,
     totalItems,

--- a/src/lib/drupal/lovell/tests/utils.test.ts
+++ b/src/lib/drupal/lovell/tests/utils.test.ts
@@ -16,6 +16,7 @@ import {
   isLovellChildVariantSlug,
   getOppositeChildVariant,
   isLovellBifurcatedResource,
+  getLovellVariantOfUrl,
 } from '../utils'
 import {
   lovellTricareSlug,
@@ -275,6 +276,35 @@ describe('getOppositeChildVariant', () => {
   test('should return TRICARE when VA passed in', () => {
     const result = getOppositeChildVariant(LOVELL.va.variant)
     expect(result).toBe(LOVELL.tricare.variant)
+  })
+})
+
+describe('getLovellVariantOfUrl', () => {
+  test('should properly convert relative url', () => {
+    const url = lovellFederalResource.path.alias
+    const result = getLovellVariantOfUrl(url, LOVELL.tricare.variant)
+    expect(result).toBe(lovellTricareResource.path.alias)
+  })
+
+  test('should properly convert absolute url', () => {
+    const domain = 'https://www.va.gov'
+    const url = `${domain}${lovellFederalResource.path.alias}`
+    const result = getLovellVariantOfUrl(url, LOVELL.va.variant)
+    expect(result).toBe(`${domain}${lovellVaResource.path.alias}`)
+  })
+
+  test('should leave non-Lovell url unchanged', () => {
+    const url = '/some/non-lovell/path'
+    const result = getLovellVariantOfUrl(url, LOVELL.va.variant)
+    expect(result).toBe(url)
+  })
+
+  test('should only replace first occurrence of a lovell path segment', () => {
+    const url = `${LOVELL.tricare.pathSegment}/${LOVELL.tricare.pathSegment}`
+    const result = getLovellVariantOfUrl(url, LOVELL.va.variant)
+    expect(result).toBe(
+      `${LOVELL.va.pathSegment}/${LOVELL.tricare.pathSegment}`
+    )
   })
 })
 

--- a/src/lib/drupal/lovell/tests/utils.test.ts
+++ b/src/lib/drupal/lovell/tests/utils.test.ts
@@ -17,6 +17,8 @@ import {
   getOppositeChildVariant,
   isLovellBifurcatedResource,
   getLovellVariantOfUrl,
+  getLovellVariantOfTitle,
+  getLovellVariantOfBreadcrumbs,
 } from '../utils'
 import {
   lovellTricareSlug,
@@ -305,6 +307,53 @@ describe('getLovellVariantOfUrl', () => {
     expect(result).toBe(
       `${LOVELL.va.pathSegment}/${LOVELL.tricare.pathSegment}`
     )
+  })
+})
+
+describe('getLovellVariantOfTitle', () => {
+  test('should properly convert Lovell title from Federal to child variant', () => {
+    const title = LOVELL.federal.title
+    const result = getLovellVariantOfTitle(title, LOVELL.va.variant)
+    expect(result).toBe(LOVELL.va.title)
+  })
+
+  test('should properly convert Lovell title from child variant to Federal', () => {
+    const title = LOVELL.tricare.title
+    const result = getLovellVariantOfTitle(title, LOVELL.federal.variant)
+    expect(result).toBe(LOVELL.federal.title)
+  })
+
+  test('should leave non-Lovell title unchanged', () => {
+    const title = 'Some non-Lovell title'
+    const result = getLovellVariantOfTitle(title, LOVELL.va.variant)
+    expect(result).toBe(title)
+  })
+})
+
+describe('getLovellVariantOfBreadcrumbs', () => {
+  const breadcrumbs = [
+    {
+      uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/',
+      title: 'Home',
+      options: [],
+    },
+    {
+      uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/lovell-federal-health-care',
+      title: 'Lovell Federal health care',
+      options: [],
+    },
+  ]
+
+  test('should properly convert breadcrumbs', () => {
+    const result = getLovellVariantOfBreadcrumbs(breadcrumbs, LOVELL.va.variant)
+    expect(result).toStrictEqual([
+      breadcrumbs[0],
+      {
+        uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/lovell-federal-health-care-va',
+        title: 'Lovell Federal health care - VA',
+        options: [],
+      },
+    ])
   })
 })
 

--- a/src/lib/drupal/lovell/utils.ts
+++ b/src/lib/drupal/lovell/utils.ts
@@ -13,6 +13,7 @@ import { StaticPathResourceType } from '@/types/index'
 import { FormattedResource } from '@/data/queries'
 import { ResourceTypeType } from '@/lib/constants/resourceTypes'
 import { slugToPath } from '@/lib/utils/slug'
+import { BreadcrumbItem } from '@/types/dataTypes/drupal/field_type'
 
 export function isLovellResourceType(resourceType: ResourceTypeType): boolean {
   return (LOVELL_RESOURCE_TYPES as readonly string[]).includes(resourceType)
@@ -106,22 +107,35 @@ export function getOppositeChildVariant(
 }
 
 /**
- * Replaces first segment (system name) in a path according to `variant`.
+ * Replaces first occurrence of a lovell path segment according to `variant`.
  * E.g.
  * Input:
  *   path: `/lovell-federal-health-care-va/stories/story-title`
  *   variant: `tricare`
  * Output: `/lovell-federal-health-care-tricare/stories/story-title`
+ * Input:
+ *   path: `https://www.va.gov/lovell-federal-health-care-tricare/stories/story-title`
+ *   variant: `va`
+ * Output: `https://www.va.gov/lovell-federal-health-care-va/stories/story-title`
+ *
  */
 export function getLovellVariantOfUrl(
-  path: string,
+  url: string,
   variant: LovellVariant
 ): string {
-  return `/${LOVELL[variant].pathSegment}/${path
-    .split('/')
-    .filter((slug) => slug !== '')
-    .slice(1)
-    .join('/')}`
+  return url.replace(
+    // Note: Lovell Federal path segment must be listed
+    // last since it's a substring of the others and
+    // we don't want to prematurely match
+    new RegExp(
+      [
+        LOVELL.tricare.pathSegment,
+        LOVELL.va.pathSegment,
+        LOVELL.federal.pathSegment,
+      ].join('|')
+    ),
+    LOVELL[variant].pathSegment
+  )
 }
 
 export function isLovellBifurcatedResource(

--- a/src/lib/drupal/lovell/utils.ts
+++ b/src/lib/drupal/lovell/utils.ts
@@ -138,6 +138,73 @@ export function getLovellVariantOfUrl(
   )
 }
 
+/**
+ * Replaces Lovell title string according to `variant`.
+ * Returns original string if no Lovell match found.
+ * E.g.
+ *   Input:
+ *     title: `Lovell Federal health care`
+ *     variant: `va`
+ *   Output: `Lovell Federal health care - VA`
+ */
+export function getLovellVariantOfTitle(
+  title: string,
+  variant: LovellVariant
+): string {
+  return title.replace(
+    // Note: Lovell Federal title must be listed
+    // last since it's a substring of the others and
+    // we don't want to prematurely match
+    new RegExp(
+      [LOVELL.tricare.title, LOVELL.va.title, LOVELL.federal.title].join('|')
+    ),
+    LOVELL[variant].title
+  )
+}
+
+/**
+ * Updates breadcrumb entries according to `variant`.
+ * Non-Lovell entries are unchanged. Lovell entries
+ * have title and uri updated.
+ * E.g.
+ *   Input:
+ *     breacrumbs: [
+ *       {
+ *         uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/',
+ *         title: 'Home',
+ *         options: [],
+ *       },
+ *       {
+ *         uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/lovell-federal-health-care',
+ *         title: 'Lovell Federal health care',
+ *         options: [],
+ *       },
+ *     ],
+ *     variant: `va`
+ *   Output: [
+ *     {
+ *        uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/',
+ *        title: 'Home',
+ *        options: [],
+ *      },
+ *      {
+ *        uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/lovell-federal-health-care-va',
+ *        title: 'Lovell Federal health care - VA',
+ *        options: [],
+ *      },
+ *   ]
+ */
+export function getLovellVariantOfBreadcrumbs(
+  breadcrumbs: BreadcrumbItem[],
+  variant: LovellVariant
+): BreadcrumbItem[] {
+  return breadcrumbs.map((breadcrumb) => ({
+    ...breadcrumb,
+    title: getLovellVariantOfTitle(breadcrumb.title, variant),
+    uri: getLovellVariantOfUrl(breadcrumb.uri, variant),
+  }))
+}
+
 export function isLovellBifurcatedResource(
   resource: FormattedResource
 ): boolean {


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15825

## Testing done
- Unit tests added
- QA steps below

## Screenshots
![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/584b5ac3-1756-4e2f-8eeb-f4a2a8b9185b)
![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/6bb95644-c703-4a8d-8ff3-db4323d9be65)
![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/7f5f2dd2-3d7d-4634-a1cf-a97cd1096606)
![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/534f93f5-057d-420e-be5c-1bf38344654d)



## QA steps
- New functionality from this PR:
  - Ensure Lovell listing pages have correct breadcrumbs:
    - [x] [TRICARE listing page](https://pr218-qk8n8egrsfnmpzfdmwfcdq0doex9euoy.tugboat.vfs.va.gov/lovell-federal-health-care-tricare/stories/)
    - [x] [VA listing page](https://pr218-qk8n8egrsfnmpzfdmwfcdq0doex9euoy.tugboat.vfs.va.gov/lovell-federal-health-care-va/stories/)
  - Ensure Lovell bifurcated stories have correct breadcrumbs:
    - [x] [TRICARE version of bifurcated story](https://pr218-qk8n8egrsfnmpzfdmwfcdq0doex9euoy.tugboat.vfs.va.gov/lovell-federal-health-care-tricare/stories/saturday-flu-shot-clinics-for-veterans-military-retirees-and-military-families/)
    - [x] [VA version of bifurcated story](https://pr218-qk8n8egrsfnmpzfdmwfcdq0doex9euoy.tugboat.vfs.va.gov/lovell-federal-health-care-va/stories/saturday-flu-shot-clinics-for-veterans-military-retirees-and-military-families/)

- Existing functionality; ensure still correct:
  - Ensure Lovell non-bifurcated stories have correct breadcrumbs:
    - [x] [TRICARE-only story](https://pr218-qk8n8egrsfnmpzfdmwfcdq0doex9euoy.tugboat.vfs.va.gov/lovell-federal-health-care-tricare/stories/changes-coming-to-tricare-secure-messaging-oct-31/)
  - Ensure non-Lovell listing pages have correct breadcrumbs:
    - [x] [Minneapolis listing page](https://pr218-qk8n8egrsfnmpzfdmwfcdq0doex9euoy.tugboat.vfs.va.gov/minneapolis-health-care/stories/)
    - [x] [Portland listing page](https://pr218-qk8n8egrsfnmpzfdmwfcdq0doex9euoy.tugboat.vfs.va.gov/portland-health-care/stories/)
  - Ensure non-Lovell story pages have correct breadcrumbs:
    - [x] [Minneapolis story](https://pr218-qk8n8egrsfnmpzfdmwfcdq0doex9euoy.tugboat.vfs.va.gov/minneapolis-health-care/stories/leading-the-way-in-stroke-care-for-veterans-at-the-minneapolis-va-health-care-system/)