### PR TITLE
Debug env vars on prod.

### DIFF
--- a/packages/env-loader/src/cms-feature-flags.ts
+++ b/packages/env-loader/src/cms-feature-flags.ts
@@ -8,6 +8,10 @@ export const getCmsFeatureFlags = async (
   drupalBaseUrl: string,
   debug: boolean = false
 ): Promise<EnvVars> => {
+  // eslint-disable-next-line no-console
+  console.log('about to dump GTM value for debugging.')
+  // eslint-disable-next-line no-console
+  console.log(process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID)
   const fetcher = getFetcher(drupalBaseUrl, debug)
   const featureFlagUrl = `${removeTrailingSlash(drupalBaseUrl)}/flags_list`
   const response = await fetcher(featureFlagUrl)


### PR DESCRIPTION
# Description
Just console logging a value to startup so that we can see if env vars are being loaded correctly.
