### PR TITLE
VACMS-9137 compile typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ certs/rootCA.pem
 
 # typescript
 *.tsbuildinfo
+# typedoc
 docs/**/*

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -12,6 +12,7 @@ services:
 
     aliases:
       - storybook
+      - typedoc
 
     # Run these commands to initialize the server, update it with any libraries and assets required, then build your site.
     commands:
@@ -53,6 +54,9 @@ services:
         # Setup storybook-*. vhost to serve compiled storybook.
         - cp "${TUGBOAT_ROOT}"/.tugboat/vhost-storybook.conf /etc/nginx/conf.d/storybook.conf
 
+        # Setup typedoc-*. vhost to serve compiled typedocs.
+        - cp "${TUGBOAT_ROOT}"/.tugboat/vhost-typedoc.conf /etc/nginx/conf.d/typedoc.conf
+
         # Restart nginx with the new config
         - sudo service nginx reload
 
@@ -84,3 +88,6 @@ services:
       online:
         # Build the static version of storybook to serve at storybook-[hash].tugboat.vfs.va.gov
         - yarn storybook:build
+
+        # Build the typedoc information for next-build
+        - yarn typedoc

--- a/.tugboat/vhost-typedoc.conf
+++ b/.tugboat/vhost-typedoc.conf
@@ -1,0 +1,14 @@
+server {
+    listen       80;
+    server_name  ~^typedoc-.*$;
+
+    location / {
+        alias   /usr/share/nginx/html/docs/;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "format": "prettier --write .",
     "lint": "next lint",
     "postinstall": "husky install",
+    "typedoc": "typedoc",
+    "typedoc:serve": "http-server docs -p 8002",
     "test": "APP_ENV=test jest",
     "test:ci": "APP_ENV=test jest --ci --coverage",
     "test:coverage": "RUST_BACKTRACE=1 APP_ENV=test jest --coverage",


### PR DESCRIPTION
## Description
Relates to #[9137](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9137).

`typedoc` was already a dependency, this PR adds explicit package json commands & creates a tugboat alias to view it


## Testing done


## Screenshots


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
