### PR TITLE
Redis hotfix

### DIFF
--- a/src/lib/drupal/drupalClient.ts
+++ b/src/lib/drupal/drupalClient.ts
@@ -63,6 +63,10 @@ export const drupalClient = new DrupalClient(baseUrl, {
   fetcher,
   useDefaultResourceTypeEntry: true,
   throwJsonApiErrors: false,
+  auth: {
+    clientId: process.env.DRUPAL_CLIENT_ID,
+    clientSecret: process.env.DRUPAL_CLIENT_SECRET,
+  },
   // cache: redisCache(createRedisClient(process.env.REDIS_URL)),
   previewSecret: process.env.DRUPAL_PREVIEW_SECRET,
 })

--- a/src/lib/drupal/drupalClient.ts
+++ b/src/lib/drupal/drupalClient.ts
@@ -63,10 +63,6 @@ export const drupalClient = new DrupalClient(baseUrl, {
   fetcher,
   useDefaultResourceTypeEntry: true,
   throwJsonApiErrors: false,
-  auth: {
-    clientId: process.env.DRUPAL_CLIENT_ID,
-    clientSecret: process.env.DRUPAL_CLIENT_SECRET,
-  },
-  cache: redisCache(createRedisClient(process.env.REDIS_URL)),
+  // cache: redisCache(createRedisClient(process.env.REDIS_URL)),
   previewSecret: process.env.DRUPAL_PREVIEW_SECRET,
 })

--- a/src/lib/drupal/queryResources.ts
+++ b/src/lib/drupal/queryResources.ts
@@ -7,8 +7,8 @@ export async function getMenu(name: string, params: QueryParams<null>) {
     params: params().getQueryObject(),
 
     // Cache resource during build, not dev.
-    withCache: process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD,
-    cacheKey: `menu:${name}`,
+    // withCache: process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD,
+    // cacheKey: `menu:${name}`,
   })
 
   return menu


### PR DESCRIPTION
## Description
disabling redis cache so cms tugboats don't exit because of a missing service that they shouldn't depend on

## Testing done


## Screenshots


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
