### PR TITLE
remove incorrect build type and instead run 2 builds

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -235,17 +235,6 @@ jobs:
       env:
         SRC: ./out/
         DEST: s3://next-content.www.va.gov
-    
-    - if: inputs.build_type =='stgprod'
-      name: Deploy to staging and prod
-      run: | 
-        cd main 
-        ./scripts/github-actions/deploy.sh -s $SRC -d $DEST -v
-        ./scripts/github-actions/deploy.sh -s $SRC -d $DEST2 -v
-      env:
-        SRC: ./out/
-        DEST: s3://next-content.staging.va.gov
-        DEST2: s3://next-content.dev.va.gov
       
     - name: Export deploy end time
       id: export-deploy-end-time

--- a/.github/workflows/release-on-push.yml
+++ b/.github/workflows/release-on-push.yml
@@ -6,10 +6,14 @@ on:
     workflow_dispatch:
     
 jobs:
-    content-release:
+    content-release-prod:
         uses: department-of-veterans-affairs/next-build/.github/workflows/content-release.yml@main
         with:
-            build_type: "stgprod"
+            build_type: "prod"
         secrets: inherit
-        
+    content-release-staging:
+        uses: department-of-veterans-affairs/next-build/.github/workflows/content-release.yml@main
+        with:
+            build_type: "staging"
+        secrets: inherit
 


### PR DESCRIPTION
## Description
This feature fixes calling "stgprod" for the release on push. It instead does a call to both staging and prod with separate builds. We May want to re-visit doing it this way in order to save time later. 

## Testing done
Rand the workflow from my branch successfully. 

##QA
Push the change and see if when changes are pused to main the build is triggered sucessfully