### PR TITLE
VACMS-15322: ENV/CLI follow-up

### DIFF
--- a/packages/env-loader/src/cli-options.ts
+++ b/packages/env-loader/src/cli-options.ts
@@ -9,8 +9,20 @@ type AdditionalHelp = {
 const ADDITIONAL_HELP: { [key: string]: AdditionalHelp[] } = {
   test: [
     {
-      heading: 'Update Snapshots',
+      heading: 'Watch mode',
+      commands: ['yarn test:watch'],
+    },
+    {
+      heading: 'With coverage report',
+      commands: ['yarn test:coverage'],
+    },
+    {
+      heading: 'Update test snapshots',
       commands: ['yarn test:update-snapshots', 'yarn test:u'],
+    },
+    {
+      heading: 'Run Playwright E2E tests',
+      commands: ['yarn test:playwright'],
     },
   ],
 }
@@ -56,7 +68,7 @@ export const getCliOptions = (scriptName: string): EnvVars => {
     .addOption(
       new Option('--NEXT_PUBLIC_BUILD_TYPE <buildType>', 'Build type').choices([
         'localhost',
-        'vaogvdev',
+        'vagovdev',
         'vagovstaging',
         'vagovprod',
       ])

--- a/packages/env-loader/src/cli-options.ts
+++ b/packages/env-loader/src/cli-options.ts
@@ -1,10 +1,51 @@
 import { Command, Option } from 'commander'
 import { EnvVars } from '.'
 
+type AdditionalHelp = {
+  heading: string
+  commands: string[]
+}
+
+const ADDITIONAL_HELP: { [key: string]: AdditionalHelp[] } = {
+  test: [
+    {
+      heading: 'Update Snapshots',
+      commands: ['yarn test:update-snapshots', 'yarn test:u'],
+    },
+  ],
+}
+
+const formatHelpText = (
+  scriptName: string,
+  helpCommands: AdditionalHelp[]
+): string => {
+  const outputLines: string[] = []
+  outputLines.push(`Additional \`${scriptName}\` commands:`)
+  helpCommands.forEach((helpCommand) => {
+    outputLines.push(`\n  ${helpCommand.heading}:`)
+    helpCommand.commands.forEach((terminalCommand) => {
+      outputLines.push(`\n    $ ${terminalCommand}`)
+    })
+  })
+  outputLines.push('\n')
+
+  return outputLines.join('')
+}
+
+const configureAdditionalHelpText = (
+  program: Command,
+  scriptName: string
+): void => {
+  const additionalHelp = ADDITIONAL_HELP[scriptName]
+  if (additionalHelp) {
+    program.addHelpText('beforeAll', formatHelpText(scriptName, additionalHelp))
+  }
+}
+
 /**
  * Parses CLI options from the command line into an object.
  */
-export const getCliOptions = (): EnvVars => {
+export const getCliOptions = (scriptName: string): EnvVars => {
   const program = new Command()
   program
     .option('--NEXT_IMAGE_DOMAIN <url>', 'Drupal image domain')
@@ -15,7 +56,7 @@ export const getCliOptions = (): EnvVars => {
     .addOption(
       new Option('--NEXT_PUBLIC_BUILD_TYPE <buildType>', 'Build type').choices([
         'localhost',
-        'vagovdev',
+        'vaogvdev',
         'vagovstaging',
         'vagovprod',
       ])
@@ -27,7 +68,8 @@ export const getCliOptions = (): EnvVars => {
     .option('--DRUPAL_SITE_ID <id>', 'Drupal site ID')
     .option('--REDIS_URL <url>', 'Redis URL')
     .option('--SITE_URL <url>', 'Origin used for generated absolute paths')
-    .parse()
 
-  return program.opts()
+  configureAdditionalHelpText(program, scriptName)
+
+  return program.parse().opts()
 }

--- a/packages/env-loader/src/index.ts
+++ b/packages/env-loader/src/index.ts
@@ -8,9 +8,9 @@ export type EnvVars = {
   [key: string]: string
 }
 
-const getAllEnvVars = async (): Promise<EnvVars> => {
+const getAllEnvVars = async (scriptName: string): Promise<EnvVars> => {
   // CLI OPTIONS
-  const cliOptions = getCliOptions()
+  const cliOptions = getCliOptions(scriptName)
 
   // ENV FILE VARS
   const envVars = getEnvFileVars(process.env.APP_ENV)
@@ -41,10 +41,17 @@ const getAllEnvVars = async (): Promise<EnvVars> => {
   }
 }
 
+const getYarnScriptName = (path: string): string => {
+  const match = path.match(/\/scripts\/yarn\/(.*)\.js/)
+  return match?.[1] || ''
+}
+
 export const processEnv = async (command: string): Promise<void> => {
+  const yarnScriptName = getYarnScriptName(process.argv[1])
+
   process.env = {
     ...process.env,
-    ...(await getAllEnvVars()),
+    ...(await getAllEnvVars(yarnScriptName)),
   }
 
   spawn(command, {


### PR DESCRIPTION
## Description
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15322

Some small follow-on work to add some additional help text to `--help` commands.

## Testing done/QA
`yarn test -h` should show additional help
```
Additional `test` commands:
  Update Snapshots:
    $ yarn test:update-snapshots
    $ yarn test:u

Usage: test [options]

Options:
  --NEXT_IMAGE_DOMAIN <url>             Drupal image domain
  --NEXT_PUBLIC_ASSETS_URL <url>        Where to source vets-website assets
  --NEXT_PUBLIC_BUILD_TYPE <buildType>  Build type (choices: "localhost", "vaogvdev", "vagovstaging", "vagovprod")
  --NEXT_PUBLIC_DRUPAL_BASE_URL <url>   Drupal base URL
  --DRUPAL_CLIENT_ID <id>               Drupal client ID
  --DRUPAL_CLIENT_SECRET <secret>       Drupal client secret
  --DRUPAL_PREVIEW_SECRET <secret>      Drupal preview secret
  --DRUPAL_SITE_ID <id>                 Drupal site ID
  --REDIS_URL <url>                     Redis URL
  --SITE_URL <url>                      Origin used for generated absolute paths
  -h, --help                            display help for command
```

`yarn build -h` should not
```
Usage: build [options]

Options:
  --NEXT_IMAGE_DOMAIN <url>             Drupal image domain
  --NEXT_PUBLIC_ASSETS_URL <url>        Where to source vets-website assets
  --NEXT_PUBLIC_BUILD_TYPE <buildType>  Build type (choices: "localhost", "vaogvdev", "vagovstaging", "vagovprod")
  --NEXT_PUBLIC_DRUPAL_BASE_URL <url>   Drupal base URL
  --DRUPAL_CLIENT_ID <id>               Drupal client ID
  --DRUPAL_CLIENT_SECRET <secret>       Drupal client secret
  --DRUPAL_PREVIEW_SECRET <secret>      Drupal preview secret
  --DRUPAL_SITE_ID <id>                 Drupal site ID
  --REDIS_URL <url>                     Redis URL
  --SITE_URL <url>                      Origin used for generated absolute paths
  -h, --help                            display help for command
```