### PR TITLE
build the preview server output as part of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Example tests
         run: yarn test:examples
+
+      - name: Verify CMS preview build works
+        run: yarn build:preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,3 @@ jobs:
 
       - name: Example tests
         run: yarn test:examples
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,3 @@ jobs:
       - name: Example tests
         run: yarn test:examples
 
-      - name: Verify CMS preview build works
-        run: yarn build:preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,36 @@
+name: CMS Preview Check
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+jobs:
+  preview:
+    timeout-minutes: 15
+    runs-on: [self-hosted, asg]
+    container:
+      image: public.ecr.aws/docker/library/node:18.19.0-bullseye
+      # Certs added for the self hosted runner
+      env:
+        NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
+      ports:
+        - 80
+      volumes:
+        - my_docker_volume:/home/runner
+        - /etc/ssl/certs:/etc/ssl/certs
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 18
+    - name: Setup Yarn
+      run: |
+        corepack enable
+        corepack install -g --cache-only .yarn/releases/corepack.tgz
+
+    - name: Install dependencies
+      run: |
+        yarn
+
+    - name: Verify CMS preview build works
+      run: yarn build:preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,6 +13,7 @@ jobs:
       # Certs added for the self hosted runner
       env:
         NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
+        APP_ENV: gha
       ports:
         - 80
       volumes:

--- a/envs/.env.gha
+++ b/envs/.env.gha
@@ -2,23 +2,10 @@
 NEXT_PUBLIC_DRUPAL_BASE_URL=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
 NEXT_IMAGE_DOMAIN=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
 
-# If running va.gov-cms locally
-# NEXT_PUBLIC_DRUPAL_BASE_URL=https://va-gov-cms.ddev.site
-# NEXT_IMAGE_DOMAIN=https://va-gov-cms.ddev.site
-
 # for Drupal preview
 DRUPAL_PREVIEW_SECRET=secret
 DRUPAL_CLIENT_ID=Retrieve this from AWS SSM /cms/consumers/next-build/client_id
 DRUPAL_CLIENT_SECRET=Retrieve this from AWS SSM /cms/consumers/next-build/client_secret
-
-# for local sitemap generation
-SITE_URL=http://localhost:8001
-
-# for local redis server
-REDIS_URL=redis://127.0.0.1:6379
-
-# for local assets from vets-website
-NEXT_PUBLIC_ASSETS_URL=/generated/
 
 # google analytics (These are the dev environment credentials)
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "yarn build:env-loader && node ./scripts/yarn/dev.js --SSG=false",
     "build": "yarn build:env-loader && node ./scripts/yarn/build.js --USE_REDIS=true",
     "build:env-loader": "tsc -b ./packages/env-loader/tsconfig.json",
-    "build:preview": "yarn build:env-loader && node ./scripts/yarn/build.js --SSG=false",
+    "build:preview": "yarn build:env-loader && node ./scripts/yarn/build.js --SSG=false --USE_REDIS=false",
     "build:sitemap": "yarn build:env-loader & node ./scripts/yarn/build:sitemap.js",
     "start": "yarn build:env-loader && node ./scripts/yarn/start.js",
     "export": "yarn build:env-loader && node ./scripts/yarn/export.js --USE_REDIS=true",

--- a/src/data/queries/tests/__snapshots__/questionAnswer.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/questionAnswer.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`node--q_a formatData outputs formatted data 1`] = `
     "entityId": 8504,
     "entityPath": "/resources/how-can-i-find-out-my-va-claim-or-appeal-status",
     "id": "c2839a4c-c13d-46da-b448-9d1ec389773b",
+    "lastUpdated": "2020-10-19T17:10:51+00:00",
     "published": true,
     "tags": [
       {
@@ -97,6 +98,7 @@ exports[`node--q_a formatData outputs formatted data 1`] = `
     "entityId": 8538,
     "entityPath": "/resources/are-service-dogs-allowed-in-va-facilities",
     "id": "eaff8edf-2cee-4e11-9373-7860a78295a6",
+    "lastUpdated": "2020-10-19T21:42:01+00:00",
     "published": true,
     "tags": [
       {
@@ -141,6 +143,7 @@ exports[`node--q_a formatData outputs formatted data 1`] = `
     "entityId": 8514,
     "entityPath": "/resources/what-types-of-claims-and-appeals-can-i-track-online",
     "id": "bcf87f05-f947-4631-8a86-a3c0c0fe9878",
+    "lastUpdated": "2020-10-19T18:13:29+00:00",
     "published": true,
     "tags": [
       {

--- a/src/lib/utils/events.test.ts
+++ b/src/lib/utils/events.test.ts
@@ -44,7 +44,7 @@ describe('formatEventCTA', () => {
       const result = createMailToLink(emailCTA, title, mostRecentDate, linkPath)
 
       expect(result).toBe(
-        'mailto:example@example.com?subject=RSVP%20for%20Event%20Title%20on%20Thu%2C%20Sep%207%2C%202023%2C%2010%3A00%20AM%20EDT%20%E2%80%93%2012%3A00%20PM%20EDT&body=I%20would%20like%20to%20register%20for%20Event%20Title%20on%20Thu%2C%20Sep%207%2C%202023%2C%2010%3A00%20AM%20EDT%20%E2%80%93%2012%3A00%20PM%20EDT.%20(https%3A%2F%2Fva.gov%2Fevent-path)'
+        'mailto:example@example.com?subject=RSVP%20for%20Event%20Title%20on%20Thu%2C%20Sep%207%2C%202023%2C%207%3A00%20AM%20PDT%20%E2%80%93%209%3A00%20AM%20PDT&body=I%20would%20like%20to%20register%20for%20Event%20Title%20on%20Thu%2C%20Sep%207%2C%202023%2C%207%3A00%20AM%20PDT%20%E2%80%93%209%3A00%20AM%20PDT.%20(https%3A%2F%2Fva.gov%2Fevent-path)'
       )
     })
   })


### PR DESCRIPTION
## Description
Adds a CI check for `yarn build:preview` as an early canary for CMS preview activities.

## Testing done
added a check to the CI workflow

## Screenshots
![Screenshot 2024-01-04 at 12 24 02 PM](https://github.com/department-of-veterans-affairs/next-build/assets/11279744/0d47409f-fba7-4a49-9445-52df5fcb2b6e)


## QA steps
CI should pass.

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```