### PR TITLE
fix: Fix sitemap so that if all feature flags are disabled, the build dosen't break

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -209,23 +209,31 @@ jobs:
       run: | 
         cd main && yarn build:sitemap
         cd out
-        cp sitemap.xml sitemap-nb.xml 
+        if [ -f sitemap.xml ]; then
+            echo "File found!"
+            cp sitemap.xml sitemap-nb.xml 
+        fi
+        if [! -f sitemap.xml ]; then
+            echo "File Not found!"
+            touch sitemap-nb.xml
+        fi
+
 
         - name: setup bucket descriptor
         id: bucket-descriptor
         run: |
           if [ "${{ inputs.build_type }}" == 'dev' ]; then
-            echo NEXT_SITEMAP_LOCATION="https://s3.us-gov-west-1.amazonaws.com/next-content.dev.va.gov/sitemap-nb.xml" >> $GITHUB_OUTPUT
-            echo OLD_SITEMAP_LOCATION="https://s3.us-gov-west-1.amazonaws.com/content.dev.va.gov/sitemap-cb.xml" >> $GITHUB_OUTPUT
+            echo NEXT_SITEMAP_LOCATION="https://dev.va.gov/sitemap-nb.xml" >> $GITHUB_OUTPUT
+            echo OLD_SITEMAP_LOCATION="https://dev.va.gov/sitemap-cb.xml" >> $GITHUB_OUTPUT
           elif [ "${{ inputs.build_type }}" == 'staging'] ; then
-            echo NEXT_SITEMAP_LOCATION="https://s3.us-gov-west-1.amazonaws.com/next-content.staging.va.gov/sitemap-nb.xml" >> $GITHUB_OUTPUT
-            echo OLD_SITEMAP_LOCATION="https://s3.us-gov-west-1.amazonaws.com/content.staging.va.gov/sitemap-cb.xml" >> $GITHUB_OUTPUT
+            echo NEXT_SITEMAP_LOCATION="https://staging.va.gov/sitemap-nb.xml" >> $GITHUB_OUTPUT
+            echo OLD_SITEMAP_LOCATION="https://staging.va.gov/sitemap-cb.xml" >> $GITHUB_OUTPUT
           elif [ "${{ inputs.build_type }}" == 'prod' ]; then
-            echo NEXT_SITEMAP_LOCATION="https://s3.us-gov-west-1.amazonaws.com/next-content.www.va.gov/sitemap-nb.xml" >> $GITHUB_OUTPUT
-            echo OLD_SITEMAP_LOCATION="https://s3.us-gov-west-1.amazonaws.com/next-content.www.va.gov/sitemap-cb.xml" >> $GITHUB_OUTPUT
+            echo NEXT_SITEMAP_LOCATION="https://www.va.gov/sitemap-nb.xml" >> $GITHUB_OUTPUT
+            echo OLD_SITEMAP_LOCATION="https://www.va.gov/sitemap-cb.xml" >> $GITHUB_OUTPUT
           else
-            echo NEXT_SITEMAP_LOCATION="https://s3.us-gov-west-1.amazonaws.com/next-content.www.va.gov/sitemap-nb.xml" >> $GITHUB_OUTPUT
-            echo OLD_SITEMAP_LOCATION="https://s3.us-gov-west-1.amazonaws.com/next-content.www.va.gov/sitemap-cb.xml" >> $GITHUB_OUTPUT
+            echo NEXT_SITEMAP_LOCATION="https://www.va.gov/sitemap-nb.xml" >> $GITHUB_OUTPUT
+            echo OLD_SITEMAP_LOCATION="https://www.va.gov/sitemap-cb.xml" >> $GITHUB_OUTPUT
           fi
         shell: bash
   


### PR DESCRIPTION

# Description
broken next build sitemap

## Ticket
This is to address a fix to the sitemap config

## Developer Task

```[tasklist]
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [x] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
tested in my local shell and it works as expected 

