### PR TITLE
8629 qa group section

### DIFF
--- a/src/data/queries/index.ts
+++ b/src/data/queries/index.ts
@@ -36,6 +36,8 @@ import * as Table from './table'
 import * as ReactWidget from './reactWidget'
 import * as QaParagraph from './qaParagraph'
 import * as QaSection from './qaSection'
+import * as QaGroup from './qaGroup'
+
 import {
   ResourceType,
   ParagraphResourceType,
@@ -72,6 +74,7 @@ export const QUERIES_MAP = {
   'paragraph--phone_number': PhoneNumber,
   'paragraph--q_a': QaParagraph,
   'paragraph--q_a_section': QaSection,
+  'paragraph--q_a_group': QaGroup,
   'paragraph--react_widget': ReactWidget,
   'paragraph--rich_text_char_limit_1000': Wysiwyg,
   'paragraph--table': Table,

--- a/src/data/queries/index.ts
+++ b/src/data/queries/index.ts
@@ -35,6 +35,7 @@ import * as CollapsiblePanelItem from './collapsiblePanelItem'
 import * as Table from './table'
 import * as ReactWidget from './reactWidget'
 import * as QaParagraph from './qaParagraph'
+import * as QaSection from './qaSection'
 import {
   ResourceType,
   ParagraphResourceType,
@@ -70,6 +71,7 @@ export const QUERIES_MAP = {
   'paragraph--non_reusable_alert': AlertNonReusable,
   'paragraph--phone_number': PhoneNumber,
   'paragraph--q_a': QaParagraph,
+  'paragraph--q_a_section': QaSection,
   'paragraph--react_widget': ReactWidget,
   'paragraph--rich_text_char_limit_1000': Wysiwyg,
   'paragraph--table': Table,

--- a/src/data/queries/qaGroup.ts
+++ b/src/data/queries/qaGroup.ts
@@ -1,0 +1,21 @@
+import { QueryFormatter } from 'next-drupal-query'
+import { queries } from '.'
+import { ParagraphQaGroup } from '@/types/drupal/paragraph'
+import { QaGroup } from '@/types/formatted/qaGroup'
+
+export const formatter: QueryFormatter<ParagraphQaGroup, QaGroup> = (
+  entity: ParagraphQaGroup
+) => {
+  return {
+    questions:
+      entity.field_q_as.map?.((item) => ({
+        title: item.title,
+        answer: queries.formatData('paragraph--wysiwyg', item.field_answer),
+      })) || [],
+    type: entity.type,
+    id: entity.id,
+    intro: entity.field_section_intro,
+    header: entity.field_section_header,
+    displayAccordion: entity.field_accordion_display,
+  }
+}

--- a/src/data/queries/qaGroup.ts
+++ b/src/data/queries/qaGroup.ts
@@ -1,6 +1,7 @@
 import { QueryFormatter } from 'next-drupal-query'
 import { ParagraphQaGroup } from '@/types/drupal/paragraph'
 import { QaGroup } from '@/types/formatted/qaGroup'
+import { QaGroupQa } from '@/types/formatted/qaGroup'
 import { formatParagraph } from '@/lib/drupal/paragraphs'
 
 export const formatter: QueryFormatter<ParagraphQaGroup, QaGroup> = (
@@ -15,10 +16,10 @@ export const formatter: QueryFormatter<ParagraphQaGroup, QaGroup> = (
       filteredQAs.map?.((item) => ({
         question: item.title,
         answers: [formatParagraph(item.field_answer)],
-        type: item.type,
+        type: item.type as QaGroupQa['type'],
         id: item.id,
       })) || [],
-    type: entity.type,
+    type: entity.type as QaGroup['type'],
     id: entity.id,
     entityId: entity.drupal_internal__id,
     intro: entity.field_section_intro || null,

--- a/src/data/queries/qaGroup.ts
+++ b/src/data/queries/qaGroup.ts
@@ -6,17 +6,23 @@ import { formatParagraph } from '@/lib/drupal/paragraphs'
 export const formatter: QueryFormatter<ParagraphQaGroup, QaGroup> = (
   entity: ParagraphQaGroup
 ) => {
+  // This handles filtering for field_q_as that are not published
+  const filteredQAs = entity.field_q_as.filter(
+    (item) => item.title || item.field_answer
+  )
   return {
     questions:
-      entity.field_q_as.map?.((item) => ({
-        title: item.title,
-        answer: formatParagraph(item.field_answer),
+      filteredQAs.map?.((item) => ({
+        question: item.title,
+        answers: [formatParagraph(item.field_answer)],
+        type: item.type,
+        id: item.id,
       })) || [],
     type: entity.type,
     id: entity.id,
     entityId: entity.drupal_internal__id,
-    intro: entity.field_section_intro ?? null,
-    header: entity.field_section_header ?? null,
-    displayAccordion: entity.field_accordion_display ?? false,
+    intro: entity.field_section_intro || null,
+    header: entity.field_section_header || null,
+    displayAccordion: entity.field_accordion_display || false,
   }
 }

--- a/src/data/queries/qaGroup.ts
+++ b/src/data/queries/qaGroup.ts
@@ -1,7 +1,7 @@
 import { QueryFormatter } from 'next-drupal-query'
-import { queries } from '.'
 import { ParagraphQaGroup } from '@/types/drupal/paragraph'
 import { QaGroup } from '@/types/formatted/qaGroup'
+import { formatParagraph } from '@/lib/drupal/paragraphs'
 
 export const formatter: QueryFormatter<ParagraphQaGroup, QaGroup> = (
   entity: ParagraphQaGroup
@@ -10,12 +10,13 @@ export const formatter: QueryFormatter<ParagraphQaGroup, QaGroup> = (
     questions:
       entity.field_q_as.map?.((item) => ({
         title: item.title,
-        answer: queries.formatData('paragraph--wysiwyg', item.field_answer),
+        answer: formatParagraph(item.field_answer),
       })) || [],
     type: entity.type,
     id: entity.id,
-    intro: entity.field_section_intro,
-    header: entity.field_section_header,
-    displayAccordion: entity.field_accordion_display,
+    entityId: entity.drupal_internal__id,
+    intro: entity.field_section_intro ?? null,
+    header: entity.field_section_header ?? null,
+    displayAccordion: entity.field_accordion_display ?? false,
   }
 }

--- a/src/data/queries/qaParagraph.ts
+++ b/src/data/queries/qaParagraph.ts
@@ -9,5 +9,7 @@ export const formatter: QueryFormatter<ParagraphQA, QaParagraph> = (
   return {
     question: entity.field_question,
     answers: entity.field_answer.map?.(formatParagraph) || [],
+    type: entity.type,
+    id: entity.id,
   }
 }

--- a/src/data/queries/qaParagraph.ts
+++ b/src/data/queries/qaParagraph.ts
@@ -7,9 +7,9 @@ export const formatter: QueryFormatter<ParagraphQA, QaParagraph> = (
   entity: ParagraphQA
 ) => {
   return {
+    type: entity.type as QaParagraph['type'],
     question: entity.field_question,
     answers: entity.field_answer.map?.(formatParagraph) || [],
-    type: entity.type,
     id: entity.id,
   }
 }

--- a/src/data/queries/qaSection.ts
+++ b/src/data/queries/qaSection.ts
@@ -11,7 +11,7 @@ export const formatter: QueryFormatter<ParagraphQaSection, QaSection> = (
     intro: entity.field_section_intro || null,
     questions: entity.field_questions.map?.(formatParagraph) || [],
     displayAccordion: entity.field_accordion_display,
-    type: entity.type,
+    type: entity.type as QaSection['type'],
     id: entity.id,
   }
 }

--- a/src/data/queries/qaSection.ts
+++ b/src/data/queries/qaSection.ts
@@ -8,7 +8,7 @@ export const formatter: QueryFormatter<ParagraphQaSection, QaSection> = (
 ) => {
   return {
     header: entity.field_section_header,
-    intro: entity.field_section_intro,
+    intro: entity.field_section_intro || null,
     questions: entity.field_questions.map?.(formatParagraph) || [],
     displayAccordion: entity.field_accordion_display,
     type: entity.type,

--- a/src/data/queries/qaSection.ts
+++ b/src/data/queries/qaSection.ts
@@ -1,0 +1,17 @@
+import { QueryFormatter } from 'next-drupal-query'
+import { ParagraphQaSection } from '@/types/drupal/paragraph'
+import { QaSection } from '@/types/formatted/qaSection'
+import { formatParagraph } from '@/lib/drupal/paragraphs'
+
+export const formatter: QueryFormatter<ParagraphQaSection, QaSection> = (
+  entity: ParagraphQaSection
+) => {
+  return {
+    header: entity.field_section_header,
+    intro: entity.field_section_intro,
+    questions: entity.field_questions.map?.(formatParagraph) || [],
+    displayAccordion: entity.field_accordion_display,
+    type: entity.type,
+    id: entity.id,
+  }
+}

--- a/src/data/queries/resourcesSupport.ts
+++ b/src/data/queries/resourcesSupport.ts
@@ -29,6 +29,7 @@ export const params: QueryParams<null> = () => {
     // content blocks (main content)
     'field_content_block',
     'field_content_block.field_q_as',
+    'field_content_block.field_q_as.field_answer',
     'field_content_block.field_va_paragraphs',
     'field_content_block.field_va_paragraphs.field_va_paragraphs',
     // tags

--- a/src/data/queries/tests/__snapshots__/banners.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/banners.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`Banners return formatted data outputs formatted data 1`] = `
   },
   {
     "alertType": "warning",
-    "bannerAlertVamcs": "/butler-health-care/operating-status",
     "body": "<p>this is a full width banner alert</p>",
     "dismiss": true,
     "emailUpdatesButton": true,

--- a/src/data/queries/tests/__snapshots__/qaGroup.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/qaGroup.test.tsx.snap
@@ -3,18 +3,23 @@
 exports[`QaGroup formatData outputs formatted data 1`] = `
 {
   "displayAccordion": false,
+  "entityId": 80861,
   "header": null,
   "id": "284e0f5b-0fbd-4eb4-96bd-350abff3214e",
-  "intro": undefined,
+  "intro": null,
   "questions": [
     {
-      "answer": {
-        "html": "<p>If you’re having trouble connecting to an app, contact the app’s customer support for help.</p>
+      "answers": [
+        {
+          "html": "<p>If you’re having trouble connecting to an app, contact the app’s customer support for help.</p>
 ",
-        "id": "c285aa42-285f-488c-89eb-c796c8d6c67e",
-        "type": "paragraph--rich_text_char_limit_1000",
-      },
-      "title": "Will my school refund money to VA if I drop a class?",
+          "id": "c285aa42-285f-488c-89eb-c796c8d6c67e",
+          "type": "paragraph--rich_text_char_limit_1000",
+        },
+      ],
+      "id": "fe41f870-be14-4c49-a6bc-52cb51096d86",
+      "question": "Will my school refund money to VA if I drop a class?",
+      "type": "node--q_a",
     },
   ],
   "type": "paragraph--q_a_group",

--- a/src/data/queries/tests/__snapshots__/qaGroup.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/qaGroup.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QaGroup formatData outputs formatted data 1`] = `
+{
+  "displayAccordion": false,
+  "header": null,
+  "id": "284e0f5b-0fbd-4eb4-96bd-350abff3214e",
+  "intro": undefined,
+  "questions": [
+    {
+      "answer": {
+        "html": "<p>If you’re having trouble connecting to an app, contact the app’s customer support for help.</p>
+",
+        "id": "c285aa42-285f-488c-89eb-c796c8d6c67e",
+        "type": "paragraph--rich_text_char_limit_1000",
+      },
+      "title": "Will my school refund money to VA if I drop a class?",
+    },
+  ],
+  "type": "paragraph--q_a_group",
+}
+`;

--- a/src/data/queries/tests/__snapshots__/qaParagraph.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/qaParagraph.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`QaParagraph formatData outputs formatted data 1`] = `
       "type": "paragraph--wysiwyg",
     },
   ],
+  "id": "66125704-adec-474c-a47c-be2968a1f84a",
   "question": "asdf",
   "type": "paragraph--q_a",
 }

--- a/src/data/queries/tests/__snapshots__/qaParagraph.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/qaParagraph.test.tsx.snap
@@ -10,5 +10,6 @@ exports[`QaParagraph formatData outputs formatted data 1`] = `
     },
   ],
   "question": "asdf",
+  "type": "paragraph--q_a",
 }
 `;

--- a/src/data/queries/tests/__snapshots__/qaSection.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/qaSection.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QaSection formatData outputs formatted data 1`] = `
+{
+  "displayAccordion": true,
+  "header": "Frequently asked quesitons about thing",
+  "intro": "asdfasdf",
+  "questions": [
+    {
+      "answers": [
+        {
+          "html": undefined,
+          "id": "f6dfd8da-877f-46bd-9707-28861c27003e",
+          "type": "paragraph--wysiwyg",
+        },
+      ],
+      "question": "asdf",
+      "type": "paragraph--q_a",
+    },
+    {
+      "answers": [
+        {
+          "html": undefined,
+          "id": "004d4d31-9e5f-4dcd-ab19-1aef98daefd4",
+          "type": "paragraph--wysiwyg",
+        },
+      ],
+      "question": "another question?",
+      "type": "paragraph--q_a",
+    },
+  ],
+}
+`;

--- a/src/data/queries/tests/__snapshots__/qaSection.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/qaSection.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`QaSection formatData outputs formatted data 1`] = `
 {
   "displayAccordion": true,
   "header": "Frequently asked quesitons about thing",
+  "id": "5d52e032-b77c-48fb-bae1-4449f242484f",
   "intro": "asdfasdf",
   "questions": [
     {
@@ -14,6 +15,7 @@ exports[`QaSection formatData outputs formatted data 1`] = `
           "type": "paragraph--wysiwyg",
         },
       ],
+      "id": "66125704-adec-474c-a47c-be2968a1f84a",
       "question": "asdf",
       "type": "paragraph--q_a",
     },
@@ -25,9 +27,11 @@ exports[`QaSection formatData outputs formatted data 1`] = `
           "type": "paragraph--wysiwyg",
         },
       ],
+      "id": "71df0e11-b6fa-482f-9c6f-8f16449d6f3a",
       "question": "another question?",
       "type": "paragraph--q_a",
     },
   ],
+  "type": "paragraph--q_a_section",
 }
 `;

--- a/src/data/queries/tests/qaGroup.test.tsx
+++ b/src/data/queries/tests/qaGroup.test.tsx
@@ -1,0 +1,25 @@
+import { ParagraphQaGroup } from '@/types/drupal/paragraph'
+import { queries } from '@/data/queries'
+import mockData from '@/mocks/qaGroup.mock.json'
+
+const QaGroupMock: ParagraphQaGroup = mockData
+
+describe('QaGroup formatData', () => {
+  let windowSpy
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get')
+  })
+
+  afterEach(() => {
+    windowSpy.mockRestore()
+  })
+
+  test('outputs formatted data', () => {
+    windowSpy.mockImplementation(() => undefined)
+
+    expect(
+      queries.formatData('paragraph--q_a_group', QaGroupMock)
+    ).toMatchSnapshot()
+  })
+})

--- a/src/data/queries/tests/qaSection.test.tsx
+++ b/src/data/queries/tests/qaSection.test.tsx
@@ -1,0 +1,25 @@
+import { ParagraphQaSection } from '@/types/drupal/paragraph'
+import { queries } from '@/data/queries'
+import mockData from '@/mocks/qaSection.mock.json'
+
+const QaSectionMock: ParagraphQaSection = mockData
+
+describe('QaSection formatData', () => {
+  let windowSpy
+
+  beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get')
+  })
+
+  afterEach(() => {
+    windowSpy.mockRestore()
+  })
+
+  test('outputs formatted data', () => {
+    windowSpy.mockImplementation(() => undefined)
+
+    expect(
+      queries.formatData('paragraph--q_a_section', QaSectionMock)
+    ).toMatchSnapshot()
+  })
+})

--- a/src/lib/constants/resourceTypes.ts
+++ b/src/lib/constants/resourceTypes.ts
@@ -31,7 +31,7 @@ export const PARAGRAPH_RESOURCE_TYPES = {
   // STAFF_PROFILE: 'paragraph--staff_profile',
   TABLE: 'paragraph--table',
   WYSIWYG: 'paragraph--wysiwyg',
-  QA_PARAGRAPH: 'paragraph--q_a',
+  QA: 'paragraph--q_a',
   QA_SECTION: 'paragraph--q_a_section',
   QA_GROUP: 'paragraph--q_a_group',
 } as const

--- a/src/lib/constants/resourceTypes.ts
+++ b/src/lib/constants/resourceTypes.ts
@@ -31,6 +31,8 @@ export const PARAGRAPH_RESOURCE_TYPES = {
   // STAFF_PROFILE: 'paragraph--staff_profile',
   TABLE: 'paragraph--table',
   WYSIWYG: 'paragraph--wysiwyg',
+  QA_PARAGRAPH: 'paragraph--q_a',
+  QA_SECTION: 'paragraph--q_a_section',
 } as const
 
 export type ParagraphResourceType =

--- a/src/lib/constants/resourceTypes.ts
+++ b/src/lib/constants/resourceTypes.ts
@@ -33,6 +33,7 @@ export const PARAGRAPH_RESOURCE_TYPES = {
   WYSIWYG: 'paragraph--wysiwyg',
   QA_PARAGRAPH: 'paragraph--q_a',
   QA_SECTION: 'paragraph--q_a_section',
+  QA_GROUP: 'paragraph--q_a_group',
 } as const
 
 export type ParagraphResourceType =

--- a/src/mocks/qaGroup.mock.json
+++ b/src/mocks/qaGroup.mock.json
@@ -1,0 +1,286 @@
+{
+  "type": "paragraph--q_a_group",
+  "id": "284e0f5b-0fbd-4eb4-96bd-350abff3214e",
+  "drupal_internal__id": 80861,
+  "drupal_internal__revision_id": 687146,
+  "langcode": "en",
+  "status": true,
+  "created": "2021-08-30T13:26:52+00:00",
+  "parent_id": "34659",
+  "parent_type": "node",
+  "parent_field_name": "field_q_a_groups",
+  "behavior_settings": [],
+  "default_langcode": true,
+  "revision_translation_affected": true,
+  "content_translation_source": "und",
+  "content_translation_outdated": false,
+  "content_translation_changed": null,
+  "field_accordion_display": false,
+  "field_rich_wysiwyg": null,
+  "field_section_header": null,
+  "links": {
+    "self": {
+      "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/q_a_group/284e0f5b-0fbd-4eb4-96bd-350abff3214e?resourceVersion=id%3A687146"
+    }
+  },
+  "paragraph_type": {
+    "type": "paragraphs_type--paragraphs_type",
+    "id": "cc3b3e2c-a7f5-4f62-a1ce-fcf307fbc28b",
+    "resourceIdObjMeta": {
+      "drupal_internal__target_id": "q_a_group"
+    }
+  },
+  "field_q_as": [
+    {
+      "type": "node--q_a",
+      "id": "fe41f870-be14-4c49-a6bc-52cb51096d86",
+      "drupal_internal__nid": 34647,
+      "drupal_internal__vid": 662628,
+      "langcode": "en",
+      "revision_timestamp": "2022-07-06T06:35:56+00:00",
+      "status": false,
+      "title": "Will my school refund money to VA if I drop a class?",
+      "created": "2021-08-30T13:05:12+00:00",
+      "changed": "2022-07-06T06:35:56+00:00",
+      "promote": false,
+      "sticky": false,
+      "default_langcode": true,
+      "revision_translation_affected": true,
+      "breadcrumbs": [
+        {
+          "uri": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/",
+          "title": "Home",
+          "options": []
+        },
+        {
+          "uri": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/resources",
+          "title": "Resources and support",
+          "options": []
+        },
+        {
+          "uri": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/resources/will-my-school-refund-money-to-va-if-i-drop-a-class",
+          "title": "Will my school refund money to VA if I drop a class?",
+          "options": []
+        }
+      ],
+      "moderation_state": "draft",
+      "metatag": [
+        {
+          "tag": "meta",
+          "attributes": {
+            "name": "title",
+            "content": "Will my school refund money to VA if I drop a class? | Veterans Affairs"
+          }
+        },
+        {
+          "tag": "link",
+          "attributes": {
+            "rel": "image_src",
+            "href": "https://www.va.gov/img/design/logo/va-og-image.png"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "property": "og:site_name",
+            "content": "Veterans Affairs"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "property": "og:title",
+            "content": "Will my school refund money to VA if I drop a class? | Veterans Affairs"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "property": "og:image",
+            "content": "https://www.va.gov/img/design/logo/va-og-image.png"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "property": "og:image:alt",
+            "content": "U.S. Department of Veterans Affairs"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "name": "twitter:card",
+            "content": "summary_large_image"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "name": "twitter:site",
+            "content": "@DeptVetAffairs"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "name": "twitter:title",
+            "content": "Will my school refund money to VA if I drop a class? | Veterans Affairs"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "name": "twitter:image",
+            "content": "https://www.va.gov/img/design/logo/va-og-image.png"
+          }
+        },
+        {
+          "tag": "meta",
+          "attributes": {
+            "name": "twitter:image:alt",
+            "content": "U.S. Department of Veterans Affairs"
+          }
+        }
+      ],
+      "path": {
+        "alias": "/resources/will-my-school-refund-money-to-va-if-i-drop-a-class",
+        "pid": 41234,
+        "langcode": "en"
+      },
+      "content_translation_source": "und",
+      "content_translation_outdated": false,
+      "field_last_saved_by_an_editor": null,
+      "field_standalone_page": false,
+      "links": {
+        "self": {
+          "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/node/q_a/fe41f870-be14-4c49-a6bc-52cb51096d86?resourceVersion=id%3A662628"
+        }
+      },
+      "resourceIdObjMeta": {
+        "drupal_internal__target_id": 34647
+      },
+      "node_type": {
+        "type": "node_type--node_type",
+        "id": "e1c04503-bcc8-4285-b2be-fa27af3634e4",
+        "resourceIdObjMeta": {
+          "drupal_internal__target_id": "q_a"
+        }
+      },
+      "revision_uid": {
+        "type": "user--user",
+        "id": "5d0d8292-185a-44ca-8153-6bdaafc21070",
+        "resourceIdObjMeta": {
+          "drupal_internal__target_id": 4194
+        }
+      },
+      "uid": {
+        "type": "user--user",
+        "id": "5d0d8292-185a-44ca-8153-6bdaafc21070",
+        "resourceIdObjMeta": {
+          "drupal_internal__target_id": 4194
+        }
+      },
+      "field_administration": {
+        "type": "taxonomy_term--administration",
+        "id": "40ef8d64-fa92-41b6-88c0-4d85dc24e191",
+        "resourceIdObjMeta": {
+          "drupal_internal__target_id": 194
+        }
+      },
+      "field_alert_single": {
+        "type": "paragraph--alert_single",
+        "id": "592c4dbe-a45c-4bc7-910d-731a97044e06",
+        "resourceIdObjMeta": {
+          "target_revision_id": 687314,
+          "drupal_internal__target_id": 80766
+        }
+      },
+      "field_answer": {
+        "type": "paragraph--rich_text_char_limit_1000",
+        "id": "c285aa42-285f-488c-89eb-c796c8d6c67e",
+        "drupal_internal__id": 14357,
+        "drupal_internal__revision_id": 769307,
+        "langcode": "en",
+        "status": true,
+        "created": "2020-11-17T16:14:37+00:00",
+        "parent_id": "9622",
+        "parent_type": "node",
+        "parent_field_name": "field_answer",
+        "behavior_settings": [],
+        "default_langcode": true,
+        "revision_translation_affected": null,
+        "content_translation_source": "und",
+        "content_translation_outdated": false,
+        "content_translation_changed": null,
+        "field_wysiwyg": {
+          "value": "<p>If you’re having trouble connecting to an app, contact the app’s customer support for help.</p>\r\n",
+          "format": "rich_text_limited",
+          "processed": "<p>If you’re having trouble connecting to an app, contact the app’s customer support for help.</p>\n"
+        },
+        "links": {
+          "self": {
+            "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/rich_text_char_limit_1000/c285aa42-285f-488c-89eb-c796c8d6c67e?resourceVersion=id%3A769307"
+          }
+        },
+        "resourceIdObjMeta": {
+          "target_revision_id": 769307,
+          "drupal_internal__target_id": 14357
+        },
+        "paragraph_type": {
+          "type": "paragraphs_type--paragraphs_type",
+          "id": "3ffc29ff-5b72-4f6a-a51b-7076c3f62f22",
+          "resourceIdObjMeta": {
+            "drupal_internal__target_id": "rich_text_char_limit_1000"
+          }
+        },
+        "relationshipNames": ["paragraph_type"]
+      },
+      "field_buttons": [],
+      "field_contact_information": {
+        "type": "paragraph--contact_information",
+        "id": "3621b22f-af17-4917-b11e-9f6dc2cf0ce0",
+        "resourceIdObjMeta": {
+          "target_revision_id": 687316,
+          "drupal_internal__target_id": 80769
+        }
+      },
+      "field_other_categories": [],
+      "field_primary_category": null,
+      "field_related_benefit_hubs": [
+        {
+          "type": "node--landing_page",
+          "id": "fd822f25-788f-489c-a0fc-b1f7ad6c20d5",
+          "resourceIdObjMeta": {
+            "drupal_internal__target_id": 67
+          }
+        }
+      ],
+      "field_related_information": [],
+      "field_tags": {
+        "type": "paragraph--audience_topics",
+        "id": "114cb52a-e468-44ee-9e48-5604469f427a",
+        "resourceIdObjMeta": {
+          "target_revision_id": 687317,
+          "drupal_internal__target_id": 80770
+        }
+      },
+      "relationshipNames": [
+        "node_type",
+        "revision_uid",
+        "uid",
+        "field_administration",
+        "field_alert_single",
+        "field_answer",
+        "field_buttons",
+        "field_contact_information",
+        "field_other_categories",
+        "field_primary_category",
+        "field_related_benefit_hubs",
+        "field_related_information",
+        "field_tags"
+      ]
+    }
+  ],
+  "relationshipNames": ["paragraph_type", "field_q_as"]
+}

--- a/src/mocks/qaSection.mock.json
+++ b/src/mocks/qaSection.mock.json
@@ -1,0 +1,134 @@
+{
+  "type": "paragraph--q_a_section",
+  "id": "5d52e032-b77c-48fb-bae1-4449f242484f",
+  "drupal_internal__id": 2758,
+  "drupal_internal__revision_id": 3015,
+  "langcode": "en",
+  "status": true,
+  "created": "2019-03-04T22:24:09+00:00",
+  "parent_id": "127",
+  "parent_type": "node",
+  "parent_field_name": "field_content_block",
+  "behavior_settings": [],
+  "default_langcode": true,
+  "revision_translation_affected": true,
+  "content_translation_source": "und",
+  "content_translation_outdated": false,
+  "content_translation_changed": null,
+  "field_accordion_display": true,
+  "field_section_header": "Frequently asked quesitons about thing",
+  "field_section_intro": "asdfasdf",
+  "links": {
+    "self": {
+      "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/q_a_section/5d52e032-b77c-48fb-bae1-4449f242484f?resourceVersion=id%3A3015"
+    }
+  },
+  "paragraph_type": {
+    "type": "paragraphs_type--paragraphs_type",
+    "id": "f7351783-e298-425f-9b27-ac95be2ed069",
+    "label": "Page-Specific Q&A Group",
+    "links": {
+      "self": {
+        "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraphs_type/paragraphs_type/f7351783-e298-425f-9b27-ac95be2ed069"
+      }
+    },
+    "resourceIdObjMeta": {
+      "drupal_internal__target_id": "q_a_section"
+    }
+  },
+  "field_questions": [
+    {
+      "type": "paragraph--q_a",
+      "id": "66125704-adec-474c-a47c-be2968a1f84a",
+      "drupal_internal__id": 2755,
+      "drupal_internal__revision_id": 3012,
+      "langcode": "en",
+      "status": true,
+      "created": "2019-03-04T22:24:09+00:00",
+      "parent_id": "2758",
+      "parent_type": "paragraph",
+      "parent_field_name": "field_questions",
+      "behavior_settings": [],
+      "default_langcode": true,
+      "revision_translation_affected": true,
+      "content_translation_source": "und",
+      "content_translation_outdated": false,
+      "content_translation_changed": null,
+      "field_question": "asdf",
+      "links": {
+        "self": {
+          "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/q_a/66125704-adec-474c-a47c-be2968a1f84a?resourceVersion=id%3A3012"
+        }
+      },
+      "resourceIdObjMeta": {
+        "target_revision_id": 3012,
+        "drupal_internal__target_id": 2755
+      },
+      "paragraph_type": {
+        "type": "paragraphs_type--paragraphs_type",
+        "id": "525c8535-c6fa-4e64-8824-82c889785a6a",
+        "resourceIdObjMeta": {
+          "drupal_internal__target_id": "q_a"
+        }
+      },
+      "field_answer": [
+        {
+          "type": "paragraph--wysiwyg",
+          "id": "f6dfd8da-877f-46bd-9707-28861c27003e",
+          "resourceIdObjMeta": {
+            "target_revision_id": 3011,
+            "drupal_internal__target_id": 2754
+          }
+        }
+      ],
+      "relationshipNames": ["paragraph_type", "field_answer"]
+    },
+    {
+      "type": "paragraph--q_a",
+      "id": "71df0e11-b6fa-482f-9c6f-8f16449d6f3a",
+      "drupal_internal__id": 2757,
+      "drupal_internal__revision_id": 3014,
+      "langcode": "en",
+      "status": true,
+      "created": "2019-03-04T22:25:58+00:00",
+      "parent_id": "2758",
+      "parent_type": "paragraph",
+      "parent_field_name": "field_questions",
+      "behavior_settings": [],
+      "default_langcode": true,
+      "revision_translation_affected": true,
+      "content_translation_source": "und",
+      "content_translation_outdated": false,
+      "content_translation_changed": null,
+      "field_question": "another question?",
+      "links": {
+        "self": {
+          "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/q_a/71df0e11-b6fa-482f-9c6f-8f16449d6f3a?resourceVersion=id%3A3014"
+        }
+      },
+      "resourceIdObjMeta": {
+        "target_revision_id": 3014,
+        "drupal_internal__target_id": 2757
+      },
+      "paragraph_type": {
+        "type": "paragraphs_type--paragraphs_type",
+        "id": "525c8535-c6fa-4e64-8824-82c889785a6a",
+        "resourceIdObjMeta": {
+          "drupal_internal__target_id": "q_a"
+        }
+      },
+      "field_answer": [
+        {
+          "type": "paragraph--wysiwyg",
+          "id": "004d4d31-9e5f-4dcd-ab19-1aef98daefd4",
+          "resourceIdObjMeta": {
+            "target_revision_id": 3013,
+            "drupal_internal__target_id": 2756
+          }
+        }
+      ],
+      "relationshipNames": ["paragraph_type", "field_answer"]
+    }
+  ],
+  "relationshipNames": ["paragraph_type", "field_questions"]
+}

--- a/src/templates/components/paragraph/index.tsx
+++ b/src/templates/components/paragraph/index.tsx
@@ -30,6 +30,9 @@ import { FeaturedContent as FormattedFeaturedContent } from '@/types/formatted/f
 import { LinkTeaser } from '@/templates/components/linkTeaser'
 import { LinkTeaser as FormattedLinkTeaser } from '@/types/formatted/linkTeaser'
 import { PhoneContact } from '@/templates/components/contactInfo'
+import { QaSection } from '@/templates/components/qaSection'
+import { QaSection as FormattedQaSection } from '@/types/formatted/qaSection'
+import { QaGroup as FormattedQaGroup } from '@/types/formatted/qaGroup'
 import { PhoneContact as FormattedPhoneContact } from '@/types/formatted/contactInfo'
 import { ReactWidget } from '@/templates/components/reactWidget'
 import { ReactWidget as FormattedReactWidget } from '@/types/formatted/reactWidget'
@@ -88,6 +91,12 @@ export const Paragraph = (paragraph: FormattedParagraph) => {
 
     case PARAGRAPH_RESOURCE_TYPES.TABLE:
       return <Table {...(paragraph as FormattedTable)} />
+
+    case PARAGRAPH_RESOURCE_TYPES.QA_GROUP:
+      return <QaSection {...(paragraph as FormattedQaGroup)} />
+
+    case PARAGRAPH_RESOURCE_TYPES.QA_SECTION:
+      return <QaSection {...(paragraph as FormattedQaSection)} />
 
     case PARAGRAPH_RESOURCE_TYPES.WYSIWYG:
     case PARAGRAPH_RESOURCE_TYPES.RICH_TEXT_CHAR_LIMIT_1000:

--- a/src/templates/components/qaCollapsiblePanel/index.test.tsx
+++ b/src/templates/components/qaCollapsiblePanel/index.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { QaCollapsiblePanel } from './index'
+const questionsData = [
+  {
+    id: '1111-1111-1111',
+    question: 'Question 1',
+    answers: [
+      {
+        id: '1',
+        html: '<p>test string 1</p>',
+        type: 'paragraph--wysiwyg',
+      },
+      {
+        id: '2',
+        html: '<p> test string 2</p>',
+        type: 'paragraph--wysiwyg',
+      },
+    ],
+    type: 'paragraph--q_a',
+  },
+]
+
+describe('QaCollapsiblePanel with valid data', () => {
+  test('renders QaCollapsiblePanel component', () => {
+    render(<QaCollapsiblePanel questions={questionsData} />)
+
+    const panelDiv = document.querySelector(
+      'div[data-template="paragraphs/q_a.collapsible_panel"]'
+    )
+    expect(panelDiv).toBeInTheDocument()
+  })
+})

--- a/src/templates/components/qaCollapsiblePanel/index.tsx
+++ b/src/templates/components/qaCollapsiblePanel/index.tsx
@@ -1,0 +1,34 @@
+export const QaCollapsiblePanel = ({ questions }) => {
+  return (
+    <div data-template="paragraphs/q_a.collapsible_panel">
+      <va-accordion>
+        {questions.map((questionObject) => (
+          <va-accordion-item
+            key={questionObject.id}
+            class="va-accordion-item"
+            header={questionObject.question}
+            id={`${questionObject.question}-header`}
+            level="3"
+          >
+            <div
+              id={questionObject.id}
+              data-template="paragraphs/q_a.collapsible_panel__qa"
+              data-entity-id={questionObject.id}
+              data-analytics-faq-section={questionObject.header}
+              data-analytics-faq-text={questionObject.question}
+            >
+              <div id={`qa-${questionObject.id}`}>
+                {questionObject.answers.map((answer, index) => (
+                  <div
+                    key={index}
+                    dangerouslySetInnerHTML={{ __html: answer.html }}
+                  />
+                ))}
+              </div>
+            </div>
+          </va-accordion-item>
+        ))}
+      </va-accordion>
+    </div>
+  )
+}

--- a/src/templates/components/qaCollapsiblePanel/qaCollapsiblePanel.stories.ts
+++ b/src/templates/components/qaCollapsiblePanel/qaCollapsiblePanel.stories.ts
@@ -1,0 +1,35 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { QaCollapsiblePanel } from './index'
+
+const meta: Meta<typeof QaCollapsiblePanel> = {
+  title: 'Paragraphs/QaCollapsiblePanel',
+  component: QaCollapsiblePanel,
+}
+export default meta
+
+type Story = StoryObj<typeof QaCollapsiblePanel>
+
+export const Example: Story = {
+  args: {
+    questions: [
+      {
+        id: '1111-1111-1111',
+        question: 'Question 1',
+        answers: [
+          {
+            id: '1',
+            html: '<p>test string 1</p>',
+            type: 'paragraph--wysiwyg',
+          },
+          {
+            id: '2',
+            html: '<p> test string 2</p>',
+            type: 'paragraph--wysiwyg',
+          },
+        ],
+        type: 'paragraph--q_a',
+      },
+    ],
+  },
+}

--- a/src/templates/components/qaParagraph/index.test.tsx
+++ b/src/templates/components/qaParagraph/index.test.tsx
@@ -4,6 +4,8 @@ import { QaParagraph as FormattedQaParagraph } from '@/types/formatted/qaParagra
 
 const qaParagraphProps: FormattedQaParagraph = {
   question: 'Sample Question',
+  id: '1111-1111-1111',
+  type: 'paragraph--q_a',
   answers: [
     {
       id: '1',

--- a/src/templates/components/qaParagraph/index.tsx
+++ b/src/templates/components/qaParagraph/index.tsx
@@ -1,12 +1,17 @@
 import { QaParagraph as FormattedQaParagraph } from '@/types/formatted/qaParagraph'
 import { Paragraph } from '@/templates/components/paragraph'
 
-export function QaParagraph({ question, answers }: FormattedQaParagraph) {
+export function QaParagraph({
+  question,
+  answers,
+  setHeaderh3,
+}: FormattedQaParagraph) {
+  const DynamicHeader = setHeaderh3 ? 'h3' : 'h2'
   return (
     <div data-template="paragraphs/q_a">
       <div>
         <div className="vads-u-display--flex">
-          <h2>{question}</h2>
+          <DynamicHeader>{question}</DynamicHeader>
         </div>
         {answers && (
           <div>

--- a/src/templates/components/qaParagraph/qaParagraph.stories.ts
+++ b/src/templates/components/qaParagraph/qaParagraph.stories.ts
@@ -1,10 +1,9 @@
 // QaParagraph.stories.tsx
 import { Meta, StoryObj } from '@storybook/react'
 import { QaParagraph } from '.'
-import { QaParagraph as FormattedQaParagraph } from '@/types/formatted/qaParagraph'
 
 const meta: Meta<typeof QaParagraph> = {
-  title: 'Components/QA Paragraph',
+  title: 'Paragraphs/QA Paragraph',
   component: QaParagraph,
 }
 export default meta

--- a/src/templates/components/qaSection/index.test.tsx
+++ b/src/templates/components/qaSection/index.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import { QaSection } from './index'
+import { QaSection as FormattedQaSection } from '@/types/formatted/qaSection'
+
+const QaSectionAccordionProps: FormattedQaSection = {
+  header: 'Accordion test header',
+  intro: 'intro text',
+  displayAccordion: true,
+  type: 'paragraph--q_a',
+  id: '1',
+  questions: [
+    {
+      question: 'Question 1',
+      answers: [
+        {
+          id: '1',
+          html: '<p>Accordion test string 1</p>',
+          type: 'paragraph--wysiwyg',
+        },
+        {
+          id: '2',
+          html: '<p>Accordion test string 2</p>',
+          type: 'paragraph--wysiwyg',
+        },
+      ],
+      id: '11111-11111-11111',
+      type: 'paragraph--q_a',
+    },
+  ],
+}
+
+const QaSectionOtherProps: FormattedQaSection = {
+  header: 'Other test header',
+  intro: 'intro text',
+  displayAccordion: false,
+  type: 'paragraph--q_a',
+  id: '1',
+  questions: [
+    {
+      question: 'Question 1',
+      answers: [
+        {
+          id: '1',
+          html: '<p>Other test string 1</p>',
+          type: 'paragraph--wysiwyg',
+        },
+        {
+          id: '2',
+          html: '<p>Other test string 2</p>',
+          type: 'paragraph--wysiwyg',
+        },
+      ],
+      id: '11111-11111-11111',
+      type: 'paragraph--q_a',
+    },
+  ],
+}
+
+describe('QaSection with with valid data', () => {
+  test('renders QaSection component with accordion', () => {
+    render(<QaSection {...QaSectionAccordionProps} />)
+    const accordionDiv = document.querySelector(
+      'div[data-template="paragraphs/q_a.collapsible_panel"]'
+    )
+    expect(accordionDiv).toBeInTheDocument()
+    expect(screen.queryByText(/Accordion test header/)).toBeInTheDocument()
+  })
+
+  test('renders QaSection component without accordion', () => {
+    render(<QaSection {...QaSectionOtherProps} />)
+    const accordionDiv = document.querySelector(
+      'div[data-template="paragraphs/q_a.collapsible_panel"]'
+    )
+    expect(accordionDiv).not.toBeInTheDocument()
+    expect(screen.queryByText(/Other test header/)).toBeInTheDocument()
+  })
+})

--- a/src/templates/components/qaSection/index.test.tsx
+++ b/src/templates/components/qaSection/index.test.tsx
@@ -6,7 +6,7 @@ const QaSectionAccordionProps: FormattedQaSection = {
   header: 'Accordion test header',
   intro: 'intro text',
   displayAccordion: true,
-  type: 'paragraph--q_a',
+  type: 'paragraph--q_a_section',
   id: '1',
   questions: [
     {
@@ -33,7 +33,7 @@ const QaSectionOtherProps: FormattedQaSection = {
   header: 'Other test header',
   intro: 'intro text',
   displayAccordion: false,
-  type: 'paragraph--q_a',
+  type: 'paragraph--q_a_section',
   id: '1',
   questions: [
     {

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -1,0 +1,31 @@
+import { QaSection as FormattedQaSection } from '@/types/formatted/qaSection'
+import { QaCollapsiblePanel } from '../qaCollapsiblePanel'
+import { QaParagraph } from '../qaParagraph'
+import { QaParagraph as FormattedQaParagraph } from '@/types/formatted/qaParagraph'
+
+export function QaSection({
+  header,
+  intro,
+  questions,
+  displayAccordion,
+}: FormattedQaSection) {
+  return (
+    <div data-template="paragraphs/q_a_section">
+      {header && <h2>{header}</h2>}
+      {intro && <p>{intro}</p>}
+      {displayAccordion ? (
+        <QaCollapsiblePanel questions={questions} />
+      ) : (
+        questions.map((questionObject: FormattedQaParagraph, index) => (
+          <QaParagraph
+            key={index}
+            type={questionObject.type}
+            answers={questionObject.answers}
+            question={questionObject.question}
+            id={questionObject.id}
+          />
+        ))
+      )}
+    </div>
+  )
+}

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -1,8 +1,8 @@
 import { QaSection as FormattedQaSection } from '@/types/formatted/qaSection'
 import { QaCollapsiblePanel } from '../qaCollapsiblePanel'
+import { QaParagraph as FormattedQaParagraph } from '@/types/formatted/qaParagraph'
 import { QaGroup as FormattedQaGroup } from '@/types/formatted/qaGroup'
 import { Paragraph } from '@/templates/components/paragraph'
-import { FormattedParagraph } from '@/data/queries'
 
 export function QaSection({
   header,
@@ -18,8 +18,12 @@ export function QaSection({
       {displayAccordion ? (
         <QaCollapsiblePanel questions={questions} />
       ) : (
-        questions.map((questionContent: FormattedParagraph, index) => (
-          <Paragraph key={questionContent?.id || index} {...questionContent} />
+        questions.map((questionContent: FormattedQaParagraph, index) => (
+          <Paragraph
+            key={questionContent?.id || index}
+            setHeaderh3={setHeaderh3}
+            {...questionContent}
+          />
         ))
       )}
     </div>

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -1,8 +1,8 @@
 import { QaSection as FormattedQaSection } from '@/types/formatted/qaSection'
 import { QaCollapsiblePanel } from '../qaCollapsiblePanel'
-import { QaParagraph } from '../qaParagraph'
-import { QaParagraph as FormattedQaParagraph } from '@/types/formatted/qaParagraph'
 import { QaGroup as FormattedQaGroup } from '@/types/formatted/qaGroup'
+import { Paragraph } from '@/templates/components/paragraph'
+import { FormattedParagraph } from '@/data/queries'
 
 export function QaSection({
   header,
@@ -18,15 +18,8 @@ export function QaSection({
       {displayAccordion ? (
         <QaCollapsiblePanel questions={questions} />
       ) : (
-        questions.map((questionObject: FormattedQaParagraph, index) => (
-          <QaParagraph
-            key={index}
-            type={questionObject.type}
-            answers={questionObject.answers}
-            question={questionObject.question}
-            id={questionObject.id}
-            setHeaderh3={setHeaderh3}
-          />
+        questions.map((questionContent: FormattedParagraph, index) => (
+          <Paragraph key={questionContent?.id || index} {...questionContent} />
         ))
       )}
     </div>

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -18,7 +18,7 @@ export function QaSection({
       {displayAccordion ? (
         <QaCollapsiblePanel questions={questions} />
       ) : (
-        questions.map((questionContent: FormattedParagraph, index) => (
+        questions.map((questionContent: FormattedParagraph) => (
           <Paragraph
             key={questionContent.id}
             setHeaderh3={setHeaderh3}

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -1,8 +1,8 @@
 import { QaSection as FormattedQaSection } from '@/types/formatted/qaSection'
 import { QaCollapsiblePanel } from '../qaCollapsiblePanel'
-import { QaParagraph as FormattedQaParagraph } from '@/types/formatted/qaParagraph'
 import { QaGroup as FormattedQaGroup } from '@/types/formatted/qaGroup'
 import { Paragraph } from '@/templates/components/paragraph'
+import { FormattedParagraph } from '@/data/queries'
 
 export function QaSection({
   header,
@@ -18,9 +18,9 @@ export function QaSection({
       {displayAccordion ? (
         <QaCollapsiblePanel questions={questions} />
       ) : (
-        questions.map((questionContent: FormattedQaParagraph, index) => (
+        questions.map((questionContent: FormattedParagraph, index) => (
           <Paragraph
-            key={questionContent?.id || index}
+            key={questionContent.id}
             setHeaderh3={setHeaderh3}
             {...questionContent}
           />

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -9,6 +9,7 @@ export function QaSection({
   questions,
   displayAccordion,
 }: FormattedQaSection) {
+  const setHeaderh3 = header ? true : false
   return (
     <div data-template="paragraphs/q_a_section">
       {header && <h2>{header}</h2>}
@@ -23,6 +24,7 @@ export function QaSection({
             answers={questionObject.answers}
             question={questionObject.question}
             id={questionObject.id}
+            setHeaderh3={setHeaderh3}
           />
         ))
       )}

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -2,13 +2,14 @@ import { QaSection as FormattedQaSection } from '@/types/formatted/qaSection'
 import { QaCollapsiblePanel } from '../qaCollapsiblePanel'
 import { QaParagraph } from '../qaParagraph'
 import { QaParagraph as FormattedQaParagraph } from '@/types/formatted/qaParagraph'
+import { QaGroup as FormattedQaGroup } from '@/types/formatted/qaGroup'
 
 export function QaSection({
   header,
   intro,
   questions,
   displayAccordion,
-}: FormattedQaSection) {
+}: FormattedQaSection | FormattedQaGroup) {
   const setHeaderh3 = header ? true : false
   return (
     <div data-template="paragraphs/q_a_section">

--- a/src/templates/components/qaSection/qaSection.stories.ts
+++ b/src/templates/components/qaSection/qaSection.stories.ts
@@ -1,0 +1,60 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { QaSection } from './index'
+
+const meta: Meta<typeof QaSection> = {
+  title: 'Paragraphs/QaSection',
+  component: QaSection,
+}
+export default meta
+
+type Story = StoryObj<typeof QaSection>
+
+export const Accordion: Story = {
+  args: {
+    header: 'Accordion test header',
+    intro: 'intro text',
+    displayAccordion: true,
+    questions: [
+      {
+        id: '1111-1111-1111',
+        question: 'Question 1',
+        answers: [
+          {
+            id: '1',
+            html: '<p>Accordion test string 1</p>',
+            type: 'paragraph--wysiwyg',
+          },
+          {
+            id: '2',
+            html: '<p>Accordion test string 2</p>',
+            type: 'paragraph--wysiwyg',
+          },
+        ],
+        type: 'paragraph--q_a',
+      },
+    ],
+  },
+}
+
+export const Other: Story = {
+  args: {
+    header: 'Other test Header',
+    intro: 'intro text',
+    displayAccordion: false,
+    questions: [
+      {
+        id: '1111-1111-1111',
+        question: 'Question 1',
+        answers: [
+          {
+            id: '1',
+            html: '<p>wysiwyg test string 1</p>',
+            type: 'paragraph--wysiwyg',
+          },
+        ],
+        type: 'paragraph--q_a',
+      },
+    ],
+  },
+}

--- a/src/types/drupal/node.ts
+++ b/src/types/drupal/node.ts
@@ -25,7 +25,7 @@ import {
   ParagraphLinkTeaser,
   ParagraphListOfLinks,
   ParagraphPhoneNumber,
-  ParagraphQAGroup,
+  ParagraphQaGroup,
   ParagraphReactWidget,
   ParagraphRichTextCharLimit1000,
   ParagraphServiceLocation,
@@ -134,7 +134,7 @@ export interface NodeBasicLandingPage extends DrupalNode {
 }
 
 export interface NodeFaqMultipleQA extends NodeAbstractResource {
-  field_q_a_groups: ParagraphQAGroup[]
+  field_q_a_groups: ParagraphQaGroup[]
   field_table_of_content_boolean: boolean
   field_buttons_repeat: boolean
 }
@@ -352,7 +352,7 @@ export interface NodeSupportResourcesDetailPage extends NodeAbstractResource {
     | ParagraphTable
     | ParagraphCollapsiblePanel
     | ParagraphReactWidget
-    | ParagraphQAGroup
+    | ParagraphQaGroup
   )[]
   field_buttons_repeat: boolean
 }

--- a/src/types/drupal/paragraph.ts
+++ b/src/types/drupal/paragraph.ts
@@ -9,12 +9,7 @@ import {
   FieldTable,
 } from './field_type'
 import { DrupalMediaImage } from './media'
-import {
-  NodeLandingPage,
-  NodePersonProfile,
-  NodeQA,
-  NodeSupportService,
-} from './node'
+import { NodeLandingPage, NodePersonProfile, NodeSupportService } from './node'
 import {
   TaxonomyTermAudienceBeneficiaries,
   TaxonomyTermAudienceNonBeneficiaries,
@@ -39,7 +34,7 @@ export type ParagraphTypes =
   | ParagraphListOfLinks
   | ParagraphNonReusableAlert
   | ParagraphPhoneNumber
-  | ParagraphQAGroup
+  | ParagraphQaGroup
   | ParagraphReactWidget
   | ParagraphRichTextCharLimit1000
   | ParagraphServiceLocation
@@ -161,16 +156,21 @@ export interface ParagraphPhoneNumber extends DrupalParagraph {
   field_phone_number_type: string
 }
 
-export interface ParagraphQAGroup extends DrupalParagraph {
-  field_accordion_display: boolean
-  field_q_as: NodeQA[]
-  field_section_header: string
-}
-
 export interface ParagraphQA extends DrupalParagraph {
   field_answer: DrupalParagraph[]
   field_question: string
   type: string
+}
+
+export interface ParagraphQaGroup extends DrupalParagraph {
+  field_accordion_display: boolean
+  field_q_as: ParagraphSectionQas[]
+  field_section_header: string
+}
+
+export interface ParagraphSectionQas {
+  title: string
+  field_answer: ParagraphWysiwyg
 }
 
 export interface ParagraphQaSection extends DrupalParagraph {

--- a/src/types/drupal/paragraph.ts
+++ b/src/types/drupal/paragraph.ts
@@ -1,4 +1,4 @@
-import { DrupalParagraph } from 'next-drupal'
+import { DrupalNode, DrupalParagraph } from 'next-drupal'
 
 import { BlockAlert } from './block'
 import {
@@ -168,7 +168,7 @@ export interface ParagraphQaGroup extends DrupalParagraph {
   field_section_header: string
 }
 
-export interface ParagraphSectionQas {
+export interface ParagraphSectionQas extends DrupalNode {
   title: string
   field_answer: ParagraphWysiwyg
 }

--- a/src/types/drupal/paragraph.ts
+++ b/src/types/drupal/paragraph.ts
@@ -173,6 +173,13 @@ export interface ParagraphQA extends DrupalParagraph {
   type: string
 }
 
+export interface ParagraphQaSection extends DrupalParagraph {
+  field_section_header: string
+  field_accordion_display: boolean
+  field_section_intro: string
+  field_questions: DrupalParagraph[]
+}
+
 export interface ParagraphReactWidget extends DrupalParagraph {
   field_cta_widget: boolean
   field_default_link: FieldLink

--- a/src/types/formatted/qaGroup.ts
+++ b/src/types/formatted/qaGroup.ts
@@ -1,0 +1,15 @@
+import { Wysiwyg as FormattedWysiwyg } from './wysiwyg'
+
+type QaGroupQa = {
+  title: string
+  answer: FormattedWysiwyg
+}
+
+export type QaGroup = {
+  questions: QaGroupQa[]
+  type: string
+  id: string
+  header: string
+  displayAccordion: boolean
+  intro: string
+}

--- a/src/types/formatted/qaGroup.ts
+++ b/src/types/formatted/qaGroup.ts
@@ -1,10 +1,11 @@
-import { Wysiwyg as FormattedWysiwyg } from './wysiwyg'
 import { PublishedParagraph } from './publishedEntity'
 import { FormattedParagraph } from '@/data/queries'
 
 type QaGroupQa = {
-  title: string
-  answer: FormattedParagraph
+  question: string
+  answers: FormattedParagraph[]
+  type: string
+  id: string
 }
 
 export type QaGroup = PublishedParagraph & {

--- a/src/types/formatted/qaGroup.ts
+++ b/src/types/formatted/qaGroup.ts
@@ -1,14 +1,14 @@
 import { Wysiwyg as FormattedWysiwyg } from './wysiwyg'
+import { PublishedParagraph } from './publishedEntity'
+import { FormattedParagraph } from '@/data/queries'
 
 type QaGroupQa = {
   title: string
-  answer: FormattedWysiwyg
+  answer: FormattedParagraph
 }
 
-export type QaGroup = {
+export type QaGroup = PublishedParagraph & {
   questions: QaGroupQa[]
-  type: string
-  id: string
   header: string
   displayAccordion: boolean
   intro: string

--- a/src/types/formatted/qaGroup.ts
+++ b/src/types/formatted/qaGroup.ts
@@ -1,14 +1,16 @@
 import { PublishedParagraph } from './publishedEntity'
 import { FormattedParagraph } from '@/data/queries'
 
-type QaGroupQa = {
+//Todo, this should be removed when the question_answer formatter is complete
+export type QaGroupQa = {
+  type: 'node--q_a'
   question: string
   answers: FormattedParagraph[]
-  type: string
   id: string
 }
 
 export type QaGroup = PublishedParagraph & {
+  type: 'paragraph--q_a_group'
   questions: QaGroupQa[]
   header: string
   displayAccordion: boolean

--- a/src/types/formatted/qaParagraph.ts
+++ b/src/types/formatted/qaParagraph.ts
@@ -1,4 +1,3 @@
-import { FieldFormattedText } from '../drupal/field_type'
 import { FormattedParagraph } from '@/data/queries'
 import { PublishedParagraph } from '@/types/formatted/publishedEntity'
 

--- a/src/types/formatted/qaParagraph.ts
+++ b/src/types/formatted/qaParagraph.ts
@@ -6,4 +6,5 @@ export type QaParagraph = PublishedParagraph & {
   question: string
   answers: FormattedParagraph[]
   type: string
+  setHeaderh3?: boolean
 }

--- a/src/types/formatted/qaParagraph.ts
+++ b/src/types/formatted/qaParagraph.ts
@@ -1,7 +1,9 @@
 import { FieldFormattedText } from '../drupal/field_type'
 import { FormattedParagraph } from '@/data/queries'
+import { PublishedParagraph } from '@/types/formatted/publishedEntity'
 
-export type QaParagraph = {
+export type QaParagraph = PublishedParagraph & {
   question: string
   answers: FormattedParagraph[]
+  type: string
 }

--- a/src/types/formatted/qaSection.ts
+++ b/src/types/formatted/qaSection.ts
@@ -1,12 +1,10 @@
 import { FormattedParagraph } from '@/data/queries'
 import { PublishedParagraph } from './publishedEntity'
-import { HeadingLevel } from './headingElement'
 
 export type QaSection = PublishedParagraph & {
+  type: 'paragraph--q_a_section'
   header: string
   intro: string
   displayAccordion: boolean
   questions: FormattedParagraph[]
-  type: 'paragraph--q_a_section' | 'paragraph--q_a_group'
-  headerTagLevel?: HeadingLevel
 }

--- a/src/types/formatted/qaSection.ts
+++ b/src/types/formatted/qaSection.ts
@@ -1,5 +1,6 @@
 import { FormattedParagraph } from '@/data/queries'
 import { PublishedParagraph } from './publishedEntity'
+import { HeadingLevel } from './headingElement'
 
 export type QaSection = PublishedParagraph & {
   header: string
@@ -8,5 +9,5 @@ export type QaSection = PublishedParagraph & {
   questions: FormattedParagraph[]
   id: string
   type: string
-  headerTagLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  headerTagLevel?: HeadingLevel
 }

--- a/src/types/formatted/qaSection.ts
+++ b/src/types/formatted/qaSection.ts
@@ -8,4 +8,5 @@ export type QaSection = PublishedParagraph & {
   questions: FormattedParagraph[]
   id: string
   type: string
+  headerTagLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
 }

--- a/src/types/formatted/qaSection.ts
+++ b/src/types/formatted/qaSection.ts
@@ -7,7 +7,6 @@ export type QaSection = PublishedParagraph & {
   intro: string
   displayAccordion: boolean
   questions: FormattedParagraph[]
-  id: string
-  type: string
+  type: 'paragraph--q_a_section' | 'paragraph--q_a_group'
   headerTagLevel?: HeadingLevel
 }

--- a/src/types/formatted/qaSection.ts
+++ b/src/types/formatted/qaSection.ts
@@ -1,0 +1,11 @@
+import { FormattedParagraph } from '@/data/queries'
+import { PublishedParagraph } from './publishedEntity'
+
+export type QaSection = PublishedParagraph & {
+  header: string
+  intro: string
+  displayAccordion: boolean
+  questions: FormattedParagraph[]
+  id: string
+  type: string
+}


### PR DESCRIPTION
## Description
issues:
 [#8629](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8629)
[#17322](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17322)

Changes
Adds q_a_section and q_a_group queries/tests/types
adds q_a_section component with tests
adds qaCollapsible panel component with tests
modifies existing qaParagraph component and types slightly

## Testing done
Local Visual
verified components render on R&S pages
## Screenshots
<img width="1077" alt="Screen Shot 2024-03-07 at 10 33 20 AM" src="https://github.com/department-of-veterans-affairs/next-build/assets/61624970/51b5fd08-0976-453b-8bda-b77656d4f32e">
<img width="1077" alt="image" src="https://github.com/department-of-veterans-affairs/next-build/assets/61624970/61baba8c-597f-42e7-aec5-7c4ea2cb65b7">


## QA steps
Verify components render as expected in storybook
Verify QA components render on R&S pages, (ie: http://localhost:3000/resources/creating-an-account-for-vagov/)

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
