### PR TITLE
use generateBuildId

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,6 +19,12 @@ const nextConfig = {
   experimental: {
     largePageDataBytes: 512 * 1000, // 512kb, is 128kb by default
   },
+  // This ensures the generated files use a consistent hash inside of the generated `.next/` directory.
+  // Necessary in order for correct asset references in various locations (S3 static files, cms preview server, etc)
+  generateBuildId: async () => {
+    // this could be anything, use latest git hash if it exists
+    return process.env.GIT_HASH ?? 'vagovprod'
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Description
Relates to https://dsva.slack.com/archives/C01SR56755H/p1713378034155279?thread_ts=1713369389.668769&cid=C01SR56755H

Without the `generateBuildId` key in next.config, the hash of the generated files changes each run. This is fine in theory, but in practice it means that when the content-release workflow runs and pushes files to S3, the location of some objects is different than when say, the CMS Preview Server is built inside of docker. It requests to the S3 bucket correctly via the `NEXT_PUBLIC_ASSETS_URL` environment var, but the hash it wants for certain assets at that URL is different.

## Testing done
Locally, I ran `yarn build --no-USE_REDIS` and `yarn build:preview`, confirmed that the hashes changed per run.

After setting the `generateBuildId` config option, the files were output with the same hash regardless of command run.

## Screenshots
`yarn build` hashes, before:
<img width="294" alt="Screenshot 2024-04-17 at 12 38 40 PM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/6c38a82e-a4d4-48cb-b222-8e5c833eed7a">
<img width="288" alt="Screenshot 2024-04-17 at 12 39 20 PM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/0435cb2f-b511-49cc-83a4-864f9e3441d0">

`yarn build:preview` hashes, before:
<img width="296" alt="Screenshot 2024-04-17 at 12 40 27 PM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/c3ba9392-d5e0-418e-817e-9281300292e9">
<img width="293" alt="Screenshot 2024-04-17 at 12 40 47 PM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/5ed78be7-1e98-42ba-b457-791a380a4b5d">

So the second set of hashes (inside `pages/`) appeared to be the same, but the first hash (containing `_buildManifest.js` and `_ssgManifest.js`) changed.

After setting `generateBuildId` and running both commands, the output appeared to be identical in the same location:
<img width="292" alt="Screenshot 2024-04-17 at 12 42 45 PM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/e98bbbbd-95b9-4d3b-857f-c41fc3ac7347">
<img width="286" alt="Screenshot 2024-04-17 at 12 42 55 PM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/e8b2110f-71a3-4a8e-91a4-5d9c8a81484a">
<img width="296" alt="Screenshot 2024-04-17 at 12 43 25 PM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/ae96dfb0-ff60-4267-a645-57ee0d70be8f">
<img width="291" alt="Screenshot 2024-04-17 at 12 43 32 PM" src="https://github.com/department-of-veterans-affairs/next-build/assets/11279744/457e35f5-c863-4421-b92a-ea0717273c5d">


## QA steps
This may need to be tested after merge, so that the content-release + mirror images workflows can run to see if the CMS preview servers pick up the updated locations.


```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```
