### PR TITLE
15061 Story layout fixes

### DIFF
--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -11,17 +11,6 @@ body {
   box-sizing: border-box;
 }
 
-.feedback-button {
-  background-color: #0071BB;
-  font-size: 1.6rem;
-  font-weight: 700;
-  line-height: 1;
-  margin-right: 0;
-  margin-top: 0.5rem;
-  height: 44px;
-  width: 133px;
-}
-
 .above-footer-elements-container {
   margin-bottom: 2.5rem;
 }

--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -11,6 +11,17 @@ body {
   box-sizing: border-box;
 }
 
+.feedback-button {
+  background-color: #0071BB;
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1;
+  margin-right: 0;
+  margin-top: 0.5rem;
+  height: 44px;
+  width: 133px;
+}
+
 .above-footer-elements-container {
   margin-bottom: 2.5rem;
 }

--- a/src/templates/layouts/newsStory/index.tsx
+++ b/src/templates/layouts/newsStory/index.tsx
@@ -7,6 +7,7 @@ import { NewsStoryType } from '@/types/index'
 import { ContentFooter } from '@/templates/common/contentFooter'
 import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
 import { LovellStaticPropsResource } from '@/lib/drupal/lovell/types'
+import clsx from 'clsx'
 
 export const NewsStory = ({
   title,
@@ -21,6 +22,10 @@ export const NewsStory = ({
   lovellVariant,
   lovellSwitchPath,
 }: LovellStaticPropsResource<NewsStoryType>) => {
+  const imageClassName = caption
+    ? 'vads-u-margin-bottom--1'
+    : 'vads-u-margin-bottom--2p5'
+
   return (
     <>
       <div className="va-l-detail-page va-facility-page">
@@ -33,7 +38,11 @@ export const NewsStory = ({
                 switchPath={lovellSwitchPath}
               />
               <h1>{title}</h1>
-              <MediaImage {...image} imageStyle="2_1_large" />
+              <MediaImage
+                {...image}
+                className={imageClassName}
+                imageStyle="2_1_large"
+              />
               <div className="vads-u-font-size--sm vads-u-margin-bottom--2p5">
                 {caption}
               </div>
@@ -56,8 +65,8 @@ export const NewsStory = ({
                 />
               </div>
               <StoryListingLink path={listing} />
-              <ContentFooter />
             </article>
+            <ContentFooter />
           </div>
         </div>
       </div>

--- a/src/templates/layouts/newsStory/index.tsx
+++ b/src/templates/layouts/newsStory/index.tsx
@@ -7,7 +7,6 @@ import { NewsStoryType } from '@/types/index'
 import { ContentFooter } from '@/templates/common/contentFooter'
 import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
 import { LovellStaticPropsResource } from '@/lib/drupal/lovell/types'
-import clsx from 'clsx'
 
 export const NewsStory = ({
   title,

--- a/src/templates/layouts/storyListing/index.tsx
+++ b/src/templates/layouts/storyListing/index.tsx
@@ -95,8 +95,8 @@ export function StoryListing({
               />
             )}
           </div>
-          <ContentFooter />
         </article>
+        <ContentFooter />
       </div>
     </div>
   )


### PR DESCRIPTION
## Description
Relates to #[15061](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15061). (or closes?)

- Adds feedback button styling
- Puts content footer below article for correct padding
- Adds conditional class for padding below newstory images
- 

## Testing done
Local visual testing

## Screenshots
<img width="1305" alt="Screen Shot 2023-11-07 at 10 23 08 AM" src="https://github.com/department-of-veterans-affairs/next-build/assets/61624970/3cef36d4-b8d5-4838-9bc7-a3a4fba32647">
<img width="1305" alt="Screen Shot 2023-11-07 at 10 23 21 AM" src="https://github.com/department-of-veterans-affairs/next-build/assets/61624970/d130e331-0849-4438-a1ca-b94549ffadb1">

## QA steps
- Navigate to a story listing page (/butler-health-care/stories/)
  - Verify layout matches prod
- Navigate to story page
  - Verify layout matches prod


## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
