### PR TITLE
VACMS-17340: Updates ExpandableText paragraph template

### DIFF
--- a/src/templates/components/expandableText/expandableText.stories.mdx
+++ b/src/templates/components/expandableText/expandableText.stories.mdx
@@ -4,4 +4,4 @@ import { Meta } from '@storybook/addon-docs'
 
 ## ExpandableText
 
-The ExpandableText component wraps the Accordion web component located [here](https://design.va.gov/storybook/?path=/docs/components-va-accordion--default).
+The ExpandableText component wraps the VaAlertExpandable web component located [here](https://design.va.gov/storybook/?path=/docs/components-va-alert-expandable--default).

--- a/src/templates/components/expandableText/index.test.tsx
+++ b/src/templates/components/expandableText/index.test.tsx
@@ -9,49 +9,19 @@ const expandableTextProps = {
 
 describe('ExpandableText with valid data', () => {
   test('renders ExpandableText component', () => {
-    render(
-      <ExpandableText key={expandableTextProps.id} {...expandableTextProps} />
-    )
+    render(<ExpandableText {...expandableTextProps} />)
 
-    const vaAccordionItemEl = document.querySelector('va-accordion-item')
-    expect(vaAccordionItemEl).toHaveAttribute('header', 'Show more')
-    expect(screen.queryByText(/If you need support.../)).toBeInTheDocument()
+    const vaAlertExpandable = document.querySelector('va-alert-expandable')
+    expect(vaAlertExpandable).toHaveAttribute('trigger', 'Show more')
   })
 })
 
 describe('ExpandableText with invalid data', () => {
   test('does not render ExpandableText component when header is not present', () => {
     expandableTextProps.header = null
+    render(<ExpandableText {...expandableTextProps} />)
 
-    render(
-      <ExpandableText key={expandableTextProps.id} {...expandableTextProps} />
-    )
-
-    const vaAccordionItemEl = document.querySelector('va-accordion-item')
-    expect(vaAccordionItemEl).toBeFalsy()
-  })
-
-  test('does not render the text info when text is not present', () => {
-    expandableTextProps.header = 'Show more'
-    expandableTextProps.text = null
-    render(
-      <ExpandableText key={expandableTextProps.id} {...expandableTextProps} />
-    )
-
-    const vaAccordionItemEl = document.querySelector('va-accordion-item')
-    expect(vaAccordionItemEl).toHaveAttribute('header', 'Show more')
-    expect(screen.queryByText(/If you need support.../)).not.toBeInTheDocument()
-  })
-
-  test('does not render the text info when processed is not present', () => {
-    expandableTextProps.header = 'Show more'
-    expandableTextProps.text = null
-    render(
-      <ExpandableText key={expandableTextProps.id} {...expandableTextProps} />
-    )
-
-    const vaAccordionItemEl = document.querySelector('va-accordion-item')
-    expect(vaAccordionItemEl).toHaveAttribute('header', 'Show more')
-    expect(screen.queryByText(/If you need support.../)).not.toBeInTheDocument()
+    const vaAlertExpandable = document.querySelector('va-alert-expandable')
+    expect(vaAlertExpandable).toBeFalsy()
   })
 })

--- a/src/templates/components/expandableText/index.tsx
+++ b/src/templates/components/expandableText/index.tsx
@@ -1,7 +1,4 @@
-import {
-  VaAccordion,
-  VaAccordionItem,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings'
+import { VaAlertExpandable } from '@department-of-veterans-affairs/component-library/dist/react-bindings'
 import { isEmpty } from 'lodash'
 import { ExpandableText as FormattedExpandableText } from '@/types/formatted/expandableText'
 import { ParagraphComponent } from '@/types/formatted/paragraph'
@@ -14,14 +11,14 @@ export function ExpandableText({
   if (isEmpty(header)) return
 
   return (
-    <VaAccordion open-single>
-      <VaAccordionItem
-        id={id}
-        header={header}
-        dangerouslySetInnerHTML={{
-          __html: text,
-        }}
-      ></VaAccordionItem>
-    </VaAccordion>
+    <VaAlertExpandable id={id} trigger={header}>
+      {text && (
+        <div
+          dangerouslySetInnerHTML={{
+            __html: text,
+          }}
+        />
+      )}
+    </VaAlertExpandable>
   )
 }


### PR DESCRIPTION
## Description
Updates the ExpandableText paragraph template to use va-alert-expandable web component.

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17340

## Testing done/QA Steps
Locally: 
- [ ] `yarn dev --NEXT_PUBLIC_DRUPAL_BASE_URL https://main-sj2uonhc6ye5eli6tsosbvr8khdsscvf.demo.cms.va.gov`
- [ ] http://localhost:3000/resources/covid-19-testing-at-va/
- [ ] See alert block and ensure expandable text is rendering correctly

## Screenshots
![image](https://github.com/department-of-veterans-affairs/next-build/assets/6863534/43d41ccf-d23b-4f3f-a7f4-e571932ee06e)
