### PR TITLE
Remove deprecated husky command lines.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 if [ -f "package-lock.json" ]; then
     echo "package-lock.json exists.  Please remove it." >&2
     exit -1


### PR DESCRIPTION
# Description
This very small PR addresses a deprecation warning that has popped up since we moved to husky 9.x:
```
➜ git commit -m "Add 'build all' flag override to test environment."
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

This is per the husky upgrade instructions: https://github.com/typicode/husky/releases/tag/v9.0.1

None of the other upgrade instructions apply to us. 

