### PR TITLE
VACMS-8636: Adds component for rendering react-widget paragraph.

### DIFF
--- a/src/data/queries/reactWidget.ts
+++ b/src/data/queries/reactWidget.ts
@@ -6,18 +6,18 @@ export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
   entity: ParagraphReactWidget
 ) => {
   return {
-    entityId: entity?.drupal_internal__id,
-    ctaWidget: entity?.field_cta_widget,
-    widgetType: entity?.field_widget_type,
-    loadingMessage: entity?.field_loading_message,
-    timeout: entity?.field_timeout,
-    errorMessage: entity?.field_error_message.processed,
+    entityId: entity.drupal_internal__id,
+    ctaWidget: entity.field_cta_widget,
+    widgetType: entity.field_widget_type,
+    loadingMessage: entity.field_loading_message,
+    timeout: entity.field_timeout,
+    errorMessage: entity.field_error_message.processed,
     defaultLink: entity.field_default_link
       ? {
           url: entity.field_default_link.url,
           title: entity.field_default_link.title,
         }
       : null,
-    buttonFormat: entity?.field_button_format,
+    buttonFormat: entity.field_button_format,
   }
 }

--- a/src/data/queries/reactWidget.ts
+++ b/src/data/queries/reactWidget.ts
@@ -7,8 +7,8 @@ export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
 ) => {
   return {
     entityId: entity.drupal_internal__id,
-    ctaWidget: entity.field_cta_widget,
     widgetType: entity.field_widget_type,
+    ctaWidget: entity.field_cta_widget,
     loadingMessage: entity.field_loading_message,
     timeout: entity.field_timeout,
     errorMessage: entity.field_error_message.processed,

--- a/src/data/queries/reactWidget.ts
+++ b/src/data/queries/reactWidget.ts
@@ -1,0 +1,23 @@
+import { ParagraphReactWidget } from '@/types/drupal/paragraph'
+import { QueryFormatter } from 'next-drupal-query'
+import { ReactWidget } from '@/types/formatted/reactWidget'
+
+export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
+  entity: ParagraphReactWidget
+) => {
+  return {
+    entityId: entity?.drupal_internal__id,
+    ctaWidget: entity?.field_cta_widget,
+    widgetType: entity?.field_widget_type,
+    loadingMessage: entity?.field_loading_message,
+    timeout: entity?.field_timeout,
+    errorMessage: entity?.field_error_message.processed,
+    defaultLink: entity.field_default_link
+      ? {
+          url: entity.field_default_link.url,
+          title: entity.field_default_link.title,
+        }
+      : null,
+    buttonFormat: entity?.field_button_format,
+  }
+}

--- a/src/mocks/button.mock.json
+++ b/src/mocks/button.mock.json
@@ -16,6 +16,7 @@
     "field_button_label": "Change VA direct deposit information",
     "field_button_link": {
       "uri": "https://www.va.gov/change-direct-deposit/",
+      "url": "https://www.va.gov/change-direct-deposit/",
       "title": "",
       "options": []
     },
@@ -50,6 +51,7 @@
     "field_button_label": "Sign in now",
     "field_button_link": {
       "uri": "https://www.va.gov/?next=%2Fsign-in-faq%2F",
+      "url": "https://www.va.gov/?next=%2Fsign-in-faq%2F",
       "title": "",
       "options": []
     },
@@ -84,6 +86,7 @@
     "field_button_label": "Change VA direct deposit information",
     "field_button_link": {
       "uri": "entity:node/710",
+      "url": "/change-direct-deposit",
       "title": "",
       "options": []
     },

--- a/src/mocks/linkTeaser.mock.json
+++ b/src/mocks/linkTeaser.mock.json
@@ -15,6 +15,7 @@
     "revision_translation_affected": true,
     "field_link": {
       "uri": "/health-care/eligibility/",
+      "url": "/health-care/eligibility/",
       "title": "Health Care Benefits Eligibility",
       "options": []
     },
@@ -45,6 +46,7 @@
     "revision_translation_affected": true,
     "field_link": {
       "uri": "/health-care/how-to-apply/",
+      "url": "/health-care/how-to-apply/",
       "title": "How to Apply for Health Care Benefits",
       "options": []
     },
@@ -75,6 +77,7 @@
     "revision_translation_affected": true,
     "field_link": {
       "uri": "/health-care/health-needs-conditions/",
+      "url": "/health-care/health-needs-conditions/",
       "title": "Health Needs and Conditions",
       "options": []
     },

--- a/src/templates/components/reactWidget/index.test.tsx
+++ b/src/templates/components/reactWidget/index.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { ReactWidget } from './index'
+
+describe('<ReactWidget> with valid data', () => {
+  test('renders CTA <ReactWidget />', () => {
+    render(
+      <ReactWidget entityId={2} widgetType="direct-deposit" ctaWidget={true} />
+    )
+    const ctaWidget = document.querySelector('[data-widget-type="cta"]')
+    expect(ctaWidget).not.toBeNull()
+  })
+
+  test('renders (default) <ReactWidget />', () => {
+    render(<ReactWidget entityId={1} widgetType="pension-app-status" />)
+    expect(screen.queryByText(/Loading.../)).toBeInTheDocument()
+  })
+
+  test('renders button-format <ReactWidget />', () => {
+    render(
+      <ReactWidget
+        entityId={1}
+        widgetType="pension-app-status"
+        buttonFormat={true}
+        defaultLink={{
+          url: '/some/path',
+          title: 'Click Here',
+        }}
+      />
+    )
+    const ctaWidget = document.querySelector(
+      '.usa-button-primary.va-button-primary'
+    )
+    expect(ctaWidget).not.toBeNull()
+    expect(screen.queryByText(/Click Here/)).toBeInTheDocument()
+  })
+})

--- a/src/templates/components/reactWidget/index.tsx
+++ b/src/templates/components/reactWidget/index.tsx
@@ -1,0 +1,127 @@
+import { ReactWidget as FormattedReactWidget } from '@/types/formatted/reactWidget'
+
+const CtaWidget = ({ entityId, widgetType }) => {
+  return (
+    <div
+      data-template="paragraphs/react_widget"
+      data-entity-id={entityId}
+      className="cta-widget"
+      data-widget-type="cta"
+      data-app-id={widgetType}
+    ></div>
+  )
+}
+
+const LoadingIndicator = ({ loadingMessage, slowLoadingMessage }) => {
+  return (
+    <div className="loading-indicator-container">
+      <div
+        aria-label={loadingMessage}
+        aria-valuetext="Loading your application..."
+        className="loading-indicator"
+        role="progressbar"
+      ></div>
+      <span className="loading-indicator-message loading-indicator-message--normal">
+        {loadingMessage}
+      </span>
+      <span
+        className="loading-indicator-message loading-indicator-message--slow vads-u-display--none"
+        aria-hidden="true"
+      >
+        {slowLoadingMessage}
+      </span>
+    </div>
+  )
+}
+
+const StaticWidgetContent = ({ defaultLink, buttonFormat }) => {
+  return (
+    <span
+      className="static-widget-content vads-u-display--none"
+      aria-hidden="true"
+    >
+      {defaultLink && (
+        <a
+          href={defaultLink.url}
+          className={buttonFormat ? 'usa-button-primary va-button-primary' : ''}
+        >
+          {defaultLink.title}
+        </a>
+      )}
+    </span>
+  )
+}
+
+const ErrorMessage = ({ errorMessage }) => {
+  if (!errorMessage) {
+    return null
+  }
+
+  return (
+    <div
+      className="usa-alert usa-alert-error sip-application-error vads-u-display--none"
+      aria-hidden="true"
+    >
+      <div className="usa-alert-body">{errorMessage}</div>
+    </div>
+  )
+}
+
+const DefaultWidget = ({
+  entityId,
+  widgetType,
+  timeout,
+  loadingMessage,
+  slowLoadingMessage,
+  errorMessage,
+  defaultLink,
+  buttonFormat,
+}) => {
+  return (
+    <div
+      data-template="paragraphs/react_widget"
+      data-entity-id={entityId}
+      data-widget-type={widgetType}
+      data-widget-timeout={timeout}
+    >
+      <LoadingIndicator
+        loadingMessage={loadingMessage}
+        slowLoadingMessage={slowLoadingMessage}
+      />
+      <StaticWidgetContent
+        defaultLink={defaultLink}
+        buttonFormat={buttonFormat}
+      />
+      <ErrorMessage errorMessage={errorMessage} />
+    </div>
+  )
+}
+
+export const ReactWidget = ({
+  entityId,
+  ctaWidget = false,
+  widgetType,
+  loadingMessage = 'Loading...',
+  slowLoadingMessage = 'Sorry, this is taking longer than expected.',
+  timeout = 20,
+  errorMessage,
+  defaultLink,
+  buttonFormat,
+}: FormattedReactWidget) => {
+  if (ctaWidget) {
+    return <CtaWidget entityId={entityId} widgetType={widgetType} />
+  } else {
+    return (
+      <DefaultWidget
+        entityId={entityId}
+        widgetType={widgetType}
+        loadingMessage={loadingMessage}
+        slowLoadingMessage={slowLoadingMessage}
+        timeout={timeout}
+        errorMessage={errorMessage}
+        defaultLink={defaultLink}
+        buttonFormat={buttonFormat}
+      />
+    )
+  }
+}

--- a/src/templates/components/reactWidget/reactWidget.stories.ts
+++ b/src/templates/components/reactWidget/reactWidget.stories.ts
@@ -1,0 +1,25 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { ReactWidget } from './index'
+
+const meta: Meta<typeof ReactWidget> = {
+  title: 'Paragraphs/ReactWidget',
+  component: ReactWidget,
+}
+export default meta
+
+type Story = StoryObj<typeof ReactWidget>
+
+export const Default: Story = {
+  args: {
+    entityId: 0,
+    widgetType: 'pension-app-status',
+  },
+}
+
+export const CtaWidget: Story = {
+  args: {
+    entityId: 0,
+    ctaWidget: true,
+    widgetType: 'direct-deposit',
+  },
+}

--- a/src/types/drupal/field_type.d.ts
+++ b/src/types/drupal/field_type.d.ts
@@ -26,7 +26,8 @@ export interface FieldFormattedTextWithSummary extends FieldFormattedText {
 }
 
 export interface FieldLink {
-  uri: string
+  uri: string //e.g. `entity:node/2424`
+  url: string //e.g. `/outreach-and-events/events/2424`
   title: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options: any[]

--- a/src/types/formatted/reactWidget.ts
+++ b/src/types/formatted/reactWidget.ts
@@ -1,0 +1,14 @@
+export type ReactWidget = {
+  entityId: number
+  widgetType: string
+  ctaWidget?: boolean
+  loadingMessage?: string
+  slowLoadingMessage?: string
+  timeout?: number
+  errorMessage?: string
+  defaultLink?: {
+    url: string
+    title: string
+  }
+  buttonFormat?: boolean
+}


### PR DESCRIPTION
## Description
Relates to: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8636

## Testing done/QA steps
Test Locally
- [ ] Add various react-widget components inside `<Wrapper>` in `[[...slug]].tsx` and ensure they render the expected react widget.
```
    <Wrapper
      bannerData={bannerData}
      headerFooterData={headerFooterData}
      preview={preview}
      resource={resource}
    >
      <ReactWidget entityId={0} widgetType="pension-app-status" />

   .
   .
   .
```
- [ ] Navigate to any page (e.g. http://localhost:3000/minneapolis-health-care/stories/)
    - Examples:
        - [ ] `<ReactWidget entityId={0} widgetType="pension-app-status" />`
        - [ ] `<ReactWidget entityId={0} widgetType="direct-deposit" ctaWidget={true} />`
