### PR TITLE
VACMS-17399: Adds more granular definition of listing pages

### DIFF
--- a/src/lib/drupal/listingPages.test.ts
+++ b/src/lib/drupal/listingPages.test.ts
@@ -1,6 +1,7 @@
 import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 import {
   isListingResourceType,
+  isSinglePageListingResourceType,
   getListingPageStaticPropsContext,
 } from './listingPages'
 import { slugToPath } from '@/lib/utils/slug'
@@ -22,6 +23,22 @@ describe('isListingResourceType', () => {
   test('should return false when not listing resource type', () => {
     const storyResult = isListingResourceType(RESOURCE_TYPES.STORY)
     expect(storyResult).toBe(false)
+  })
+})
+
+describe('isSinglePageListingResourceType', () => {
+  test('should return true when single-page listing resource type', () => {
+    const eventListingResult = isSinglePageListingResourceType(
+      RESOURCE_TYPES.EVENT_LISTING
+    )
+    expect(eventListingResult).toBe(true)
+  })
+
+  test('should return false when not single-page listing resource type', () => {
+    const storyListingResult = isListingResourceType(
+      RESOURCE_TYPES.STORY_LISTING
+    )
+    expect(storyListingResult).toBe(false)
   })
 })
 

--- a/src/lib/drupal/listingPages.ts
+++ b/src/lib/drupal/listingPages.ts
@@ -15,7 +15,14 @@ const LISTING_RESOURCE_TYPES = [
   RESOURCE_TYPES.EVENT_LISTING,
 ] as const
 
+const SINGLE_PAGE_LISTING_RESOURCE_TYPES = [
+  RESOURCE_TYPES.EVENT_LISTING,
+] as const
+
 export type ListingResourceType = (typeof LISTING_RESOURCE_TYPES)[number]
+
+export type SinglePageListingResourceType =
+  (typeof SINGLE_PAGE_LISTING_RESOURCE_TYPES)[number]
 
 export type StaticPathResourceTypeWithPaging = StaticPathResource & {
   paging: {
@@ -62,6 +69,14 @@ export const LISTING_RESOURCE_TYPE_URL_SEGMENTS: Readonly<{
 
 export function isListingResourceType(resourceType: ResourceType): boolean {
   return (LISTING_RESOURCE_TYPES as readonly string[]).includes(resourceType)
+}
+
+export function isSinglePageListingResourceType(
+  resourceType: ResourceType
+): boolean {
+  return (SINGLE_PAGE_LISTING_RESOURCE_TYPES as readonly string[]).includes(
+    resourceType
+  )
 }
 
 export async function getListingPageCounts(

--- a/src/lib/drupal/listingPages.ts
+++ b/src/lib/drupal/listingPages.ts
@@ -15,6 +15,11 @@ const LISTING_RESOURCE_TYPES = [
   RESOURCE_TYPES.EVENT_LISTING,
 ] as const
 
+// Some listing pages do not need all "paged" pages generated
+// statically because the paging mechanism is done client side.
+// These listing pages are "single page". They are still
+// listing pages in some regards, but we need to be able to
+// skip subsequent-page generation for these resources.
 const SINGLE_PAGE_LISTING_RESOURCE_TYPES = [
   RESOURCE_TYPES.EVENT_LISTING,
 ] as const

--- a/src/lib/drupal/staticPaths.ts
+++ b/src/lib/drupal/staticPaths.ts
@@ -3,6 +3,7 @@ import {
   ListingResourceType,
   getAllPagedListingStaticPathResources,
   isListingResourceType,
+  isSinglePageListingResourceType,
 } from '@/lib/drupal/listingPages'
 import { ResourceType } from '@/lib/constants/resourceTypes'
 import { queries } from '@/data/queries'
@@ -33,10 +34,14 @@ async function modifyStaticPathResourcesByResourceType(
 
   if (isListingResourceType(resourceType)) {
     const lovellFederalRemoved = removeLovellFederalPathResources(resources)
-    return await getAllPagedListingStaticPathResources(
-      lovellFederalRemoved,
-      resourceType as ListingResourceType
-    )
+    if (!isSinglePageListingResourceType(resourceType)) {
+      return await getAllPagedListingStaticPathResources(
+        lovellFederalRemoved,
+        resourceType as ListingResourceType
+      )
+    }
+
+    return lovellFederalRemoved
   }
 
   return resources


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17399

Event-listing pages do not need all "paged" pages generated statically because the paging mechanism is done client side. This PR introduces some additional config and helper functions to be able to more granularly define whether a content type is a listing page that needs static generation of all "paged" pages or if it is a listing page that does not need that (but still needs other listing-page treatment).

The biggest gain here is efficiency of the build, as this PR will remove some unnecessary processing that was taking place for event-listing pages. Also important, this should make the code much more easy to follow, and a much more accurate representation of how things are structured/treated.

## Testing done/QA steps
The biggest risk here is screwing up existing static-page generation for story-listing pages. So, the biggest thing to test is that story-listing pages still have subsequent "paged" pages statically built. We were never generating subsequent pages for event-listing pages, but we also want to test that they do not exist.

Some examples of things that _should_ exist:
- [ ] `/minneapolis-health-care/stories/page-2`
- [ ] `/minneapolis-health-care/events`

Some examples of things that _should not_ exist:
- [ ] `/minneapolis-health-care/events/page-2`