### PR TITLE
Disable robots.txt generation.

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -9,7 +9,7 @@ const sitemapConfig = {
   // relative paths to exclude
   exclude: [],
 
-  generateRobotsTxt: true, // (optional)
+  generateRobotsTxt: false, // (optional)
 
   // todo: migrate to server side sitemap to include last edited date from content for lastmod
   // will need to update static-path-resources to optionally include that field when requested


### PR DESCRIPTION
# Description
Currently we output a simple default robots.txt file with the next-sitemap plugin. This PR disables that so that [the existing robots.txt from Content Build](https://www.va.gov/robots.txt) continues to be used. 

## Ticket
#773 , indirectly. This PR does not close that ticket. 

## Developer Task

```[tasklist]
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
1. Go to the admin for the Tugboat instance associated with this PR: https://tugboat.vfs.va.gov/66fdd05e25a4ad7d7601e0bd
2. Enter 'Terminal' for the main web preview. This may take a second if the preview is currently suspended.
3. Run `cd out && ls -al robots.txt`

If the file is not found, **the behavior is correct.** We are removing the file with this PR.

 If you see a file there and it has content like the following (`less robots.txt`), this PR is not passing:
```
# *
User-agent: *
Allow: /

# Host
Host: https://pr768-hrqyjsstuyk6vydpmua8bvdyp6fzfmci.tugboat.vfs.va.gov/

# Sitemaps
Sitemap: https://pr768-hrqyjsstuyk6vydpmua8bvdyp6fzfmci.tugboat.vfs.va.gov/sitemap.xml
```
