### PR TITLE
Change envs to work with the revproxy

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -132,7 +132,9 @@ jobs:
       # Certs added for the self hosted runner
       env:
         NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
-        APP_ENV: prod
+        APP_ENV: ${{ inputs.build_type }}
+         
+
       ports:
         - 80
       volumes:
@@ -147,8 +149,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: department-of-veterans-affairs/next-build
-        ref: ${{ needs.validate-build-status.outputs.TAG }}
-        path: main
+        #ref: ${{ needs.validate-build-status.outputs.TAG }}
+        path: ${{ github.head_ref || github.ref_name }}
+        sparse-checkout-cone-mode: false
 
     - name: Checkout vets-website
       uses: actions/checkout@v4
@@ -193,7 +196,8 @@ jobs:
         retry_on: error
         timeout_minutes: 30
         command: echo YARN_OUTPUT=$(cd main && yarn export --DRUPAL_CLIENT_ID ${{ secrets.PROD_DRUPAL_CLIENT_ID }} --DRUPAL_CLIENT_SECRET ${{ secrets.PROD_DRUPAL_CLIENT_SECRET }} --no-USE_REDIS) >> $GITHUB_OUTPUT
-
+        #command: cd main && yarn export --NEXT_PUBLIC_DRUPAL_BASE_URL https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov --NEXT_IMAGE_DOMAIN https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov --SITE_URL https://www.va.gov --DRUPAL_CLIENT_ID  ${{ secrets.PROD_DRUPAL_CLIENT_ID }} --DRUPAL_CLIENT_SECRET ${{ secrets.PROD_DRUPAL_CLIENT_SECRET }} --no-USE_REDIS
+    
     - name: Build sitemap
       run: cd main && yarn build:sitemap
 

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -150,7 +150,8 @@ jobs:
       with:
         repository: department-of-veterans-affairs/next-build
         #ref: ${{ needs.validate-build-status.outputs.TAG }}
-        path: ${{ github.head_ref || github.ref_name }}
+        ref: ${{ github.head_ref || github.ref_name }}
+        path: main
         sparse-checkout-cone-mode: false
 
     - name: Checkout vets-website

--- a/envs/.env.dev
+++ b/envs/.env.dev
@@ -4,7 +4,7 @@ NEXT_IMAGE_DOMAIN=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.
 
 # Prod bucket for vets-website assets
 # NEXT_PUBLIC_ASSETS_URL=https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/
-NEXT_PUBLIC_ASSETS_URL=https://s3-us-gov-west-1.amazonaws.com/next-content.dev.va.gov/generated/
+NEXT_PUBLIC_ASSETS_URL=/generated/
 SITE_URL=https://www.va.gov
 
 # for Drupal preview

--- a/envs/.env.dev
+++ b/envs/.env.dev
@@ -4,8 +4,7 @@ NEXT_IMAGE_DOMAIN=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.
 
 # Prod bucket for vets-website assets
 # NEXT_PUBLIC_ASSETS_URL=https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/
-NEXT_PUBLIC_ASSETS_URL=http://next-content.dev.va.gov.s3-website-us-gov-west-1.amazonaws.com/generated/
-
+NEXT_PUBLIC_ASSETS_URL=https://s3-us-gov-west-1.amazonaws.com/next-content.dev.va.gov/generated/
 SITE_URL=https://www.va.gov
 
 # for Drupal preview

--- a/envs/.env.dev
+++ b/envs/.env.dev
@@ -1,0 +1,19 @@
+# This is the standard lower environment for Content API.
+NEXT_PUBLIC_DRUPAL_BASE_URL=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
+NEXT_IMAGE_DOMAIN=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
+
+# Prod bucket for vets-website assets
+# NEXT_PUBLIC_ASSETS_URL=https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/
+NEXT_PUBLIC_ASSETS_URL=http://next-content.dev.va.gov.s3-website-us-gov-west-1.amazonaws.com/generated/
+
+SITE_URL=https://www.va.gov
+
+# for Drupal preview
+DRUPAL_PREVIEW_SECRET=secret
+# store these securely in the build pipeline env
+#DRUPAL_CLIENT_ID=Retrieve this from AWS SSM /cms/consumers/next-build/client_id
+#DRUPAL_CLIENT_SECRET=Retrieve this from AWS SSM /cms/consumers/next-build/client_secret
+
+# Google Analytics
+# These print directly to the page so do not need to store in SSM.
+NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD

--- a/envs/.env.prod
+++ b/envs/.env.prod
@@ -4,7 +4,7 @@ NEXT_IMAGE_DOMAIN=https://prod.cms.va.gov
 
 # Prod bucket for vets-website assets
 # NEXT_PUBLIC_ASSETS_URL=https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/
-NEXT_PUBLIC_ASSETS_URL=/next-content.www.va.gov/generated/
+NEXT_PUBLIC_ASSETS_URL=http://next-content.www.va.gov.s3-website-us-gov-west-1.amazonaws.com
 
 SITE_URL=https://www.va.gov
 

--- a/envs/.env.prod
+++ b/envs/.env.prod
@@ -4,8 +4,7 @@ NEXT_IMAGE_DOMAIN=https://prod.cms.va.gov
 
 # Prod bucket for vets-website assets
 # NEXT_PUBLIC_ASSETS_URL=https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/
-NEXT_PUBLIC_ASSETS_URL=http://next-content.www.va.gov.s3-website-us-gov-west-1.amazonaws.com
-
+NEXT_PUBLIC_ASSETS_URL=/generated/
 SITE_URL=https://www.va.gov
 
 # for Drupal preview

--- a/envs/.env.staging
+++ b/envs/.env.staging
@@ -2,8 +2,7 @@
 NEXT_PUBLIC_DRUPAL_BASE_URL=https://staging.cms.va.gov/
 NEXT_IMAGE_DOMAIN=https://staging.cms.va.gov/
 
-NEXT_PUBLIC_ASSETS_URL=/generated/
-
+NEXT_PUBLIC_ASSETS_URL=http://next-content.staging.va.gov.s3-website-us-gov-west-1.amazonaws.com/
 # for Drupal preview
 DRUPAL_PREVIEW_SECRET=secret
 # store these securely in the build pipeline env

--- a/envs/.env.staging
+++ b/envs/.env.staging
@@ -2,7 +2,7 @@
 NEXT_PUBLIC_DRUPAL_BASE_URL=https://staging.cms.va.gov/
 NEXT_IMAGE_DOMAIN=https://staging.cms.va.gov/
 
-NEXT_PUBLIC_ASSETS_URL=http://next-content.staging.va.gov.s3-website-us-gov-west-1.amazonaws.com/
+NEXT_PUBLIC_ASSETS_URL=/generated/
 # for Drupal preview
 DRUPAL_PREVIEW_SECRET=secret
 # store these securely in the build pipeline env


### PR DESCRIPTION
## Description
Change our environments to point to /genereated to support all platforms in order to get stylesheets to work. Also added a dev envrionment. Add support for testing code on any branch rather than a specific tag. Add change for app_env to actually specify targeted build location


## Testing done
I used content release to push built pages to dev. I went to dev.va.gov and this code in combination with the previous changes made in vsp-reverse-proxy I was able to prove that outreach and events worked where before it failed to load styles. 