### PR TITLE
missed a require statement

### DIFF
--- a/.github/workflows/fetch-latest-release/index.js
+++ b/.github/workflows/fetch-latest-release/index.js
@@ -1,5 +1,5 @@
-const core = require('@actions/core')
-const github = require('@actions/github')
+import core from '@actions/core'
+import github from '@actions/github'
 
 const customRepo = (repoPath) => {
   const segments = repoPath.split('/', 2)


### PR DESCRIPTION
## Description
Relates to #498 

missed a require statement that was hidden in github actions 🤦 

failed the content release workflow because of it: https://github.com/department-of-veterans-affairs/next-build/actions/runs/8654524837


## Testing done


## Screenshots


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
