### PR TITLE
Add workflow dispatch trigger to content release.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -11,6 +11,7 @@ on:
     workflows: ['Create Production Tag']
     types: [completed]
     branches: [main]
+  workflow_dispatch:
 
 env:
   SLACK_CHANNEL: C06DSBT7CBW #status-next-build


### PR DESCRIPTION
## Description
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18046

This simply adds a manual `workflow_dispatch` to the Content Release workflow. This is temporary; it will be used to facilitate development and testing for Content Release in the ticket above.

