### PR TITLE
Update content-release trigger

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -8,7 +8,7 @@ on:
   repository_dispatch:
     types: [content-release]
   workflow_run:
-    workflows: ['Continuous Integration']
+    workflows: ['Create Production Tag']
     types: [completed]
     branches: [main]
 


### PR DESCRIPTION
## Description
Relates to https://dsva.slack.com/archives/C01SR56755H/p1712162234520889

Change the content-release workflow to start after a new production tag is created instead of CI pass

## Testing done


## Screenshots


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```