### PR TITLE
Use `class` instead of `className` in custom web component

### DIFF
--- a/src/templates/components/accordion/index.tsx
+++ b/src/templates/components/accordion/index.tsx
@@ -16,7 +16,7 @@ export function Accordion({ id, bordered, items }: AccordionProps) {
           <va-accordion-item
             key={`${id}-${stringToId(item.header)}`}
             header={item.header}
-            className="va-accordion-item"
+            class="va-accordion-item"
             id={`${id}-${stringToId(item.header)}`}
           >
             {item.html && (

--- a/src/templates/components/collapsiblePanel/index.tsx
+++ b/src/templates/components/collapsiblePanel/index.tsx
@@ -26,7 +26,7 @@ export const CollapsiblePanelItem = ({
   return (
     <va-accordion-item
       key={entityId}
-      className="va-accordion-item"
+      class="va-accordion-item"
       id={`${slugifyTitle(title, 60)}-${id}`}
       {...accordionItemAttrs}
     >

--- a/src/templates/components/lovellSwitcher/index.tsx
+++ b/src/templates/components/lovellSwitcher/index.tsx
@@ -20,7 +20,7 @@ export function LovellSwitcher({
   return (
     <va-alert
       status="warning"
-      className="vads-u-margin-bottom--2"
+      class="vads-u-margin-bottom--2"
       id="va-info-alert"
     >
       <h2 slot="headline">


### PR DESCRIPTION
## Description
TIL that the use of `className` in place of `class` in JSX does not apply to custom web components. So, accordingly, this PR updates incorrect usage throughout the repo.