### PR TITLE
Feat: recurring release on all 'environments'

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -31,7 +31,7 @@ on:
           - prod
 
 concurrency:
-  group: ${{ inputs.build_type }}
+  group: ${{ inputs.build_type || 'prod' }} 
 
 env:
   SLACK_CHANNEL: C06DSBT7CBW #status-next-build
@@ -132,7 +132,7 @@ jobs:
       # Certs added for the self hosted runner
       env:
         NODE_EXTRA_CA_CERTS: /etc/ssl/certs/ca-certificates.crt
-        APP_ENV: ${{ inputs.build_type }}
+        APP_ENV: ${{ inputs.build_type || 'prod' }}
          
 
       ports:
@@ -249,21 +249,13 @@ jobs:
         SRC: ./out/
         DEST: s3://next-content.www.va.gov
     
-    - if: inputs.build_type =='stgprod'
-      name: Deploy to staging and prod
-      run: | 
-        cd main 
-        ./scripts/github-actions/deploy.sh -s $SRC -d $DEST -v
-        ./scripts/github-actions/deploy.sh -s $SRC -d $DEST2 -v
+    - if: inputs.build_type == '' 
+      name: Deploy to S3
+      run: cd main && ./scripts/github-actions/deploy.sh -s $SRC -d $DEST -v
       env:
         SRC: ./out/
-        DEST: s3://next-content.staging.va.gov
-        DEST2: s3://next-content.dev.va.gov
-      
-    - name: Export deploy end time
-      id: export-deploy-end-time
-      run: echo DEPLOY_END_TIME=$(date +"%s") >> $GITHUB_OUTPUT
-
+        DEST: s3://next-content.www.va.gov
+    
   notify-success:
     name: Notify Success
     needs: [validate-build-status, build]
@@ -306,7 +298,7 @@ jobs:
           jq '.tags[0] = "project:vagov"' | \
           jq '.tags[1] = "repo:next-build"' | \
           jq '.tags[2] = "workflow:content-release"' | \
-          jq '.tags[3] = "env:${{ inputs.build_type }}"' | \
+          jq '.tags[3] = "env:${{ inputs.build_type || 'prod' }}"' | \
           jq '.tags[5] = "status:${{needs.build.result}}"' | \
           jq '.alert_type = "success"' > event.json
 
@@ -360,7 +352,7 @@ jobs:
           jq '.tags[0] = "project:vagov"' | \
           jq '.tags[1] = "repo:next-build"' | \
           jq '.tags[2] = "workflow:content-release"' | \
-          jq '.tags[3] = "env:${{ inputs.build_type }}"' | \
+          jq '.tags[3] = "env:${{ inputs.build_type || 'prod' }}"' | \
           jq '.tags[5] = "status:${{needs.build.result}}"' | \
           jq '.alert_type = "error"' > event.json
 
@@ -390,7 +382,7 @@ jobs:
         - name: Set vars for CMS-triggered runs
           if: ${{ github.event_name == 'repository_dispatch' }}
           run: |
-            echo "DEPLOY_ENV=${{ inputs.build_type }}" >> $GITHUB_ENV
+            echo "DEPLOY_ENV=${{ inputs.build_type || 'prod' }}" >> $GITHUB_ENV
             echo "BUILD_TRIGGER=cms" >> $GITHUB_ENV
 
         - name: Calculate durations

--- a/.github/workflows/recurring-release.yml
+++ b/.github/workflows/recurring-release.yml
@@ -12,4 +12,16 @@ jobs:
             build_type: "prod"
         secrets: inherit
         
+    content-release-dev:
+        uses: department-of-veterans-affairs/next-build/.github/workflows/content-release.yml@main
+        with:
+            build_type: "dev"
+        secrets: inherit
+    
+    content-release-staging:
+        uses: department-of-veterans-affairs/next-build/.github/workflows/content-release.yml@main
+        with:
+            build_type: "staging"
+        secrets: inherit
+        
 


### PR DESCRIPTION
Run recurring release for all environments. This is a quick and dirty solution to the problem. We should use the matrix strategy for this in the future but would require heavy logic changes to the content-release workflow. That documentation is here https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs. 

