### PR TITLE
bump timeout

### DIFF
--- a/.github/workflows/broken-links-check.yml
+++ b/.github/workflows/broken-links-check.yml
@@ -19,7 +19,7 @@ jobs:
   broken-links-check:
     name: Broken link check
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 64


### PR DESCRIPTION
## Description
<img width="988" alt="Screenshot 2024-03-04 at 8 40 12 AM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/b1f25096-4702-4bd1-8871-9a26bb0da542">

all of those errors are due to timeout limit reached, even if the batch run in question appears to finish faster than reported. I think it's incorrectly timing between all the split batches, but not 100% sure.

![Screenshot 2024-03-04 at 8 41 28 AM](https://github.com/department-of-veterans-affairs/next-build/assets/11279744/18fa41d0-ffa1-4af5-ae27-2370b276005a)
![Screenshot 2024-03-04 at 8 41 35 AM](https://github.com/department-of-veterans-affairs/next-build/assets/11279744/77b5cf02-c295-413a-bb99-ddfd403ff232)


e.g. this one fails, the failing step is reported at 40 minutes, but it actually shows just over 5 minutes in the logs:
https://github.com/department-of-veterans-affairs/next-build/actions/runs/8137087154/job/22234693639
```
 All batches complete in 05:17!
Of an initial 408 pages, scanned total of 18673 links on 408 pages!
Detected 44 broken links.
```

## Testing done


## Screenshots


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
