### PR TITLE
Fix AudienceTopics styles and add types

### DIFF
--- a/src/data/queries/audienceTopics.ts
+++ b/src/data/queries/audienceTopics.ts
@@ -3,14 +3,21 @@ import { ParagraphAudienceTopics } from '@/types/drupal/paragraph'
 import { QueryFormatter } from 'next-drupal-query'
 import { AudienceTopic } from '@/types/formatted/audienceTopics'
 
-const getTagsList = (fieldTags) => {
-  if (!fieldTags) return null
+interface Tag {
+  id: string
+  href: string | undefined
+  name: string
+  categoryLabel: string
+}
+
+const getTagsList = (entity: ParagraphAudienceTopics): Tag[] | null => {
+  if (!entity) return null
 
   const {
     field_topics: fieldTopics = [],
     field_audience_beneficiares: fieldAudienceBeneficiares,
     fieldNonBeneficiares: fieldNonBeneficiares,
-  } = fieldTags
+  } = entity
 
   const topics = fieldTopics.map((topic) => ({
     id: topic.id,

--- a/src/templates/components/audienceTopics/index.tsx
+++ b/src/templates/components/audienceTopics/index.tsx
@@ -6,10 +6,11 @@ export function AudienceTopics({ tags }: FormattedAudienceTopics) {
   if (isEmpty(tags)) return null
   const tagsList = tags.map(({ id, href, name }) => (
     <div key={id}>
-      <div className="vads-u-margin-right--1 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--0">
+      <div className="vads-u-margin-right--1 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--1p5">
         <Link
           href={`${href}/${encodeURI(name)}`}
-          className="vads-u-margin-bottom--1p5 usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1p5 vads-u-text-decoration--none vads-u-color--base"
+          className="usa-button-secondary vads-u-font-size--sm vads-u-border--1px vads-u-border-color--primary vads-u-padding--0p25 vads-u-padding-x--0p5 vads-u-margin-left--1p5 vads-u-text-decoration--none vads-u-color--base"
+          style={{ borderRadius: '3px', lineHeight: '1.3' }}
         >
           {name}
         </Link>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16617

Tags for resource and support taxonomies were largely already done.  This PR fixes up some styling and adds type safety to the getTags function.

Changes
- Styling for tag borders
- Styling for spacing
- Types in query function

## Testing done
Local

## Screenshots
<img width="1022" alt="image" src="https://github.com/department-of-veterans-affairs/next-build/assets/61624970/becf1868-3e96-420e-a4f6-5b2a1a8d050f">


## QA steps
Verify tags render as expected in storybook


## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
