### PR TITLE
paragraph--alert_single added, with logic for reusable and non-reusable alert types

### DIFF
--- a/src/data/queries/alert.ts
+++ b/src/data/queries/alert.ts
@@ -2,20 +2,10 @@
 import { BlockAlert } from '@/types/drupal/block'
 import { QueryFormatter } from 'next-drupal-query'
 import { Alert } from '@/types/formatted/alert'
+import { transformAlertData } from '@/lib/drupal/query'
 
 export const formatter: QueryFormatter<BlockAlert, Alert> = (
   entity: BlockAlert
 ) => {
-  return {
-    alertType:
-      entity.field_alert_type === 'information'
-        ? 'info'
-        : entity.field_alert_type,
-    id: entity.id,
-    title: entity.field_alert_title,
-    content: {
-      header: entity.field_alert_content.field_text_expander,
-      text: entity.field_alert_content.field_wysiwyg.processed,
-    },
-  }
+  return transformAlertData(entity)
 }

--- a/src/data/queries/alertSingle.ts
+++ b/src/data/queries/alertSingle.ts
@@ -8,11 +8,11 @@ import { drupalClient } from '@/lib/drupal/drupalClient'
 import { queries } from '.'
 import { ParagraphAlertSingle } from '@/types/drupal/paragraph'
 import { AlertSingle } from '@/types/formatted/alertSingle'
+import { transformAlertData } from '@/lib/drupal/query'
 
 export const params: QueryParams<null> = () => {
   return queries
     .getParams()
-    .addPageLimit(3)
     .addInclude([
       'field_alert_block_reference',
       'field_alert_block_reference.field_alert_content',
@@ -36,17 +36,6 @@ export const data: QueryData<DataOpts, AlertSingle[]> = async (
   return entities
 }
 
-const transformAlert = (alert) => ({
-  alertType:
-    alert.field_alert_type === 'information' ? 'info' : alert.field_alert_type,
-  id: alert.id,
-  title: alert.field_alert_title,
-  content: {
-    header: alert.field_alert_heading,
-    text: alert.field_alert_content?.field_wysiwyg?.processed ?? '',
-  },
-})
-
 export const formatter: QueryFormatter<
   ParagraphAlertSingle[],
   AlertSingle[]
@@ -55,10 +44,10 @@ export const formatter: QueryFormatter<
     id: entity.id,
     alertSelection: entity.field_alert_section ?? null,
     blockReference: entity.field_alert_block_reference
-      ? transformAlert(entity.field_alert_block_reference)
+      ? transformAlertData(entity.field_alert_block_reference)
       : null,
     nonReusableRef: entity.field_alert_non_reusable_ref
-      ? transformAlert(entity.field_alert_non_reusable_ref)
+      ? transformAlertData(entity.field_alert_non_reusable_ref)
       : null,
   }))
 }

--- a/src/data/queries/alertSingle.ts
+++ b/src/data/queries/alertSingle.ts
@@ -1,0 +1,64 @@
+import {
+  QueryData,
+  QueryFormatter,
+  QueryParams,
+  QueryOpts,
+} from 'next-drupal-query'
+import { drupalClient } from '@/lib/drupal/drupalClient'
+import { queries } from '.'
+import { ParagraphAlertSingle } from '@/types/drupal/paragraph'
+import { AlertSingle } from '@/types/formatted/alertSingle'
+
+export const params: QueryParams<null> = () => {
+  return queries
+    .getParams()
+    .addPageLimit(3)
+    .addInclude([
+      'field_alert_block_reference',
+      'field_alert_block_reference.field_alert_content',
+      'field_alert_non_reusable_ref',
+      'field_alert_non_reusable_ref.field_va_paragraphs',
+    ])
+}
+
+type DataOpts = QueryOpts<null>
+
+export const data: QueryData<DataOpts, AlertSingle[]> = async (
+  opts
+): Promise<AlertSingle[]> => {
+  const entities = await drupalClient.getResourceCollection<AlertSingle[]>(
+    'paragraph--alert_single',
+    {
+      params: params().getQueryObject(),
+    }
+  )
+
+  return entities
+}
+
+const transformAlert = (alert) => ({
+  alertType:
+    alert.field_alert_type === 'information' ? 'info' : alert.field_alert_type,
+  id: alert.id,
+  title: alert.field_alert_title,
+  content: {
+    header: alert.field_alert_heading,
+    text: alert.field_alert_content?.field_wysiwyg?.processed ?? '',
+  },
+})
+
+export const formatter: QueryFormatter<
+  ParagraphAlertSingle[],
+  AlertSingle[]
+> = (entities: ParagraphAlertSingle[]) => {
+  return entities.map((entity) => ({
+    id: entity.id,
+    alertSelection: entity.field_alert_section ?? null,
+    blockReference: entity.field_alert_block_reference
+      ? transformAlert(entity.field_alert_block_reference)
+      : null,
+    nonReusableRef: entity.field_alert_non_reusable_ref
+      ? transformAlert(entity.field_alert_non_reusable_ref)
+      : null,
+  }))
+}

--- a/src/data/queries/index.ts
+++ b/src/data/queries/index.ts
@@ -11,6 +11,7 @@ import * as PersonProfile from './personProfile'
 import * as Button from './button'
 import * as AudienceTopics from './audienceTopics'
 import * as Alert from './alert'
+import * as AlertSingle from './alertSingle'
 import * as EmailContact from './emailContact'
 import * as BenefitsHub from './benefitsHub'
 import * as Wysiwyg from './wysiwyg'
@@ -37,6 +38,7 @@ export const QUERIES_MAP = {
   'paragraph--link_teaser': LinkTeaser,
   'paragraph--rich_text_char_limit_1000': Wysiwyg,
   'paragraph--wysiwyg': Wysiwyg,
+  'paragragh--alert_single': AlertSingle,
   'media--image': MediaImage,
   'block--alert': Alert,
   'block_content--promo': PromoBlock,

--- a/src/lib/drupal/query.ts
+++ b/src/lib/drupal/query.ts
@@ -140,3 +140,17 @@ export const entityBaseFields = (entity: NodeTypes): PublishedEntity => {
     lastUpdated: entity.field_last_saved_by_an_editor || entity.created,
   }
 }
+
+// Helper function to return consistent shape of alerts
+export const transformAlertData = (alert) => ({
+  alertType:
+    alert.field_alert_type === 'information' ? 'info' : alert.field_alert_type,
+  id: alert.id,
+  title: alert.field_alert_title,
+  content: {
+    header:
+      alert.field_alert_content.field_text_expander ??
+      alert.field_alert_heading,
+    text: alert.field_alert_content?.field_wysiwyg?.processed ?? '',
+  },
+})

--- a/src/mocks/alertSingle.mock.json
+++ b/src/mocks/alertSingle.mock.json
@@ -1,0 +1,215 @@
+{
+  "type": "paragraph--alert_single",
+  "id": "0e71c5cd-a4e2-4dec-9b1e-0ef1c5666f65",
+  "drupal_internal__id": 13070,
+  "drupal_internal__revision_id": 145553,
+  "langcode": "en",
+  "status": true,
+  "created": "2020-10-01T15:35:24+00:00",
+  "parent_id": "12696",
+  "parent_type": "paragraph",
+  "parent_field_name": "field_alert",
+  "behavior_settings": [],
+  "default_langcode": true,
+  "revision_translation_affected": null,
+  "content_translation_source": "und",
+  "content_translation_outdated": false,
+  "content_translation_changed": null,
+  "field_alert_selection": "R",
+  "field_markup": null,
+  "links": {
+    "self": {
+      "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/alert_single/0e71c5cd-a4e2-4dec-9b1e-0ef1c5666f65?resourceVersion=id%3A145553"
+    }
+  },
+  "paragraph_type": {
+    "type": "paragraphs_type--paragraphs_type",
+    "id": "f2e64319-f14b-4bc1-8674-4661358e4242",
+    "resourceIdObjMeta": {
+      "drupal_internal__target_id": "alert_single"
+    }
+  },
+  "field_alert_non_reusable_ref": {
+    "type": "paragraph--non_reusable_alert",
+    "id": "4eff76c1-5e3e-410b-a56a-64b572f98756",
+    "drupal_internal__id": 13072,
+    "drupal_internal__revision_id": 145559,
+    "langcode": "en",
+    "status": true,
+    "created": "2020-10-01T17:08:59+00:00",
+    "parent_id": "13073",
+    "parent_type": "paragraph",
+    "parent_field_name": "field_alert_non_reusable_ref",
+    "behavior_settings": [],
+    "default_langcode": true,
+    "revision_translation_affected": null,
+    "content_translation_source": "und",
+    "content_translation_outdated": false,
+    "content_translation_changed": null,
+    "field_alert_heading": "Sample non-reusable alert",
+    "field_alert_type": "information",
+    "links": {
+      "self": {
+        "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/non_reusable_alert/4eff76c1-5e3e-410b-a56a-64b572f98756?resourceVersion=id%3A145559"
+      }
+    },
+    "resourceIdObjMeta": {
+      "target_revision_id": 145559,
+      "drupal_internal__target_id": 13072
+    },
+    "paragraph_type": {
+      "type": "paragraphs_type--paragraphs_type",
+      "id": "3d633fc0-97d6-4087-b709-edfa2d1e6a1e",
+      "resourceIdObjMeta": {
+        "drupal_internal__target_id": "non_reusable_alert"
+      }
+    },
+    "field_va_paragraphs": [
+      {
+        "type": "paragraph--wysiwyg",
+        "id": "2fc092f1-969a-4136-9039-4fc50a9f93c4",
+        "drupal_internal__id": 13071,
+        "drupal_internal__revision_id": 141493,
+        "langcode": "en",
+        "status": true,
+        "created": "2020-10-01T17:09:17+00:00",
+        "parent_id": "13072",
+        "parent_type": "paragraph",
+        "parent_field_name": "field_va_paragraphs",
+        "behavior_settings": [],
+        "default_langcode": true,
+        "revision_translation_affected": true,
+        "content_translation_source": "und",
+        "content_translation_outdated": false,
+        "content_translation_changed": null,
+        "field_wysiwyg": {
+          "value": "sample text"
+        },
+        "links": {
+          "self": {
+            "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/wysiwyg/2fc092f1-969a-4136-9039-4fc50a9f93c4?resourceVersion=id%3A141493"
+          }
+        },
+        "resourceIdObjMeta": {
+          "target_revision_id": 141493,
+          "drupal_internal__target_id": 13071
+        },
+        "paragraph_type": {
+          "type": "paragraphs_type--paragraphs_type",
+          "id": "885e4b61-cfd2-44b9-94ae-f068ba2b48b6",
+          "resourceIdObjMeta": {
+            "drupal_internal__target_id": "wysiwyg"
+          }
+        },
+        "relationshipNames": ["paragraph_type"]
+      }
+    ],
+    "relationshipNames": ["paragraph_type", "field_va_paragraphs"]
+  },
+  "field_alert_block_reference": {
+    "type": "block_content--alert",
+    "id": "ba9dd3f4-4260-4e21-bbf9-a5cf0db49fc1",
+    "drupal_internal__id": 45,
+    "drupal_internal__revision_id": 994,
+    "langcode": "en",
+    "revision_created": "2022-09-06T17:30:19+00:00",
+    "revision_log": "Archiving as no longer needed per Sitewide Content convo",
+    "status": false,
+    "info": "COVID-19 alert: Claims and other services",
+    "changed": "2022-09-06T17:30:19+00:00",
+    "reusable": true,
+    "default_langcode": true,
+    "revision_translation_affected": true,
+    "moderation_state": "archived",
+    "metatag": [
+      {
+        "tag": "meta",
+        "attributes": {
+          "name": "title",
+          "content": "| Veterans Affairs"
+        }
+      }
+    ],
+    "field_alert_title": "You can still file a claim and apply for benefits during the coronavirus pandemic",
+    "field_alert_type": "information",
+    "field_reusability": "reusable",
+    "links": {
+      "self": {
+        "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/block_content/alert/ba9dd3f4-4260-4e21-bbf9-a5cf0db49fc1?resourceVersion=id%3A994"
+      }
+    },
+    "resourceIdObjMeta": {
+      "drupal_internal__target_id": 45
+    },
+    "block_content_type": {
+      "type": "block_content_type--block_content_type",
+      "id": "278a3f4b-8d89-4768-ab03-869b8cc98613",
+      "resourceIdObjMeta": {
+        "drupal_internal__target_id": "alert"
+      }
+    },
+    "revision_user": {
+      "type": "user--user",
+      "id": "38daa8d4-3d05-48a3-bb95-a9c75988e382",
+      "resourceIdObjMeta": {
+        "drupal_internal__target_id": 295
+      }
+    },
+    "field_alert_content": {
+      "type": "paragraph--wysiwyg",
+      "id": "65fda9e9-1bbb-45f2-bc39-d3c659ba30d1",
+      "drupal_internal__id": 10536,
+      "drupal_internal__revision_id": 729754,
+      "langcode": "en",
+      "status": true,
+      "created": "2020-05-30T16:44:57+00:00",
+      "parent_id": "45",
+      "parent_type": "block_content",
+      "parent_field_name": "field_alert_content",
+      "behavior_settings": [],
+      "default_langcode": true,
+      "revision_translation_affected": true,
+      "content_translation_source": "und",
+      "content_translation_outdated": false,
+      "content_translation_changed": null,
+      "field_wysiwyg": {
+        "value": "sample text"
+      },
+      "links": {
+        "self": {
+          "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/wysiwyg/65fda9e9-1bbb-45f2-bc39-d3c659ba30d1?resourceVersion=id%3A729754"
+        }
+      },
+      "resourceIdObjMeta": {
+        "target_revision_id": 729754,
+        "drupal_internal__target_id": 10536
+      },
+      "paragraph_type": {
+        "type": "paragraphs_type--paragraphs_type",
+        "id": "885e4b61-cfd2-44b9-94ae-f068ba2b48b6",
+        "resourceIdObjMeta": {
+          "drupal_internal__target_id": "wysiwyg"
+        }
+      },
+      "relationshipNames": ["paragraph_type"]
+    },
+    "field_owner": {
+      "type": "taxonomy_term--administration",
+      "id": "40ef8d64-fa92-41b6-88c0-4d85dc24e191",
+      "resourceIdObjMeta": {
+        "drupal_internal__target_id": 194
+      }
+    },
+    "relationshipNames": [
+      "block_content_type",
+      "revision_user",
+      "field_alert_content",
+      "field_owner"
+    ]
+  },
+  "relationshipNames": [
+    "paragraph_type",
+    "field_alert_non_reusable_ref",
+    "field_alert_block_reference"
+  ]
+}

--- a/src/templates/components/alertSingle/alertSingle.stories.ts
+++ b/src/templates/components/alertSingle/alertSingle.stories.ts
@@ -1,0 +1,47 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { AlertSingle } from './'
+import { Alert } from '@/types/formatted/alert'
+
+const meta: Meta<typeof AlertSingle> = {
+  title: 'Paragraphs/AlertSingle',
+  component: AlertSingle,
+}
+export default meta
+
+type Story = StoryObj<typeof AlertSingle>
+
+const blockReference: Alert = {
+  id: '6ecdbf96-2a9e-4beb-9d95-d41fced1473b',
+  alertType: 'information',
+  title: 'Block Reference Title',
+  content: {
+    header: 'Block Reference Header',
+    text: '<p>This is the block reference content.</p>',
+  },
+}
+
+const nonReusableRef: Alert = {
+  id: '7fced1473b-2a9e-4beb-9d95-6ecdbf96',
+  alertType: 'warning',
+  title: 'Non-Reusable Reference Title',
+  content: {
+    header: 'Non-Reusable Reference Header',
+    text: '<p>This is the non-reusable reference content.</p>',
+  },
+}
+
+export const ReusableAlert: Story = {
+  args: {
+    alertSelection: 'R',
+    blockReference: blockReference,
+    nonReusableRef: nonReusableRef,
+  },
+}
+
+export const NonReusableAlert: Story = {
+  args: {
+    alertSelection: 'NR',
+    blockReference: blockReference,
+    nonReusableRef: nonReusableRef,
+  },
+}

--- a/src/templates/components/alertSingle/index.test.tsx
+++ b/src/templates/components/alertSingle/index.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { AlertSingle } from './'
+
+describe('AlertSingle Component', () => {
+  const blockReference = {
+    id: 'block-ref-id',
+    alertType: 'info',
+    title: 'Block Reference Title',
+    content: {
+      header: 'Block Reference Header',
+      text: 'Block reference content text.',
+    },
+  }
+
+  const nonReusableRef = {
+    id: 'non-reusable-ref-id',
+    alertType: 'warning',
+    title: 'Non-Reusable Reference Title',
+    content: {
+      header: 'Non-Reusable Reference Header',
+      text: 'Non-reusable reference content text.',
+    },
+  }
+
+  it('renders nothing if alertSelection is not provided', () => {
+    render(
+      <AlertSingle
+        alertSelection={null}
+        blockReference={blockReference}
+        nonReusableRef={nonReusableRef}
+      />
+    )
+    expect(screen.queryByText(/Block Reference Title/)).toBeNull()
+    expect(screen.queryByText(/Non-Reusable Reference Title/)).toBeNull()
+  })
+
+  it('renders blockReference content for alertSelection "R"', () => {
+    render(
+      <AlertSingle
+        alertSelection="R"
+        blockReference={blockReference}
+        nonReusableRef={nonReusableRef}
+      />
+    )
+    expect(screen.getByText(/Block Reference Title/)).toBeInTheDocument()
+  })
+
+  it('renders nonReusableRef content for alertSelection "NR"', () => {
+    render(
+      <AlertSingle
+        alertSelection="NR"
+        blockReference={blockReference}
+        nonReusableRef={nonReusableRef}
+      />
+    )
+    expect(screen.getByText(/Non-Reusable Reference Title/)).toBeInTheDocument()
+  })
+})

--- a/src/templates/components/alertSingle/index.tsx
+++ b/src/templates/components/alertSingle/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { AlertBlock } from '../alert'
+import { Alert } from '@/types/formatted/alert'
+
+type AlertSingleProps = {
+  alertSelection: string
+  blockReference: Alert
+  nonReusableRef: Alert
+}
+
+export function AlertSingle({
+  alertSelection,
+  blockReference,
+  nonReusableRef,
+}: AlertSingleProps) {
+  if (!alertSelection) return null
+
+  const alertContent = alertSelection === 'R' ? blockReference : nonReusableRef
+
+  if (!alertContent) return null
+
+  const blockContent: Alert = {
+    id: alertContent.id,
+    alertType: alertContent.alertType,
+    title: alertContent.title,
+    content: {
+      header: alertContent.content.header,
+      text: alertContent.content.text,
+    },
+  }
+
+  return <AlertBlock {...blockContent} />
+}
+
+export default AlertSingle

--- a/src/types/drupal/paragraph.ts
+++ b/src/types/drupal/paragraph.ts
@@ -70,7 +70,7 @@ export interface ParagraphAlert extends DrupalParagraph {
 }
 
 export interface ParagraphAlertSingle extends DrupalParagraph {
-  field_alert_section: string
+  field_alert_selection: string
   field_alert_block_reference: BlockAlert
   field_alert_non_reusable_ref: ParagraphNonReusableAlert
 }

--- a/src/types/formatted/alertSingle.ts
+++ b/src/types/formatted/alertSingle.ts
@@ -1,0 +1,7 @@
+import { Alert } from '@/types/formatted/alert'
+
+export type AlertSingle = {
+  alertSelection: string
+  blockReference: Alert
+  nonReusableRef: Alert
+}


### PR DESCRIPTION
## Description
Relates to:
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8608
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8608

Brings in queries and component for the alert_single type.  Also addresses the logic required to render Non reusable alerts in the same component.

Changes:
Adds alertSingle react component
Adds alertSingle query
Updates types and property names where necessary
Adds jest test for alert component
Adds storybook for AlertSingle

## Testing done
Local testing

## Screenshots
<img width="1048" alt="Screen Shot 2024-01-25 at 10 43 22 AM" src="https://github.com/department-of-veterans-affairs/next-build/assets/61624970/e6e8a275-f329-4612-8000-173574535f50">


## QA steps
Verify that component renders properly with storybook
Further verification when resources and support page is added and this component is actually used


## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
