### PR TITLE
Vacms 16105 metatags

### DIFF
--- a/src/data/queries/newsStory.ts
+++ b/src/data/queries/newsStory.ts
@@ -1,14 +1,9 @@
-import {
-  QueryData,
-  QueryFormatter,
-  QueryOpts,
-  QueryParams,
-} from 'next-drupal-query'
+import { QueryData, QueryFormatter, QueryParams } from 'next-drupal-query'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { queries } from '.'
 import { NodeNewsStory } from '@/types/dataTypes/drupal/node'
 import { NewsStory } from '@/types/dataTypes/formatted/newsStory'
-import { GetServerSidePropsContext } from 'next'
+import { ExpandedStaticPropsContext } from '@/lib/drupal/staticProps'
 
 // Define the query params for fetching node--news_story.
 export const params: QueryParams<null> = () => {
@@ -24,10 +19,10 @@ export const params: QueryParams<null> = () => {
 }
 
 // Define the option types for the data loader.
-export type NewsStoryDataOpts = QueryOpts<{
+export type NewsStoryDataOpts = {
   id: string
-  context?: GetServerSidePropsContext
-}>
+  context?: ExpandedStaticPropsContext
+}
 
 // Implement the data loader.
 export const data: QueryData<NewsStoryDataOpts, NodeNewsStory> = async (
@@ -64,6 +59,7 @@ export const formatter: QueryFormatter<NodeNewsStory, NewsStory> = (
     type: entity.type,
     published: entity.status,
     title: entity.title,
+    metatags: entity.metatag,
     image: queries.formatData('media--image', {
       entity: entity.field_media,
       cropType: '2_1_large',

--- a/src/data/queries/storyListing.ts
+++ b/src/data/queries/storyListing.ts
@@ -124,6 +124,7 @@ export const formatter: QueryFormatter<StoryListingData, StoryListing> = ({
     type: entity.type,
     published: entity.status,
     title: entity.title,
+    metatags: entity.metatag,
     introText: entity.field_intro_text,
     stories: formattedStories,
     menu: formattedMenu,

--- a/src/data/queries/tests/__snapshots__/newsStory.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/newsStory.test.tsx.snap
@@ -363,6 +363,106 @@ exports[`node--news_story formatData outputs formatted data 1`] = `
   },
   "introText": "When a hospital has a host of great doctors, honoring just two every year is challenging. ",
   "listing": "/pittsburgh-health-care/stories",
+  "metatags": [
+    {
+      "attributes": {
+        "content": "It’s never too late to quit smoking and start breathing easier | VA Minneapolis health care | Veterans Affairs",
+        "name": "title",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "When you stop smoking, you feel the benefits almost immediately, no matter how long you’ve smoked.",
+        "name": "description",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "href": "https://www.va.gov/img/design/logo/va-og-image.png",
+        "rel": "image_src",
+      },
+      "tag": "link",
+    },
+    {
+      "attributes": {
+        "content": "Veterans Affairs",
+        "property": "og:site_name",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "It’s never too late to quit smoking and start breathing easier | VA Minneapolis health care | Veterans Affairs",
+        "property": "og:title",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "When you stop smoking, you feel the benefits almost immediately, no matter how long you’ve smoked.",
+        "property": "og:description",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "http://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/sites/default/files/styles/3_2_medium_thumbnail/public/2023-10/Great%20American%20Smokeout.jpg",
+        "property": "og:image",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "Great American Smokeout 2023",
+        "property": "og:image:alt",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "summary_large_image",
+        "name": "twitter:card",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "When you stop smoking, you feel the benefits almost immediately, no matter how long you’ve smoked.",
+        "name": "twitter:description",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "@DeptVetAffairs",
+        "name": "twitter:site",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "It’s never too late to quit smoking and start breathing easier | VA Minneapolis health care | Veterans Affairs",
+        "name": "twitter:title",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "http://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/sites/default/files/styles/3_2_medium_thumbnail/public/2023-10/Great%20American%20Smokeout.jpg",
+        "name": "twitter:image",
+      },
+      "tag": "meta",
+    },
+    {
+      "attributes": {
+        "content": "Great American Smokeout 2023",
+        "name": "twitter:image:alt",
+      },
+      "tag": "meta",
+    },
+  ],
   "published": true,
   "socialLinks": {
     "path": "/pittsburgh-health-care/stories/we-honor-outstanding-doctors",

--- a/src/lib/constants/environment.ts
+++ b/src/lib/constants/environment.ts
@@ -1,5 +1,6 @@
 export const environments = {
   LOCAL: 'localhost',
+  TUGBOAT: 'tugboat',
   DEV: 'development',
   STAGING: 'staging',
   PROD: 'production',
@@ -9,6 +10,10 @@ export const hosts = {
   [environments.LOCAL]: {
     hostname: 'localhost',
     origin: 'http://localhost:3000',
+  },
+  [environments.TUGBOAT]: {
+    hostname: process.env.TUGBOAT_DEFAULT_SERVICE_URL_HOST,
+    origin: process.env.TUGBOAT_DEFAULT_SERVICE_URL,
   },
   [environments.DEV]: {
     hostname: 'dev.va.gov',

--- a/src/lib/constants/environment.ts
+++ b/src/lib/constants/environment.ts
@@ -1,0 +1,25 @@
+export const environments = {
+  LOCAL: 'localhost',
+  DEV: 'development',
+  STAGING: 'staging',
+  PROD: 'production',
+} as const
+
+export const hosts = {
+  [environments.LOCAL]: {
+    hostname: 'localhost',
+    origin: 'http://localhost:3000',
+  },
+  [environments.DEV]: {
+    hostname: 'dev.va.gov',
+    origin: 'https://dev.va.gov',
+  },
+  [environments.STAGING]: {
+    hostname: 'staging.va.gov',
+    origin: 'https://staging.va.gov',
+  },
+  [environments.PROD]: {
+    hostname: 'www.va.gov',
+    origin: 'https://www.va.gov',
+  },
+} as const

--- a/src/lib/constants/resourceTypes.ts
+++ b/src/lib/constants/resourceTypes.ts
@@ -1,7 +1,7 @@
 export const RESOURCE_TYPES = {
   STORY_LISTING: 'node--story_listing',
   STORY: 'node--news_story',
-  QA: 'node--q_a',
+  // QA: 'node--q_a',
 } as const
 
 export type ResourceType = (typeof RESOURCE_TYPES)[keyof typeof RESOURCE_TYPES]

--- a/src/lib/drupal/listingPages.ts
+++ b/src/lib/drupal/listingPages.ts
@@ -2,13 +2,13 @@ import { drupalClient } from '@/lib/drupal/drupalClient'
 import { QUERIES_MAP, queries } from '@/data/queries'
 import { RESOURCE_TYPES, ResourceType } from '@/lib/constants/resourceTypes'
 import { StaticPathResource } from '@/types/dataTypes/formatted/staticPathResource'
-import { GetServerSidePropsContext, GetStaticPropsContext } from 'next'
-import { QueryOpts } from 'next-drupal-query'
+import { GetStaticPropsContext } from 'next'
 import { LovellStaticPropsContextProps } from '@/lib/drupal/lovell/types'
 import { isLovellChildVariantResource } from '@/lib/drupal/lovell/utils'
 import { getLovellVariantOfStaticPathResource } from '@/lib/drupal/lovell/staticPaths'
 import { LOVELL } from '@/lib/drupal/lovell/constants'
 import { PAGE_SIZES } from '@/lib/constants/pageSizes'
+import { ExpandedStaticPropsContext } from './staticProps'
 
 const LISTING_RESOURCE_TYPES = [RESOURCE_TYPES.STORY_LISTING] as const
 
@@ -26,12 +26,12 @@ export type ListingPageStaticPropsContextProps = {
   page: number
 }
 
-export type ListingPageDataOpts = QueryOpts<{
+export type ListingPageDataOpts = {
   id: string
   page?: number
   lovell?: LovellStaticPropsContextProps
-  context?: GetServerSidePropsContext
-}>
+  context?: ExpandedStaticPropsContext
+}
 
 type ListingPageCounts = {
   totalItems: number

--- a/src/lib/drupal/lovell/tests/mockData.ts
+++ b/src/lib/drupal/lovell/tests/mockData.ts
@@ -82,6 +82,7 @@ export const newsStoryPartialResource = {
   },
   listing: 'listing',
   entityId: 12345,
+  metatags: null,
 }
 
 export const lovellSidenavData = {

--- a/src/lib/drupal/lovell/tests/utils.test.ts
+++ b/src/lib/drupal/lovell/tests/utils.test.ts
@@ -39,10 +39,11 @@ describe('isLovellResourceType', () => {
     expect(storyResult).toBe(true)
   })
 
-  test('should return false when not Lovell resource type', () => {
-    const storyListingResult = isLovellResourceType(RESOURCE_TYPES.QA)
-    expect(storyListingResult).toBe(false)
-  })
+  // Currently, all resource types are Lovell resource types (Story, Story Listing)
+  // test('should return false when not Lovell resource type', () => {
+  //   const storyListingResult = isLovellResourceType(RESOURCE_TYPES.QA)
+  //   expect(storyListingResult).toBe(false)
+  // })
 })
 
 describe('isLovellBifurcatedResourceType', () => {

--- a/src/lib/drupal/staticProps.ts
+++ b/src/lib/drupal/staticProps.ts
@@ -33,12 +33,7 @@ export type StaticPropsResource<T extends FormattedResource> =
   | T
   | LovellStaticPropsResource<LovellFormattedResource>
 
-type StaticPropsQueryOpts =
-  | NewsStoryDataOpts
-  | ListingPageDataOpts
-  | QueryOpts<{
-      id: string
-    }>
+type StaticPropsQueryOpts = NewsStoryDataOpts | ListingPageDataOpts
 
 /**
  * Decorates the original context with expanded details:

--- a/src/lib/utils/environment.test.ts
+++ b/src/lib/utils/environment.test.ts
@@ -1,0 +1,31 @@
+import { generateAbsoluteUrlFromBuildType } from './environment'
+import { environments } from '@/lib/constants/environment'
+
+describe('generateAbsoluteUrlFromBuildType', () => {
+  test('should properly handle url with leading slash', () => {
+    const relativeUrl = '/some/path'
+    const result = generateAbsoluteUrlFromBuildType(
+      relativeUrl,
+      environments.PROD
+    )
+    expect(result).toBe('https://www.va.gov/some/path')
+  })
+
+  test('should properly handle url without leading slash', () => {
+    const relativeUrl = 'some/path'
+    const result = generateAbsoluteUrlFromBuildType(
+      relativeUrl,
+      environments.PROD
+    )
+    expect(result).toBe('https://www.va.gov/some/path')
+  })
+
+  test('should return relative url if buildType is not valid', () => {
+    const relativeUrl = '/some/path'
+    const result = generateAbsoluteUrlFromBuildType(
+      relativeUrl,
+      'invalidBuildType'
+    )
+    expect(result).toBe(relativeUrl)
+  })
+})

--- a/src/lib/utils/environment.ts
+++ b/src/lib/utils/environment.ts
@@ -1,0 +1,20 @@
+import { hosts } from '@/lib/constants/environment'
+
+export const generateAbsoluteUrlFromBuildType = (
+  relativeUrl: string,
+  buildType: string
+) => {
+  const host = hosts[buildType]
+  if (!host) {
+    return relativeUrl
+  }
+  return relativeUrl.charAt(0) === '/'
+    ? `${host.origin}${relativeUrl}`
+    : `${host.origin}/${relativeUrl}`
+}
+
+export const generateAbsoluteUrlFromEnv = (relativeUrl: string) =>
+  generateAbsoluteUrlFromBuildType(
+    relativeUrl,
+    process.env.NEXT_PUBLIC_BUILD_TYPE
+  )

--- a/src/lib/utils/environment.ts
+++ b/src/lib/utils/environment.ts
@@ -2,9 +2,9 @@ import { hosts } from '@/lib/constants/environment'
 
 export const generateAbsoluteUrlFromBuildType = (
   relativeUrl: string,
-  buildType: string
+  appEnv: string
 ) => {
-  const host = hosts[buildType]
+  const host = hosts[appEnv]
   if (!host) {
     return relativeUrl
   }
@@ -14,7 +14,4 @@ export const generateAbsoluteUrlFromBuildType = (
 }
 
 export const generateAbsoluteUrlFromEnv = (relativeUrl: string) =>
-  generateAbsoluteUrlFromBuildType(
-    relativeUrl,
-    process.env.NEXT_PUBLIC_BUILD_TYPE
-  )
+  generateAbsoluteUrlFromBuildType(relativeUrl, process.env.APP_ENV)

--- a/src/mocks/newsStory.mock.json
+++ b/src/mocks/newsStory.mock.json
@@ -27,7 +27,106 @@
   "default_langcode": true,
   "revision_translation_affected": true,
   "moderation_state": "published",
-  "metatag": null,
+  "metatag": [
+    {
+      "tag": "meta",
+      "attributes": {
+        "name": "title",
+        "content": "It’s never too late to quit smoking and start breathing easier | VA Minneapolis health care | Veterans Affairs"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "name": "description",
+        "content": "When you stop smoking, you feel the benefits almost immediately, no matter how long you’ve smoked."
+      }
+    },
+    {
+      "tag": "link",
+      "attributes": {
+        "rel": "image_src",
+        "href": "https://www.va.gov/img/design/logo/va-og-image.png"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "property": "og:site_name",
+        "content": "Veterans Affairs"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "property": "og:title",
+        "content": "It’s never too late to quit smoking and start breathing easier | VA Minneapolis health care | Veterans Affairs"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "property": "og:description",
+        "content": "When you stop smoking, you feel the benefits almost immediately, no matter how long you’ve smoked."
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "property": "og:image",
+        "content": "http://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/sites/default/files/styles/3_2_medium_thumbnail/public/2023-10/Great%20American%20Smokeout.jpg"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "property": "og:image:alt",
+        "content": "Great American Smokeout 2023"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "name": "twitter:card",
+        "content": "summary_large_image"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "name": "twitter:description",
+        "content": "When you stop smoking, you feel the benefits almost immediately, no matter how long you’ve smoked."
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "name": "twitter:site",
+        "content": "@DeptVetAffairs"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "name": "twitter:title",
+        "content": "It’s never too late to quit smoking and start breathing easier | VA Minneapolis health care | Veterans Affairs"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "name": "twitter:image",
+        "content": "http://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/sites/default/files/styles/3_2_medium_thumbnail/public/2023-10/Great%20American%20Smokeout.jpg"
+      }
+    },
+    {
+      "tag": "meta",
+      "attributes": {
+        "name": "twitter:image:alt",
+        "content": "Great American Smokeout 2023"
+      }
+    }
+  ],
   "field_featured": false,
   "field_full_story": "<p>VA Pittsburgh's Outstanding Physicians of the Year for 2019, Drs. Brooke Decker and Aref M. Rahman, stand out for expertly filling critical medical facility roles while fostering a collaborative spirit among staff in caring for Veterans.</p>\n\n<p>Dr. Decker, director of Infection Prevention, sees herself as a problem solver.</p>\n\n<p>\"The problems that cause infections are incredibly varied and sometimes challenging,\" said Decker. \"My job involves getting the right people together to help solve these problems.\"</p>\n\n<p>Recent examples include ensuring hand sanitizers are plentiful and optimally located to support hand hygiene; safe disposal of needles and syringes; and developing the safest way to shut down and perform maintenance on an air handler in a patient-care area that is always open.</p>\n\n<p>Dr. Rahman, a cardiologist, has been director of the Cardiac Cath Lab for the past six years. He credits his dedicated and skilled team for the lab's success, but he says one other factor plays a big role in that success.</p>\n\n\n    <p>\n    \"The icing on top is the staff's eagerness to help our Veterans,\"\n    said\n    Rahman.\n    \"All hospital environments can be intense and demanding and come with general and specific challenges. But having co-workers whom one can count on makes my job at VA an invaluable opportunity.\"\n    </p>\n        n\n    \n\n    <p>Decker\n    said\n    she\n    likens\n    her\n    investigative\n    work\n    to\n    that\n    of\n    the\n    fictional\n    private\n    detective\n    Sherlock\n    Holmes\n    or\n    Dr.\n    Gregory\n    House,\n    a\n    fictional\n    doctor\n    who\n    solved\n    medical\n    mysteries\n    on\n    television\n    's \"House\" series.</p>\n\n\n    <p>\n    \"For every issue, there may be layers and layers of additional clues to unravel,\"\n    said\n    Decker.\n    \"The 'aha moment' when it all comes together is very gratifying.\"\n    </p>\n        n\n    \n<p>Even so, Decker says preventing illness in the first place is even more gratifying.</p>\n\n\n    <p>\n    \"Caring for a single patient and solving that one patient's illness is our honor and privilege as health care providers,\"\n    said\n    Decker.\n    \"Preventing 10 patients from getting sick is even better, and that's what we strive to do in Infection Prevention.\"\n    </p>\n        n\n    \n<p>Rahman said he's been fascinated since childhood with how the human body works.</p>\n\n\n    <p>\n    \"I would read all kinds of articles about new discoveries in medicine and I found myself being drawn more and more toward what is literally the 'heart' of our bodies,\"\n    he\n    said.\n    \"Cardiology is not just a career choice, but a calling, and I think it found me.\"\n    </p>\n        n\n    \n<p>Both doctors said the best part of working at VA is listening to Veterans' stories.</p>\n\n\n    <p>\n    \"I love sitting down at the bedside and hearing about someone's family, pets, adventures,\"\n    said\n    Decker.\n    \"I've met some truly great people working at VA.\"\n    </p>\n        n\n    \n<p>Rahman said Veterans' stories make every day at work interesting.</p>\n\n\n    <p>\n    \"As I interact with my patients, I get to hear a lot of fascinating stories of their experiences all over the world,\"\n    said\n    Rahman.\n    \"It's never a dull day at work.\"\n    </p>\n        n\n    \n<p>Decker and Rahman were formally recognized as Outstanding Physicians of the Year on April 26 during the medical staff's quarterly meeting at University Drive.</p>",
   "field_image_caption": "\n  \"Caring for a single patient and solving that one patient's illness is our honor and privilege as health care providers.\"\n  -\n  Dr.\n  Brooke\n  Decker\n  ",

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -4,13 +4,11 @@ import {
   GetStaticPathsResult,
   GetStaticPropsContext,
 } from 'next'
-import Head from 'next/head'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { getGlobalElements } from '@/lib/drupal/getGlobalElements'
 import { Wrapper } from '@/templates/globals/wrapper'
 import { NewsStory } from '@/templates/layouts/newsStory'
 import { StoryListing } from '@/templates/layouts/storyListing'
-import { QuestionAnswer } from '@/templates/layouts/questionAnswer'
 import HTMLComment from '@/templates/globals/util/HTMLComment'
 import { getStaticPathsByResourceType } from '@/lib/drupal/staticPaths'
 import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
@@ -19,6 +17,12 @@ import {
   getStaticPropsResource,
 } from '@/lib/drupal/staticProps'
 import Breadcrumbs from '@/templates/common/breadcrumbs'
+import { StaticPropsResource } from '@/lib/drupal/staticProps'
+import { FormattedResource } from '@/data/queries'
+import { LayoutProps } from '@/templates/globals/wrapper'
+import { NewsStory as FormattedNewsStory } from '@/types/dataTypes/formatted/newsStory'
+import { StoryListing as FormattedStoryListing } from '@/types/dataTypes/formatted/storyListing'
+import { Meta } from '@/templates/globals/meta'
 
 const RESOURCE_TYPES_TO_BUILD = [
   RESOURCE_TYPES.STORY_LISTING,
@@ -33,10 +37,13 @@ export default function ResourcePage({
   bannerData,
   headerFooterData,
   preview,
+}: {
+  resource: StaticPropsResource<FormattedResource>
+  bannerData: LayoutProps['bannerData']
+  headerFooterData: LayoutProps['headerFooterData']
+  preview: boolean
 }) {
   if (!resource) return null
-
-  const title = `${resource.title} | Veterans Affairs`
   const comment = `
       --
       | resourceType: ${resource?.type || 'N/A'}
@@ -47,12 +54,8 @@ export default function ResourcePage({
 
   return (
     <Wrapper bannerData={bannerData} headerFooterData={headerFooterData}>
+      <Meta resource={resource} />
       <HTMLComment position="head" content={comment} />
-      <Head>
-        <title>{title}</title>
-        {/* todo: do all meta tags correctly, currently this fixes an error on news story */}
-        <meta property="og:url" content="foo" />
-      </Head>
 
       {preview && (
         <div className="usa-grid-full">
@@ -78,14 +81,14 @@ export default function ResourcePage({
       <main>
         <div id="content" className="interior">
           {resource.type === RESOURCE_TYPES.STORY_LISTING && (
-            <StoryListing {...resource} />
+            <StoryListing {...(resource as FormattedStoryListing)} />
           )}
           {resource.type === RESOURCE_TYPES.STORY && (
-            <NewsStory {...resource} />
+            <NewsStory {...(resource as FormattedNewsStory)} />
           )}
-          {resource.type === RESOURCE_TYPES.QA && (
+          {/* {resource.type === RESOURCE_TYPES.QA && (
             <QuestionAnswer {...resource} />
-          )}
+          )} */}
         </div>
       </main>
     </Wrapper>

--- a/src/templates/common/contentFooter/index.tsx
+++ b/src/templates/common/contentFooter/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { parseDate, getDateParts } from '@/lib/utils/date'
 import { MedalliaAssets } from '@/templates/globals/medallia'
 import { getSurveyNumber, showForm } from '@/lib/utils/medallia'
+import { environments } from '@/lib/constants/environment'
 
 type ContentFooterProps = {
   lastUpdated?: string | number
@@ -43,7 +44,7 @@ function FeedbackButton() {
         aria-label="give feedback"
         onClick={() => {
           const isProduction =
-            process.env.NEXT_PUBLIC_BUILD_TYPE === 'production'
+            process.env.NEXT_PUBLIC_BUILD_TYPE === environments.PROD
           const surveyNumber = getSurveyNumber(
             window.location.pathname,
             isProduction

--- a/src/templates/globals/medallia/index.tsx
+++ b/src/templates/globals/medallia/index.tsx
@@ -6,12 +6,13 @@ import {
   onMedalliaLoaded,
   setWindowVaSurvey,
 } from '@/lib/utils/medallia'
+import { environments } from '@/lib/constants/environment'
 
 export function MedalliaAssets() {
-  const scriptId = process.env.BUILD_TYPE === 'production' ? 2 : 5
+  const scriptId = process.env.BUILD_TYPE === environments.PROD ? 2 : 5
 
   useEffect(() => {
-    if (process.env.NEXT_PUBLIC_BUILD_TYPE === 'localhost') {
+    if (process.env.NEXT_PUBLIC_BUILD_TYPE === environments.LOCAL) {
       onMedalliaLoaded(() => {
         const surveyNumber = getSurveyNumber(window.location.pathname, false)
         const neb_status = loadForm(surveyNumber)

--- a/src/templates/globals/meta/index.tsx
+++ b/src/templates/globals/meta/index.tsx
@@ -1,0 +1,134 @@
+import Head from 'next/head'
+import { MetaTag } from '@/types/dataTypes/formatted/metatags'
+import { parseDate, getDateParts } from '@/lib/utils/date'
+import { StaticPropsResource } from '@/lib/drupal/staticProps'
+import { FormattedResource } from '@/data/queries'
+import { generateAbsoluteUrlFromEnv } from '@/lib/utils/environment'
+import { environments } from '@/lib/constants/environment'
+
+const LastUpdated = ({ timestamp }: { timestamp: string | number }) => {
+  if (timestamp) {
+    const lastUpdatedDate = parseDate(timestamp)
+    const dateParts = getDateParts(lastUpdatedDate)
+    const month = dateParts.month?.twoDigit
+    const day = dateParts.day?.twoDigit
+    const year = dateParts.year?.numeric
+
+    if (month && day && year) {
+      return (
+        <Head>
+          <meta name="DC.Date" content={`${year}-${month}-${day}`}></meta>
+        </Head>
+      )
+    }
+  }
+}
+
+const IOSBanner = () => (
+  <Head>
+    <meta name="apple-itunes-app" content="app-id=1559609596" />
+    <meta
+      name="smartbanner:exclude-user-agent-regex"
+      content="^.*(Version).*Safari"
+    />
+    <meta name="smartbanner:title" content="VA: Health and Benefits" />
+    <meta name="smartbanner:author" content="US Dept. of Veteran Affairs" />
+    <meta name="smartbanner:price" content=" " />
+    <meta name="smartbanner:price-suffix-apple" content=" " />
+    <meta name="smartbanner:price-suffix-google" content=" " />
+    <meta
+      name="smartbanner:icon-apple"
+      content="https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/cb/43/1f/cb431fa1-b110-805f-251d-2fbb68babb1a/AppIcon-1x_U007emarketing-0-7-0-85-220.png/230x0w.webp"
+    />
+    <meta
+      name="smartbanner:icon-google"
+      content="https://play-lh.googleusercontent.com/pxpOEzV8odLxElJtNrPhorM48TPh6p-RnTWqwvlhetuMM3lZuGmbXP2_4YHlQ-fCOA=w240-h480-rw"
+    />
+    <meta name="smartbanner:button" content="VIEW" />
+    <meta
+      name="smartbanner:button-url-apple"
+      content="https://apps.apple.com/us/app/va-health-and-benefits/id1559609596"
+    />
+    <meta
+      name="smartbanner:button-url-google"
+      content="https://play.google.com/store/apps/details?id=gov.va.mobileapp&hl=en_US&gl=US&pli=1"
+    />
+    <meta name="smartbanner:enabled-platforms" content="android,ios" />
+    <meta name="smartbanner:close-label" content="Close" />
+  </Head>
+)
+
+// TODO: Implement article tags
+// TODO: Is this necessary? Are these ever set?
+// See: https://github.com/department-of-veterans-affairs/content-build/blob/f898e20d02cbf011e6e26976de95c5d33eace1c0/src/site/includes/metatags.drupal.liquid#L58-L63C12
+const ArticleTags = ({ tags }: { tags: string[] }) => <></>
+
+const CustomTags = ({ tags }: { tags: MetaTag[] }) => (
+  <Head>
+    {tags.map?.(({ tag: Tag, attributes }, i) =>
+      attributes.name === 'title' ? (
+        <title key={i}>{attributes.content}</title>
+      ) : (
+        <Tag key={i} {...attributes} />
+      )
+    )}
+  </Head>
+)
+
+// TODO: Implement default meta tags when no custom tags are present
+// TODO: Is this necessary? Are there content types where custom meta tags are not set?
+// See: https://github.com/department-of-veterans-affairs/content-build/blob/f898e20d02cbf011e6e26976de95c5d33eace1c0/src/site/includes/metatags.drupal.liquid#L88-L146
+const DefaultTags = ({
+  resource,
+}: {
+  resource: StaticPropsResource<FormattedResource>
+}) => <></>
+
+export const Meta = ({
+  resource,
+}: {
+  resource: StaticPropsResource<FormattedResource>
+}) => {
+  const noIndex = process.env.NEXT_PUBLIC_BUILD_TYPE !== environments.PROD
+  const canonicalLink =
+    'canonicalLink' in resource ? resource.canonicalLink : resource.entityPath
+
+  // TODO: pass this value when we have it present in future content types
+  const lastUpdated = null
+
+  // TODO: calculate when to show iOS banner
+  // See: https://github.com/department-of-veterans-affairs/content-build/blob/f898e20d02cbf011e6e26976de95c5d33eace1c0/src/site/filters/liquid.js#L1741-L1756
+  const showIOSBanner = false
+
+  return (
+    <>
+      <Head>
+        {noIndex && <meta name="robots" content="noindex" />}
+        <meta charSet="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="HandheldFriendly" content="True" />
+        <meta name="MobileOptimized" content="320" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link
+          rel="canonical"
+          href={generateAbsoluteUrlFromEnv(canonicalLink)}
+        />
+        <meta
+          property="og:url"
+          content={generateAbsoluteUrlFromEnv(resource.entityPath)}
+        />
+        <meta property="og:type" content="website" />
+      </Head>
+
+      {lastUpdated && <LastUpdated timestamp={lastUpdated} />}
+      {showIOSBanner && <IOSBanner />}
+      <ArticleTags tags={null} />
+
+      {resource.metatags?.length > 0 ? (
+        <CustomTags tags={resource.metatags} />
+      ) : (
+        <DefaultTags resource={resource} />
+      )}
+    </>
+  )
+}

--- a/src/templates/layouts/newsStory/index.test.tsx
+++ b/src/templates/layouts/newsStory/index.test.tsx
@@ -55,6 +55,24 @@ const data = {
     id: 12,
     name: 'VA Pittsburgh health care',
   },
+  metatags: [
+    {
+      attributes: {
+        content:
+          'It’s never too late to quit smoking and start breathing easier | VA Minneapolis health care | Veterans Affairs',
+        name: 'title',
+      },
+      tag: 'meta',
+    },
+    {
+      attributes: {
+        content:
+          'When you stop smoking, you feel the benefits almost immediately, no matter how long you’ve smoked.',
+        name: 'description',
+      },
+      tag: 'meta',
+    },
+  ],
 }
 
 describe('<newsStory> with valid data', () => {

--- a/src/templates/layouts/storyListing/index.test.tsx
+++ b/src/templates/layouts/storyListing/index.test.tsx
@@ -22,6 +22,22 @@ let storyListingProps: FormattedStoryListing = {
   currentPage: 1,
   totalItems: 0,
   totalPages: 1,
+  metatags: [
+    {
+      attributes: {
+        content: 'Stories | VA Minneapolis health care | Veterans Affairs',
+        name: 'title',
+      },
+      tag: 'meta',
+    },
+    {
+      attributes: {
+        content: 'This is the description',
+        name: 'description',
+      },
+      tag: 'meta',
+    },
+  ],
 }
 
 describe('<StoryListing> component renders', () => {

--- a/src/types/dataTypes/drupal/metatag.ts
+++ b/src/types/dataTypes/drupal/metatag.ts
@@ -1,0 +1,6 @@
+export type DrupalMetaTag = {
+  tag: string
+  attributes: {
+    [key: string]: string
+  }
+}

--- a/src/types/dataTypes/formatted/metatags.ts
+++ b/src/types/dataTypes/formatted/metatags.ts
@@ -1,0 +1,6 @@
+export type MetaTag = {
+  tag: string
+  attributes: {
+    [key: string]: string
+  }
+}

--- a/src/types/dataTypes/formatted/newsStory.ts
+++ b/src/types/dataTypes/formatted/newsStory.ts
@@ -4,6 +4,7 @@ import { SocialLinksProps } from '@/templates/common/socialLinks'
 import { Administration } from '@/types/dataTypes/formatted/administration'
 import { BreadcrumbItem } from '@/types/dataTypes/drupal/field_type'
 import { PublishedEntity } from './publishedEntity'
+import { MetaTag } from './metatags'
 import { MediaImage } from './media'
 
 export type NewsStoryTeaser = PublishedEntity & {
@@ -28,4 +29,5 @@ export type NewsStory = PublishedEntity & {
   entityPath: string
   administration: Administration
   breadcrumbs: BreadcrumbItem[]
+  metatags: MetaTag[]
 }

--- a/src/types/dataTypes/formatted/path.ts
+++ b/src/types/dataTypes/formatted/path.ts
@@ -1,5 +1,0 @@
-export type Path = {
-  pid?: number
-  alias?: string
-  langcode?: string
-}

--- a/src/types/dataTypes/formatted/path.ts
+++ b/src/types/dataTypes/formatted/path.ts
@@ -1,0 +1,5 @@
+export type Path = {
+  pid?: number
+  alias?: string
+  langcode?: string
+}

--- a/src/types/dataTypes/formatted/storyListing.ts
+++ b/src/types/dataTypes/formatted/storyListing.ts
@@ -2,6 +2,7 @@ import { PublishedEntity } from './publishedEntity'
 import { NewsStoryTeaser } from '@/types/dataTypes/formatted/newsStory'
 import { SideNavMenu } from '@/types/dataTypes/formatted/sideNav'
 import { BreadcrumbItem } from '@/types/dataTypes/drupal/field_type'
+import { MetaTag } from './metatags'
 
 export type StoryListingLink = {
   path: string
@@ -18,4 +19,5 @@ export type StoryListing = PublishedEntity & {
   entityId: number
   entityPath: string
   breadcrumbs: BreadcrumbItem[]
+  metatags: MetaTag[]
 }


### PR DESCRIPTION
## Description
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16105

Custom meta tags were made available via JSON:API in recent work. This PR places those custom meta tags, along with other global meta tags, on the page.

## Testing done
Manual; see QA steps

## QA steps
- Visit a number of different page types and ensure meta tags are in the page markup
  - [ ] News story
  - [ ] Lovell news story
  - [ ] Story listing
  - [ ] Lovell story listing
