### PR TITLE
Build GHAR Packer Cannot Use Bundled Plugins 

### DIFF
--- a/.github/workflows/packer-ghar.yml
+++ b/.github/workflows/packer-ghar.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: manifest
-          path: packer/github-action-runner/manifest.json
+          path: ${{ matrix.build_location }}/manifest.json 
       - uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb # latest
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
@@ -131,7 +131,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: manifest
-          path: ${{ matrix.build_location }}/manifest.json
+          path: packer/github-action-runner/manifest.json
       - name: get ami ID from manifest
         run: echo "AMI_ID=$(cat manifest.json |jq -r .builds[].artifact_id|awk -F":" '{print $2}')" >> $GITHUB_ENV
       - name: Update Launch Templates

--- a/.github/workflows/packer-ghar.yml
+++ b/.github/workflows/packer-ghar.yml
@@ -131,7 +131,6 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: manifest
-          path: packer/github-action-runner/manifest.json
       - name: get ami ID from manifest
         run: echo "AMI_ID=$(cat manifest.json |jq -r .builds[].artifact_id|awk -F":" '{print $2}')" >> $GITHUB_ENV
       - name: Update Launch Templates

--- a/.github/workflows/packer-ghar.yml
+++ b/.github/workflows/packer-ghar.yml
@@ -131,6 +131,7 @@ jobs:
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: manifest
+          path: ${{ matrix.build_location }}/manifest.json
       - name: get ami ID from manifest
         run: echo "AMI_ID=$(cat manifest.json |jq -r .builds[].artifact_id|awk -F":" '{print $2}')" >> $GITHUB_ENV
       - name: Update Launch Templates

--- a/.github/workflows/packer-ghar.yml
+++ b/.github/workflows/packer-ghar.yml
@@ -1,5 +1,6 @@
 name: Build GHAR
 on:
+  pull_request:
   schedule:
     - cron: '30 5 1,15 * *'
   workflow_dispatch:

--- a/.github/workflows/packer-ghar.yml
+++ b/.github/workflows/packer-ghar.yml
@@ -1,6 +1,5 @@
 name: Build GHAR
 on:
-  pull_request:
   schedule:
     - cron: '30 5 1,15 * *'
   workflow_dispatch:

--- a/.github/workflows/packer-ghar.yml
+++ b/.github/workflows/packer-ghar.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: manifest
-          path: ${{ matrix.build_location }}/manifest.json 
+          path: ${{ matrix.build_location }}/manifest.json
       - uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb # latest
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN

--- a/.github/workflows/packer-ghar.yml
+++ b/.github/workflows/packer-ghar.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: manifest
-          path: ${{ matrix.build_location }}/manifest.json
+          path: packer/github-action-runner/manifest.json
       - uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb # latest
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN

--- a/packer/github-action-runner/variables.pkr.hcl
+++ b/packer/github-action-runner/variables.pkr.hcl
@@ -1,3 +1,12 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
 variable "skip_ami" {
   type    = bool
   default = true


### PR DESCRIPTION
## Description

Building Github Actions Runner AMIs never set required plugins like Base AMI builds did. The Build workflow had been reporting this error:

```
Warning: Bundled plugins used

This template relies on the use of plugins bundled into the Packer binary.
The practice of bundling external plugins into Packer will be removed in an
upcoming version.

To remove this warning, add the following section to your template:

packer {
  required_plugins {
    amazon = {
      source  = "github.com/hashicorp/amazon"
      version = "~> 1"
    }
  }
}
```

The payments on this technical debt are due. Simply add the required plugin to Build GHAR's variables.hcl file.

## Related Issues
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16240
https://github.com/department-of-veterans-affairs/devops/pull/13814


## Testing done


## Screenshots


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
