### PR TITLE
VACMS-17582: Rearchitects query parameters

### DIFF
--- a/src/data/queries/alertSingle.ts
+++ b/src/data/queries/alertSingle.ts
@@ -1,4 +1,5 @@
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { ParagraphAlertSingle } from '@/types/drupal/paragraph'
 import {
   AlertSingle,
@@ -8,52 +9,14 @@ import {
 import { formatParagraph } from '@/lib/drupal/paragraphs'
 import { queries } from '.'
 
-// TODO:
-//
-// EDIT:
-// It seems *maybe* that next-drupal-query is designed to handle this already.
-// You can pass an `id` to queries.getParams().
-// E.g.
-// queries.getParams('paragraph--alert_single'))
-//
-// We don't need this here:
-// export const params: QueryParams<null> = () => {
-//   return new DrupalJsonApiParams()
-//     .addInclude([
-//       'field_alert_block_reference',
-//       'field_alert_block_reference.field_alert_content',
-//       'field_alert_non_reusable_ref',
-//       'field_alert_non_reusable_ref.field_va_paragraphs',
-//     ])
-// }
-//
-// ...but it seems like we might want to define
-// paragraph-specific `includes` within the paragraph's
-// query file (this file), and then somehow reference these in
-// the node query when we need to include fields of a specific
-// paragraph type.
-//
-// E.g.
-// export const include = [
-//   'field_alert_block_reference',
-//   'field_alert_block_reference.field_alert_content',
-//   'field_alert_non_reusable_ref',
-//   'field_alert_non_reusable_ref.field_va_paragraphs',
-// ]
-//
-// /* Some util file*/
-// export const getIncludedSubFields = (
-//   parentField: string,
-//   subFields: string[]
-// ) => [parentField, ...subFields.map((subField) => `${parentField}.${subField}`)]
-//
-// /* src/data/queries/resourcesSupport.ts */
-// import { include } from '@/data/queries/alertSingle'
-// export const params: QueryParams<null> = () => {
-//   return new DrupalJsonApiParams().addInclude([
-//     ...getIncludedSubFields('field_alert_single', include)
-//   ])
-// }
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude([
+    'field_alert_block_reference',
+    'field_alert_block_reference.field_alert_content',
+    'field_alert_non_reusable_ref',
+    'field_alert_non_reusable_ref.field_va_paragraphs',
+  ])
+}
 
 export const formatter: QueryFormatter<ParagraphAlertSingle, AlertSingle> = (
   entity: ParagraphAlertSingle

--- a/src/data/queries/audienceTopics.ts
+++ b/src/data/queries/audienceTopics.ts
@@ -1,7 +1,16 @@
 // Define the query params for fetching node--news_story.
 import { ParagraphAudienceTopics } from '@/types/drupal/paragraph'
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
 import { AudienceTopic, AudienceTopics } from '@/types/formatted/audienceTopics'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude([
+    'field_audience_beneficiares',
+    'field_non_beneficiares',
+    'field_topics',
+  ])
+}
 
 const getTagsList = (
   entity: ParagraphAudienceTopics

--- a/src/data/queries/benefitsHubLinks.ts
+++ b/src/data/queries/benefitsHubLinks.ts
@@ -1,6 +1,12 @@
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
 import { NodeLandingPage } from '@/types/drupal/node'
 import { BenefitsHubLink } from '@/types/formatted/benefitsHub'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+
+// Define the query params for fetching node--landing_page.
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude(['field_support_services'])
+}
 
 // Format NodeLandingPage (Benefits Hub) into link teasers.
 export const formatter: QueryFormatter<NodeLandingPage[], BenefitsHubLink[]> = (

--- a/src/data/queries/collapsiblePanel.ts
+++ b/src/data/queries/collapsiblePanel.ts
@@ -1,7 +1,20 @@
 import { ParagraphCollapsiblePanel } from '@/types/drupal/paragraph'
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
 import { CollapsiblePanel } from '@/types/formatted/collapsiblePanel'
 import { formatParagraph } from '@/lib/drupal/paragraphs'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+import { getNestedIncludes } from '@/lib/utils/queries'
+import { PARAGRAPH_RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
+
+// Define the query params for fetching paragraph--collapsible_panel.
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude([
+    ...getNestedIncludes(
+      'field_va_paragraphs',
+      PARAGRAPH_RESOURCE_TYPES.COLLAPSIBLE_PANEL_ITEM
+    ),
+  ])
+}
 
 export const formatter: QueryFormatter<
   ParagraphCollapsiblePanel,

--- a/src/data/queries/collapsiblePanelItem.ts
+++ b/src/data/queries/collapsiblePanelItem.ts
@@ -1,7 +1,13 @@
 import { ParagraphCollapsiblePanelItem } from '@/types/drupal/paragraph'
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
 import { CollapsiblePanelItem } from '@/types/formatted/collapsiblePanel'
 import { formatParagraph } from '@/lib/drupal/paragraphs'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+
+// Define the query params for fetching paragraph--collapsible_panel_item.
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude(['field_va_paragraphs'])
+}
 
 export const formatter: QueryFormatter<
   ParagraphCollapsiblePanelItem,

--- a/src/data/queries/contactInfo.ts
+++ b/src/data/queries/contactInfo.ts
@@ -4,14 +4,20 @@ import { ParagraphContactInformation } from '@/types/drupal/paragraph'
 import { ContactInfo, AdditionalContact } from '@/types/formatted/contactInfo'
 import { queries } from '.'
 import { formatParagraph } from '@/lib/drupal/paragraphs'
+import { getNestedIncludes } from '@/lib/utils/queries'
+import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
-    'field_additional_contact', // can be paragraph--phone_number or paragraph--email_contact
-    'field_contact_default',
-    'field_contact_default.field_office',
-    'field_benefit_hub_contacts',
-    'field_benefit_hub_contacts.field_support_services', // this is the additional contact info for a Benefit Hub, node--support_service
+    'field_additional_contact',
+    ...getNestedIncludes(
+      'field_contact_default',
+      RESOURCE_TYPES.SUPPORT_SERVICES
+    ),
+    ...getNestedIncludes(
+      'field_benefit_hub_contacts',
+      RESOURCE_TYPES.BENEFITS_HUB
+    ),
   ])
 }
 
@@ -25,17 +31,27 @@ export const formatter: QueryFormatter<
     id: entity.id,
     entityId: entity.drupal_internal__id,
     contactType: entity.field_contact_info_switch as ContactInfo['contactType'],
-    defaultContact: {
-      title: entity.field_contact_default.title,
-      value: entity.field_contact_default.field_phone_number,
-      href: entity.field_contact_default.field_link.uri,
-    },
+    defaultContact: queries.formatData(
+      RESOURCE_TYPES.SUPPORT_SERVICES,
+      entity.field_contact_default
+    ),
     additionalContact: formatParagraph(
       entity.field_additional_contact
     ) as AdditionalContact,
-    benefitHubContacts: queries.formatData(
-      'node--support_service',
-      entity.field_benefit_hub_contacts?.field_support_services
-    ),
+
+    //TODO:
+    // This should likely be: `queries.formatData(RESOURCE_TYPES.BENEFITS_HUB, entity.field_benefit_hub_contacts)
+    // since `entity.field_benefit_hub_contacts` will be a reference to a Benefits Hub Landing Page,
+    // but the formatter for Benefits Hub Landing Pages is currently just a "partial"/"teaser" formatter
+    // that doesn't include everything we'd need. That likely needs to be broken into  "full" and "teaser"
+    // files so we have a formatter for each.
+    //
+    // For now, we can drill down into `field_support_services` and pass that to the formatter for
+    // RESOURCE_TYPES.SUPPORT_SERVICE.
+    benefitHubContacts:
+      entity.field_benefit_hub_contacts?.field_support_services.map(
+        (supportService) =>
+          queries.formatData(RESOURCE_TYPES.SUPPORT_SERVICES, supportService)
+      ),
   }
 }

--- a/src/data/queries/contactInfo.ts
+++ b/src/data/queries/contactInfo.ts
@@ -1,18 +1,19 @@
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { ParagraphContactInformation } from '@/types/drupal/paragraph'
 import { ContactInfo, AdditionalContact } from '@/types/formatted/contactInfo'
 import { queries } from '.'
 import { formatParagraph } from '@/lib/drupal/paragraphs'
 
-// export const params: QueryParams<null> = () => {
-//   return new DrupalJsonApiParams().addInclude([
-//     'field_additional_contact', // can be paragraph--phone_number or paragraph--email_contact
-//     'field_contact_default',
-//     'field_contact_default.field_office',
-//     'field_benefit_hub_contacts',
-//     'field_benefit_hub_contacts.field_support_services', // this is the additional contact info for a Benefit Hub, node--support_service
-//   ])
-// }
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude([
+    'field_additional_contact', // can be paragraph--phone_number or paragraph--email_contact
+    'field_contact_default',
+    'field_contact_default.field_office',
+    'field_benefit_hub_contacts',
+    'field_benefit_hub_contacts.field_support_services', // this is the additional contact info for a Benefit Hub, node--support_service
+  ])
+}
 
 // paragraph--contact_information is essentially a wrapper paragraph around several other entity references
 export const formatter: QueryFormatter<

--- a/src/data/queries/event.ts
+++ b/src/data/queries/event.ts
@@ -14,11 +14,11 @@ import {
   fetchSingleEntityOrPreview,
 } from '@/lib/drupal/query'
 import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
+import { getNestedIncludes } from '@/lib/utils/queries'
 
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
-    'field_media',
-    'field_media.image',
+    ...getNestedIncludes('field_media', 'media--image'),
     'field_listing',
     'field_administration',
     'field_facility_location',

--- a/src/data/queries/featuredContent.ts
+++ b/src/data/queries/featuredContent.ts
@@ -1,7 +1,12 @@
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { ParagraphFeaturedContent } from '@/types/drupal/paragraph'
 import { FeaturedContent } from '@/types/formatted/featuredContent'
 import { queries } from '.'
+
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude(['field_cta'])
+}
 
 export const formatter: QueryFormatter<
   ParagraphFeaturedContent,

--- a/src/data/queries/headerFooter.ts
+++ b/src/data/queries/headerFooter.ts
@@ -4,6 +4,7 @@ import { Menu, HeaderMegaMenu } from '@/types/drupal/menu'
 import { HeaderFooterData } from '@/types/formatted/headerFooter'
 import { buildHeaderFooterData } from '@/lib/utils/headerFooter'
 import { getMenu } from '@/lib/drupal/query'
+import { getNestedIncludes } from '@/lib/utils/queries'
 
 export type RawHeaderFooterData = {
   footerColumns: Menu
@@ -14,10 +15,7 @@ export type RawHeaderFooterData = {
 // Define extra equery params for fetching header megamenu data. Include referenced promo block data, if present
 export const megaMenuParams: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
-    'field_promo_reference',
-    'field_promo_reference.field_image',
-    'field_promo_reference.field_image.image',
-    'field_promo_reference.field_promo_link',
+    ...getNestedIncludes('field_promo_reference', 'block_content--promo'),
   ])
 }
 

--- a/src/data/queries/healthServices.ts
+++ b/src/data/queries/healthServices.ts
@@ -3,7 +3,14 @@ import {
   HealthService as FormattedHealthService,
   HealthServices as FormattedHealthServices,
 } from '@/types/formatted/healthServices'
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude([
+    'field_service_name_and_descripti',
+  ])
+}
 
 export const formatter: QueryFormatter<
   FieldHealthServicesArray,

--- a/src/data/queries/index.ts
+++ b/src/data/queries/index.ts
@@ -109,6 +109,13 @@ export const QUERIES_MAP = {
   'vamc-ehr': VamcEhr,
 }
 
+// All resource types that have a `params` function defined
+export type ParamsType = {
+  [K in keyof typeof QUERIES_MAP]: 'params' extends keyof (typeof QUERIES_MAP)[K]
+    ? K
+    : never
+}[keyof typeof QUERIES_MAP]
+
 // All resource types that have a `data` function defined
 export type QueryableType = {
   [K in keyof typeof QUERIES_MAP]: 'data' extends keyof (typeof QUERIES_MAP)[K]

--- a/src/data/queries/newsStory.ts
+++ b/src/data/queries/newsStory.ts
@@ -9,12 +9,12 @@ import {
   fetchSingleEntityOrPreview,
 } from '@/lib/drupal/query'
 import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
+import { getNestedIncludes } from '@/lib/utils/queries'
 
 // Define the query params for fetching node--news_story.
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
-    'field_media',
-    'field_media.image',
+    ...getNestedIncludes('field_media', 'media--image'),
     'field_author',
     'field_listing',
     'field_administration',

--- a/src/data/queries/newsStoryTeaser.ts
+++ b/src/data/queries/newsStoryTeaser.ts
@@ -3,12 +3,12 @@ import { queries } from '.'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { NodeNewsStory } from '@/types/drupal/node'
 import { NewsStoryTeaser } from '@/types/formatted/newsStory'
+import { getNestedIncludes } from '@/lib/utils/queries'
 
 // Define the query params for fetching node--news_story.
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
-    'field_media',
-    'field_media.image',
+    ...getNestedIncludes('field_media', 'media--image'),
     'field_listing',
   ])
 }

--- a/src/data/queries/promoBlock.ts
+++ b/src/data/queries/promoBlock.ts
@@ -8,12 +8,12 @@ import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { BlockPromo } from '@/types/drupal/block'
 import { MegaMenuPromoColumn } from '@/types/formatted/headerFooter'
+import { getNestedIncludes } from '@/lib/utils/queries'
 
 // Define the query params for fetching block_content--promo.
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
-    'field_image',
-    'field_image.image',
+    ...getNestedIncludes('field_image', 'media--image'),
     'field_promo_link',
   ])
 }

--- a/src/data/queries/qaGroup.ts
+++ b/src/data/queries/qaGroup.ts
@@ -1,8 +1,18 @@
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
 import { ParagraphQaGroup } from '@/types/drupal/paragraph'
 import { QaGroup } from '@/types/formatted/qaGroup'
 import { QaGroupQa } from '@/types/formatted/qaGroup'
 import { formatParagraph } from '@/lib/drupal/paragraphs'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+import { getNestedIncludes } from '@/lib/utils/queries'
+import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
+
+// Define the query params for fetching paragraph--q_a_group.
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude([
+    ...getNestedIncludes('field_q_as', RESOURCE_TYPES.QA),
+  ])
+}
 
 export const formatter: QueryFormatter<ParagraphQaGroup, QaGroup> = (
   entity: ParagraphQaGroup

--- a/src/data/queries/resourcesSupport.ts
+++ b/src/data/queries/resourcesSupport.ts
@@ -30,11 +30,10 @@ export const params: QueryParams<null> = () => {
     // buttons
     'field_buttons',
     // content blocks (main content)
-    'field_content_block',
-    'field_content_block.field_q_as',
-    'field_content_block.field_q_as.field_answer',
-    'field_content_block.field_va_paragraphs',
-    'field_content_block.field_va_paragraphs.field_va_paragraphs',
+    ...getNestedIncludes('field_content_block', [
+      PARAGRAPH_RESOURCE_TYPES.COLLAPSIBLE_PANEL,
+      PARAGRAPH_RESOURCE_TYPES.QA_GROUP,
+    ]),
     // tags
     ...getNestedIncludes(
       'field_tags',

--- a/src/data/queries/resourcesSupport.ts
+++ b/src/data/queries/resourcesSupport.ts
@@ -8,22 +8,25 @@ import {
 } from '@/lib/drupal/query'
 import { NodeSupportResourcesDetailPage } from '@/types/drupal/node'
 import { ResourcesSupport } from '@/types/formatted/resourcesSupport'
-import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
+import {
+  PARAGRAPH_RESOURCE_TYPES,
+  RESOURCE_TYPES,
+} from '@/lib/constants/resourceTypes'
 import { formatParagraph } from '@/lib/drupal/paragraphs'
 import { AlertSingle } from '@/types/formatted/alert'
 import { ContactInfo } from '@/types/formatted/contactInfo'
 import { Button } from '@/types/formatted/button'
 import { AudienceTopics } from '@/types/formatted/audienceTopics'
+import { getNestedIncludes } from '@/lib/utils/queries'
 
 // Define the query params for fetching node--news_story.
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
     // alert
-    'field_alert_single',
-    'field_alert_single.field_alert_block_reference',
-    'field_alert_single.field_alert_block_reference.field_alert_content',
-    'field_alert_single.field_alert_non_reusable_ref',
-    'field_alert_single.field_alert_non_reusable_ref.field_va_paragraphs',
+    ...getNestedIncludes(
+      'field_alert_single',
+      PARAGRAPH_RESOURCE_TYPES.ALERT_SINGLE
+    ),
     // buttons
     'field_buttons',
     // content blocks (main content)
@@ -33,20 +36,19 @@ export const params: QueryParams<null> = () => {
     'field_content_block.field_va_paragraphs',
     'field_content_block.field_va_paragraphs.field_va_paragraphs',
     // tags
-    'field_tags',
-    'field_tags.field_audience_beneficiares',
-    'field_tags.field_non_beneficiares',
-    'field_tags.field_topics',
+    ...getNestedIncludes(
+      'field_tags',
+      PARAGRAPH_RESOURCE_TYPES.AUDIENCE_TOPICS
+    ),
     // related information
     'field_related_information',
     // related benefit hubs
     'field_related_benefit_hubs',
     // contact information
-    'field_contact_information',
-    'field_contact_information.field_additional_contact',
-    'field_contact_information.field_benefit_hub_contacts',
-    'field_contact_information.field_benefit_hub_contacts.field_support_services',
-    'field_contact_information.field_contact_default',
+    ...getNestedIncludes(
+      'field_contact_information',
+      PARAGRAPH_RESOURCE_TYPES.CONTACT_INFORMATION
+    ),
   ])
 }
 

--- a/src/data/queries/supportServices.ts
+++ b/src/data/queries/supportServices.ts
@@ -1,22 +1,26 @@
-import { QueryFormatter } from 'next-drupal-query'
+import { QueryFormatter, QueryParams } from 'next-drupal-query'
 import { NodeSupportService } from '@/types/drupal/node'
 import { Contact } from '@/types/formatted/contactInfo'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+
+// Define the query params for fetching node--support_service.
+export const params: QueryParams<null> = () => {
+  return new DrupalJsonApiParams().addInclude(['field_office'])
+}
 
 // takes an array of Support Services and returns them for contact info
-export const formatter: QueryFormatter<NodeSupportService[], Contact[]> = (
-  entities: NodeSupportService[]
+export const formatter: QueryFormatter<NodeSupportService, Contact> = (
+  entity: NodeSupportService
 ) => {
-  if (!entities) return null
+  if (!entity) return null
 
-  return entities.map((entity) => {
-    if (entity.status) {
-      return {
-        title: entity.title,
-        value: entity.field_phone_number,
-        href: entity.field_link.uri,
-      }
-    } else {
-      return null
+  if (entity.status) {
+    return {
+      title: entity.title,
+      value: entity.field_phone_number,
+      href: entity.field_link.uri,
     }
-  })
+  } else {
+    return null
+  }
 }

--- a/src/data/queries/tests/__snapshots__/contactInfo.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/contactInfo.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ContactInfo formatData outputs formatted data 1`] = `
     "label": "Loremipsum label here",
     "type": "paragraph--email_contact",
   },
-  "benefitHubContacts": null,
+  "benefitHubContacts": undefined,
   "contactType": "DC",
   "defaultContact": {
     "href": "tel:1-800-698-2411",

--- a/src/data/queries/vetCenter.ts
+++ b/src/data/queries/vetCenter.ts
@@ -1,5 +1,5 @@
 import { QueryData, QueryFormatter, QueryParams } from 'next-drupal-query'
-
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { queries } from '.'
 import { NodeVetCenter } from '@/types/drupal/node'
 import { VetCenter as FormattedVetCenter } from '@/types/formatted/vetCenter'
@@ -16,21 +16,23 @@ import {
 import { FeaturedContent } from '@/types/formatted/featuredContent'
 import { Button } from '@/types/formatted/button'
 import { Wysiwyg } from '@/types/formatted/wysiwyg'
+import { getNestedIncludes } from '@/lib/utils/queries'
 
 // Define the query params for fetching node--vet_center.
 export const params: QueryParams<null> = () => {
-  return queries
-    .getParams()
-    .addInclude([
-      'field_media',
-      'field_media.image',
-      'field_administration',
-      'field_prepare_for_visit',
+  return new DrupalJsonApiParams().addInclude([
+    ...getNestedIncludes('field_media', 'media--image'),
+    'field_administration',
+    'field_prepare_for_visit',
+    ...getNestedIncludes(
       'field_vet_center_feature_content',
-      'field_vet_center_feature_content.field_cta',
+      PARAGRAPH_RESOURCE_TYPES.FEATURED_CONTENT
+    ),
+    ...getNestedIncludes(
       'field_health_services',
-      'field_health_services.field_service_name_and_descripti',
-    ])
+      RESOURCE_TYPES.HEALTH_SERVICES
+    ),
+  ])
 }
 
 // Define the option types for the data loader.

--- a/src/lib/utils/queries.test.ts
+++ b/src/lib/utils/queries.test.ts
@@ -1,0 +1,37 @@
+import { ParamsType } from '@/data/queries'
+import { getNestedIncludes } from './queries'
+
+jest.mock('@/data/queries', () => ({
+  queries: {
+    getParams: jest.fn().mockReturnValue({
+      getQueryObject: () => ({
+        include: 'field_a,field_b',
+      }),
+    }),
+  },
+}))
+
+describe('getNestedIncludes', () => {
+  describe('fieldName is provided', () => {
+    test('should return included fields prepended with fieldName', () => {
+      const result = getNestedIncludes(
+        'some_field',
+        'mock_param_type' as ParamsType
+      )
+
+      expect(result).toStrictEqual([
+        'some_field',
+        'some_field.field_a',
+        'some_field.field_b',
+      ])
+    })
+  })
+
+  describe('fieldName is not provided', () => {
+    test('should return included fields as is', () => {
+      const result = getNestedIncludes(null, 'mock_param_type' as ParamsType)
+
+      expect(result).toStrictEqual(['field_a', 'field_b'])
+    })
+  })
+})

--- a/src/lib/utils/queries.test.ts
+++ b/src/lib/utils/queries.test.ts
@@ -25,6 +25,21 @@ describe('getNestedIncludes', () => {
         'some_field.field_b',
       ])
     })
+
+    test('ParamsType is an array', () => {
+      const result = getNestedIncludes('some_field', [
+        'mock_param_type_1' as ParamsType,
+        'mock_param_type_2' as ParamsType,
+      ])
+
+      expect(result).toStrictEqual([
+        'some_field',
+        'some_field.field_a',
+        'some_field.field_b',
+        'some_field.field_a',
+        'some_field.field_b',
+      ])
+    })
   })
 
   describe('fieldName is not provided', () => {
@@ -32,6 +47,15 @@ describe('getNestedIncludes', () => {
       const result = getNestedIncludes(null, 'mock_param_type' as ParamsType)
 
       expect(result).toStrictEqual(['field_a', 'field_b'])
+    })
+
+    test('ParamsType is an array', () => {
+      const result = getNestedIncludes(null, [
+        'mock_param_type_1' as ParamsType,
+        'mock_param_type_2' as ParamsType,
+      ])
+
+      expect(result).toStrictEqual(['field_a', 'field_b', 'field_a', 'field_b'])
     })
   })
 })

--- a/src/lib/utils/queries.ts
+++ b/src/lib/utils/queries.ts
@@ -1,0 +1,20 @@
+import { queries, ParamsType } from '@/data/queries'
+
+export const getNestedIncludes = (
+  fieldName: string,
+  resourceType: ParamsType
+) => {
+  const includedFields = queries
+    .getParams(resourceType)
+    .getQueryObject()
+    .include.split(',')
+
+  return fieldName
+    ? [
+        fieldName,
+        ...includedFields.map(
+          (includedField) => `${fieldName}.${includedField}`
+        ),
+      ]
+    : includedFields
+}

--- a/src/lib/utils/queries.ts
+++ b/src/lib/utils/queries.ts
@@ -2,12 +2,15 @@ import { queries, ParamsType } from '@/data/queries'
 
 export const getNestedIncludes = (
   fieldName: string,
-  resourceType: ParamsType
+  resourceType: ParamsType | ParamsType[]
 ) => {
-  const includedFields = queries
-    .getParams(resourceType)
-    .getQueryObject()
-    .include.split(',')
+  const resourceTypes = Array.isArray(resourceType)
+    ? resourceType
+    : [resourceType]
+
+  const includedFields = resourceTypes.flatMap((resourceType) =>
+    queries.getParams(resourceType).getQueryObject().include.split(',')
+  )
 
   return fieldName
     ? [


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17582

There was this `TODO` in [src/data/queries/alertSingle.ts](https://github.com/department-of-veterans-affairs/next-build/blob/a10b0ff1f9bab4e796d6774b073c473cd2370774/src/data/queries/alertSingle.ts#L11-L57). This PR implements a solution to this.

```
// TODO:
//
// EDIT:
// It seems *maybe* that next-drupal-query is designed to handle this already.
// You can pass an `id` to queries.getParams().
// E.g.
// queries.getParams('paragraph--alert_single'))
//
// We don't need this here:
// export const params: QueryParams<null> = () => {
//   return new DrupalJsonApiParams()
//     .addInclude([
//       'field_alert_block_reference',
//       'field_alert_block_reference.field_alert_content',
//       'field_alert_non_reusable_ref',
//       'field_alert_non_reusable_ref.field_va_paragraphs',
//     ])
// }
//
// ...but it seems like we might want to define
// paragraph-specific `includes` within the paragraph's
// query file (this file), and then somehow reference these in
// the node query when we need to include fields of a specific
// paragraph type.
//
// E.g.
// export const include = [
//   'field_alert_block_reference',
//   'field_alert_block_reference.field_alert_content',
//   'field_alert_non_reusable_ref',
//   'field_alert_non_reusable_ref.field_va_paragraphs',
// ]
//
// /* Some util file*/
// export const getIncludedSubFields = (
//   parentField: string,
//   subFields: string[]
// ) => [parentField, ...subFields.map((subField) => `${parentField}.${subField}`)]
//
// /* src/data/queries/resourcesSupport.ts */
// import { include } from '@/data/queries/alertSingle'
// export const params: QueryParams<null> = () => {
//   return new DrupalJsonApiParams().addInclude([
//     ...getIncludedSubFields('field_alert_single', include)
//   ])
// }
```

Briefly, the goal is to remove the need for engineers writing page-level queries to need to understand the inner details of content that is included. For example:

A Resources-and-Support page has a field `field_alert_single`. This field references a `paragraph--alert_single`. Prior to this PR, the query to build this type of page needed to include this:
```
    'field_alert_single',
    'field_alert_single.field_alert_block_reference',
    'field_alert_single.field_alert_block_reference.field_alert_content',
    'field_alert_single.field_alert_non_reusable_ref',
    'field_alert_single.field_alert_non_reusable_ref.field_va_paragraphs',
```

But all those included fields are really an implementation detail of the `paragraph`, so requiring the R&S node query to know these details is not good architecture, and puts undue burden on the engineers tasked with building these page-level queries like R&S. This isn't even to mention, if that paragraph structure ever changed, we'd have to update _every_ query that repeated this structure. So, now, after this PR, this is what can be used instead:

```
    ...getNestedIncludes(
      'field_alert_single',
      PARAGRAPH_RESOURCE_TYPES.ALERT_SINGLE
    ),
```

Now, the page-level node query (R&S in this case) doesn't need to know anything about the paragraph. It can simply say, "give me the data for this paragraph found at this field."

## Testing done/QA


## Screenshots

