### PR TITLE
Normalize CMS banner data for vamc facilities

### DIFF
--- a/src/data/queries/banners.ts
+++ b/src/data/queries/banners.ts
@@ -61,7 +61,16 @@ export const formatter: QueryFormatter<any, BannersData> = (entities) => {
           emailUpdatesButton: banner.field_alert_email_updates_button,
           path: banner.path?.alias,
           findFacilities: banner.field_alert_find_facilities_cta,
-          // bannerAlertVamcs: banner.field_banner_alert_vamcs.url,
+          // Normalizes banner alert data as it can come from api as a single object or array
+          bannerAlertVamcs: []
+            .concat(banner.field_banner_alert_vamcs)
+            .map((vamc) => ({
+              id: vamc.target_id,
+              path: vamc.url,
+              office: {
+                path: vamc.office?.url || null,
+              },
+            })),
           type: banner.type.target_id,
         }
       default:


### PR DESCRIPTION
## Description
Relates to #[17334](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17334).
Vamc data was coming through as either an object or an array.  this normalized the data.

## Testing done


## Screenshots


## QA steps
Verify tugboat builds without error

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
