### PR TITLE
VACMS-16501 gtm keys

### DIFF
--- a/READMEs/analytics.md
+++ b/READMEs/analytics.md
@@ -1,0 +1,15 @@
+Analytics in next-build:
+
+1. Google Tag Manager via [react-gtm-module](https://www.npmjs.com/package/react-gtm-module). See `src/pages/_app.tsx`
+
+Existing content-build analytics tags for reference:
+
+- [vagovdev](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/assets/js/google-analytics/vagovdev.js)
+- [vagovstaging](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/assets/js/google-analytics/vagovstaging.js)
+- [vagovprod](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/assets/js/google-analytics/vagovprod.js)
+
+2. VA.gov participates in the US government’s analytics program. See the data at analytics.usa.gov.
+
+- https://github.com/digital-analytics-program/gov-wide-code
+
+3. Datadog integration coming soon

--- a/envs/.env.example
+++ b/envs/.env.example
@@ -20,7 +20,7 @@ REDIS_URL=redis://127.0.0.1:6379
 # for local assets from vets-website
 NEXT_PUBLIC_ASSETS_URL=/generated/
 
-# google analytics (These are the dev environment credentials)
+# Google Analytics (These are the dev environment credentials)
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_AUTH=N9BisSDKAwJENFQtQIEvXQ
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_PREVIEW=env-423

--- a/envs/.env.gha
+++ b/envs/.env.gha
@@ -7,7 +7,7 @@ DRUPAL_PREVIEW_SECRET=secret
 DRUPAL_CLIENT_ID=Retrieve this from AWS SSM /cms/consumers/next-build/client_id
 DRUPAL_CLIENT_SECRET=Retrieve this from AWS SSM /cms/consumers/next-build/client_secret
 
-# google analytics (These are the dev environment credentials)
+# Google Analytics (These are the dev environment credentials)
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_AUTH=N9BisSDKAwJENFQtQIEvXQ
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_PREVIEW=env-423

--- a/envs/.env.prod
+++ b/envs/.env.prod
@@ -1,0 +1,15 @@
+# This is the standard lower environment for Content API.
+NEXT_PUBLIC_DRUPAL_BASE_URL=https://prod.cms.va.gov/
+NEXT_IMAGE_DOMAIN=https://prod.cms.va.gov/
+
+NEXT_PUBLIC_ASSETS_URL=/generated/
+
+# for Drupal preview
+DRUPAL_PREVIEW_SECRET=secret
+# store these securely in the build pipeline env
+#DRUPAL_CLIENT_ID=Retrieve this from AWS SSM /cms/consumers/next-build/client_id
+#DRUPAL_CLIENT_SECRET=Retrieve this from AWS SSM /cms/consumers/next-build/client_secret
+
+# Google Analytics
+# These print directly to the page so do not need to store in SSM.
+NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD

--- a/envs/.env.staging
+++ b/envs/.env.staging
@@ -1,0 +1,17 @@
+# This is the standard lower environment for Content API.
+NEXT_PUBLIC_DRUPAL_BASE_URL=https://staging.cms.va.gov/
+NEXT_IMAGE_DOMAIN=https://staging.cms.va.gov/
+
+NEXT_PUBLIC_ASSETS_URL=/generated/
+
+# for Drupal preview
+DRUPAL_PREVIEW_SECRET=secret
+# store these securely in the build pipeline env
+#DRUPAL_CLIENT_ID=Retrieve this from AWS SSM /cms/consumers/next-build/client_id
+#DRUPAL_CLIENT_SECRET=Retrieve this from AWS SSM /cms/consumers/next-build/client_secret
+
+# Google Analytics
+# These print directly to the page so do not need to store in SSM.
+NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD
+NEXT_PUBLIC_GOOGLE_TAG_MANAGER_AUTH=inC4EKQce9vlWpRVcowiyQ
+NEXT_PUBLIC_GOOGLE_TAG_MANAGER_PREVIEW=env-661

--- a/envs/.env.tugboat
+++ b/envs/.env.tugboat
@@ -10,7 +10,7 @@ REDIS_URL=redis://redis:6379
 # Where to source vets-website assets from
 NEXT_PUBLIC_ASSETS_URL=/generated/
 
-# google analytics
+# Google Analytics (These are the dev environment credentials)
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_AUTH=N9BisSDKAwJENFQtQIEvXQ
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_PREVIEW=env-423

--- a/src/lib/analytics/index.tsx
+++ b/src/lib/analytics/index.tsx
@@ -1,6 +1,6 @@
 import TagManager from 'react-gtm-module'
 
-export const GTM_ID = process.env.GOOGLE_TAG_MANAGER_ID
+export const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID
 export const TAG_MANAGER_ARGS = {
   gtmId: process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID,
   auth: process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_AUTH,

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,5 @@
 import { Html, Main, NextScript, Head } from 'next/document'
+import { GTM_ID } from '@/lib/analytics'
 import Script from 'next/script'
 
 const Document = () => {
@@ -110,14 +111,14 @@ const Document = () => {
         />
       </Head>
       <body className="merger">
-        {/* <noscript>
+        <noscript>
           <iframe
             src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
             height="0"
             width="0"
             style={{ display: 'none', visibility: 'hidden' }}
           />
-        </noscript> */}
+        </noscript>
         <Main />
         <NextScript />
       </body>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,11 +1,8 @@
 import { Html, Main, NextScript, Head } from 'next/document'
-import { GTM_ID } from '@/lib/analytics'
 import Script from 'next/script'
 
 const Document = () => {
-  const ASSETS_URL =
-    process.env.NEXT_PUBLIC_ASSETS_URL ||
-    'https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/'
+  const ASSETS_URL = process.env.NEXT_PUBLIC_ASSETS_URL || '/generated/'
 
   return (
     <Html lang="en" dir="ltr">
@@ -113,14 +110,14 @@ const Document = () => {
         />
       </Head>
       <body className="merger">
-        <noscript>
+        {/* <noscript>
           <iframe
             src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
             height="0"
             width="0"
             style={{ display: 'none', visibility: 'hidden' }}
           />
-        </noscript>
+        </noscript> */}
         <Main />
         <NextScript />
       </body>


### PR DESCRIPTION
## Description
Closes #[16501](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16501). 

## Testing done
locally, using `APP_ENV=staging` and `APP_ENV=prod` to verify that different GTM variables were loaded correctly.


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

we don't have staging or prod build pipelines yet, but locally you can change the `APP_ENV` to the desired environment.

note you will need to copy the DRUPAL_CLIENT_ID and DRUPAL_CLIENT_SECRET from your local .env. those will be stored in their respective pipeline environments.

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
- [ ] running `APP_ENV=staging yarn dev` initializes gtm with staging env vars
- [ ] running `APP_ENV=prod yarn dev` initializes gtm with prod env vars
```