### PR TITLE
Adds utility to create conditional JSX args

### DIFF
--- a/src/lib/utils/helpers.test.ts
+++ b/src/lib/utils/helpers.test.ts
@@ -1,0 +1,51 @@
+import { conditionalAttr } from './helpers'
+
+describe('conditionalAttr', () => {
+  describe('boolean condition', () => {
+    test('should include attr when condition is true', () => {
+      const result = conditionalAttr(true, 'test-attr', 'test-value')
+
+      expect(result).toStrictEqual({
+        'test-attr': 'test-value',
+      })
+    })
+
+    test('should include blank attr when condition is true and value is not passed', () => {
+      const result = conditionalAttr(true, 'test-attr')
+
+      expect(result).toStrictEqual({
+        'test-attr': '',
+      })
+    })
+
+    test('should not include attr when condition is false', () => {
+      const result = conditionalAttr(false, 'test-attr', 'test-value')
+
+      expect(result).toStrictEqual({})
+    })
+  })
+
+  describe('function condition', () => {
+    test('should include attr when function returns true', () => {
+      const result = conditionalAttr(() => true, 'test-attr', 'test-value')
+
+      expect(result).toStrictEqual({
+        'test-attr': 'test-value',
+      })
+    })
+
+    test('should include blank attr when function returns true and value is not passed', () => {
+      const result = conditionalAttr(() => true, 'test-attr')
+
+      expect(result).toStrictEqual({
+        'test-attr': '',
+      })
+    })
+
+    test('should not include attr when function returns false', () => {
+      const result = conditionalAttr(() => false, 'test-attr', 'test-value')
+
+      expect(result).toStrictEqual({})
+    })
+  })
+})

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -97,3 +97,29 @@ export const escape = (input) => {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
 }
+
+/**
+ * Returns an object that conditionally includes attrKey
+ * for passing to a JSX element
+ *
+ * E.g.
+ * <input {...conditionalAttr(!editable, 'readonly')} />
+ *   If (editable): <input />
+ *   Else: <input readonly />
+ *
+ * <my-custom-element {...conditionalAttr(includeCustomProp, 'custom-prop', 'custom-value')} />
+ *   If (includeCustomProp): <my-custom-element custom-prop="custom-value" />
+ *   Else: <my-custom-element />
+ */
+export const conditionalAttr = (
+  condition: boolean | (() => boolean),
+  attrKey,
+  attrValue: string | boolean = ''
+) => {
+  const includeAttr = typeof condition === 'function' ? condition() : condition
+  return includeAttr
+    ? {
+        [attrKey]: attrValue,
+      }
+    : {}
+}

--- a/src/templates/components/collapsiblePanel/collapsiblePanel.stories.ts
+++ b/src/templates/components/collapsiblePanel/collapsiblePanel.stories.ts
@@ -55,11 +55,11 @@ export const Bordered: Story = {
   },
 }
 
-export const MultiSelect: Story = {
+export const OpenSingle: Story = {
   args: {
     entityId: 3,
     paragraphs,
-    multiSelect: true,
+    multiSelect: false,
   },
 }
 

--- a/src/templates/components/collapsiblePanel/index.tsx
+++ b/src/templates/components/collapsiblePanel/index.tsx
@@ -8,6 +8,7 @@ import { Paragraph } from '@/templates/components/paragraph'
 import { escape } from '@/lib/utils/helpers'
 import { slugifyTitle } from '@/lib/utils/slug'
 import { ParagraphComponent } from '@/types/formatted/paragraph'
+import { conditionalAttr } from '@/lib/utils/helpers'
 
 export const CollapsiblePanelItem = ({
   id,
@@ -18,17 +19,12 @@ export const CollapsiblePanelItem = ({
   expanded = false,
   paragraphs = [],
 }: ParagraphComponent<FormattedCollapsiblePanelItem>) => {
-  const accordionItemAttrs = {}
-  if (expanded) {
-    accordionItemAttrs['open'] = 'true'
-  }
-
   return (
     <va-accordion-item
       key={entityId}
       class="va-accordion-item"
       id={`${slugifyTitle(title, 60)}-${id}`}
-      {...accordionItemAttrs}
+      {...conditionalAttr(expanded, 'open', true)}
     >
       <HeadingElement headingLevel={headingLevel} slot="headline">
         {title}
@@ -63,14 +59,6 @@ export const CollapsiblePanel = ({
   multiSelect = true,
   headingLevel = 'h4',
 }: ParagraphComponent<FormattedCollapsiblePanel>) => {
-  const accordionAttrs = {}
-  if (bordered) {
-    accordionAttrs['bordered'] = ''
-  }
-  if (!multiSelect) {
-    accordionAttrs['open-single'] = ''
-  }
-
   return (
     <div
       id={id}
@@ -80,7 +68,10 @@ export const CollapsiblePanel = ({
       data-entity-id={entityId}
       data-multiselectable={multiSelect}
     >
-      <va-accordion {...accordionAttrs}>
+      <va-accordion
+        {...conditionalAttr(bordered, 'bordered')}
+        {...conditionalAttr(!multiSelect, 'open-single')}
+      >
         {paragraphs.map((collapsiblePanelItem, index) => {
           // These paragraphs will always be `paragraph--collapsible_panel_item
           return (


### PR DESCRIPTION
## Description
Some web components document unary props (e.g. `<va-accordion bordered>`). Adding these props without values requires some conditional code that is kind of uglier than we'd like sprinkled throughout our components. This PR creates an abstraction for defining the conditional attributes in the JSX element in a relatively clean and repeatable fashion.

```
<va-accordion
    {...conditionalAttr(bordered, 'bordered')}
    {...conditionalAttr(!multiSelect, 'open-single')}
>
```

Mostly unrelated, this PR also updates one story in Storybook to bring it in line with the default props. `multiSelect` defaults to true on `<CollapsiblePanel>` (I initially defaulted it to false), so this updates the story to align with that.

## Testing done
- Unit tests added. 
- Manual testing on `<CollapsiblePanel />` in Storybook
