### PR TITLE
stub link test

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "chalk": "^5.3.0",
     "clsx": "^2.1.0",
     "commander": "^12.0.0",
-    "cross-fetch": "^4.0.0",
     "debug": "^4.3.4",
     "drupal-jsonapi-params": "^2.3.1",
     "env-loader": "0.1.0",

--- a/packages/proxy-fetcher/src/index.ts
+++ b/packages/proxy-fetcher/src/index.ts
@@ -6,9 +6,10 @@ export const getFetcher =
   async (input: RequestInfo, init: RequestInit = {}) => {
     const url = new URL(baseUrl)
     const host = url.host
+
     // CI envs don't need the SOCKS proxy.
     const useProxy =
-      host.match(/cms\.va\.gov$/) &&
+      (host.match(/cms\.va\.gov$/) || host.match(/vfs\.va\.gov$/)) &&
       (process.env.APP_ENV === 'local' ||
         typeof process.env.APP_ENV === 'undefined')
     const syswideCas = await import('syswide-cas')

--- a/scripts/broken-links-slack-payload.js
+++ b/scripts/broken-links-slack-payload.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import fs from 'fs'
-import core from '@actions/core'
 import { program } from 'commander'
 
 const DEFAULT_INPUT_FILE = 'broken-links-report.json'

--- a/scripts/test-links.js
+++ b/scripts/test-links.js
@@ -1,0 +1,17 @@
+/* eslint-disable no-console */
+import { getFetcher } from 'proxy-fetcher'
+import { getSitemapLocations } from '../test/getSitemapLocations.js'
+
+const SITE_URL = process.env.SITE_URL || 'http://www.va.gov/'
+const allPaths = await getSitemapLocations(SITE_URL)
+
+const debug = process.env.DEBUG || process.env.VERBOSE
+const fetcher = getFetcher(SITE_URL, debug)
+
+const slim = allPaths.slice(0, 100)
+
+slim.forEach(async (path) => {
+  const response = await fetcher(path)
+
+  console.log(response.status)
+})

--- a/test/getSitemapLocations.js
+++ b/test/getSitemapLocations.js
@@ -1,5 +1,4 @@
 import { getFetcher } from 'proxy-fetcher'
-import crossFetch from 'cross-fetch'
 
 // Given an .xml file, extracts every string inside a <loc> element.
 function extractUrlsFromXML(xml) {
@@ -15,8 +14,8 @@ function extractUrlsFromXML(xml) {
 
 // Gets all URLs included in the output from `yarn build:sitemap` from all sitemaps
 export async function getSitemapLocations(baseUrl) {
-  const fetcher =
-    process.env.USE_PROXY === true ? getFetcher(baseUrl) : crossFetch
+  const debug = process.env.DEBUG || process.env.VERBOSE
+  const fetcher = getFetcher(baseUrl, debug)
   // handle trailing slash
   const base = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl
   const mainSitemapUrl = `${base}/sitemap.xml`

--- a/yarn.lock
+++ b/yarn.lock
@@ -12724,7 +12724,6 @@ __metadata:
     chalk: ^5.3.0
     clsx: ^2.1.0
     commander: ^12.0.0
-    cross-fetch: ^4.0.0
     debug: ^4.3.4
     drupal-jsonapi-params: ^2.3.1
     env-loader: 0.1.0


### PR DESCRIPTION
## Description
Relates to https://dsva.slack.com/archives/C01SR56755H/p1713986665887349


## Testing done
run `yarn tsc -b ./packages/proxy-fetcher/tsconfig.json` to compile updates to proxy-fetcher (there was an actual bug here, we only targeted `.cms.va.gov` endpoints, not `.vfs.va.gov`)

run `SITE_URL="https://main-kqjsor0i3mjdwsy9gojxhhyvdzh0wubb.tugboat.vfs.va.gov/" node ./scripts/test-links.js`

SITE_URL can be any valid link that has a sitemap.

## Screenshots

```
SITE_URL="https://main-kqjsor0i3mjdwsy9gojxhhyvdzh0wubb.tugboat.vfs.va.gov/" node ./scripts/test-links.js
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
200
```


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

```[tasklist]
- [ ] Automated tests have passed
- [ ] Tugboat environment was generated without errors
```

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:
