### PR TITLE
Check for ongoing recurring events when making date-based event calculations.

### DIFF
--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -246,14 +246,27 @@ describe('formatDateObject', () => {
 })
 
 describe('deriveMostRecentDate', () => {
-  it('should return the closest future event', () => {
-    const mockCurrentTime = new Date('2023-08-01T12:00:00Z').getTime()
+  it('should return the closest future or ongoing event', () => {
+    const mockCurrentTime = new Date('2023-08-01T18:00:00Z').getTime()
     jest.spyOn(Date, 'now').mockImplementation(() => mockCurrentTime)
 
     const datetimeRange = [
-      { value: new Date('2023-07-01T14:00:00Z').getTime() / 1000 }, // Past event
-      { value: new Date('2023-09-01T14:00:00Z').getTime() / 1000 }, // Closest future event
-      { value: new Date('2023-10-01T14:00:00Z').getTime() / 1000 }, // Later future event
+      {
+        value: new Date('2023-07-01T14:00:00Z').getTime() / 1000,
+        endValue: new Date('2023-07-01T16:00:00Z').getTime() / 1000,
+      }, // Past event
+      {
+        value: new Date('2023-08-01T14:00:00Z').getTime() / 1000,
+        endValue: new Date('2023-08-01T19:00:00Z').getTime() / 1000,
+      },
+      {
+        value: new Date('2023-09-01T14:00:00Z').getTime() / 1000,
+        endValue: new Date('2023-09-01T16:00:00Z').getTime() / 1000,
+      }, // Closest future event
+      {
+        value: new Date('2023-10-01T14:00:00Z').getTime() / 1000,
+        endValue: new Date('2023-10-01T16:00:00Z').getTime() / 1000,
+      }, // Later future event
     ]
 
     const closestEvent = deriveMostRecentDate(datetimeRange)

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -193,14 +193,14 @@ export const deriveMostRecentDate = (
 ) => {
   const currentTime = Math.floor(Date.now() / 1000)
 
-  // Filter for future events
-  const futureEvents = datetimeRange.filter(
-    (event) => event.value > currentTime
+  // Filter for ongoing and future events
+  const ongoingAndFutureEvents = datetimeRange.filter(
+    (event) => event.endValue > currentTime
   )
 
   // If there are future events, return closest event
-  if (futureEvents.length > 0) {
-    return futureEvents.reduce((closest, current) => {
+  if (ongoingAndFutureEvents.length > 0) {
+    return ongoingAndFutureEvents.reduce((closest, current) => {
       return closest.value < current.value ? closest : current
     })
   }


### PR DESCRIPTION
# Description
This corrects an error where a recurring event that is in progress would show the following event's date while the event was still in progress. A recurring event that is currently in progress should show the current date until the event window has passed. 

## Ticket
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19470

## Developer Task

```[tasklist]
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [x] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
### Testing existing recurring events
We are looking at this event: https://main-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/outreach-and-events/events/73053
This event runs daily through Oct 30, from 9:00 am - 5:00 pm ET, which makes it a good candidate for testing of ongoing recurring events.
1. On any given day, before 5:00 pm ET, the following URL should show 'When' as the current day: https://pr795-sqczpa1lsqkrhxqurt8pmzmjjxf2rytt.tugboat.vfs.va.gov/outreach-and-events/events/73053/
    <img width="644" alt="image" src="https://github.com/user-attachments/assets/ba7b8177-6006-48d3-8549-f5f43ea2b7a3">
    Compare this to Dev currently, which will incorrectly show the following day once the current day's event starts at 9:00 am ET: https://dev.va.gov/outreach-and-events/events/73053/
2. On any given day, after 5:00 pm ET, the following URL should show 'When' as the following day: https://pr795-sqczpa1lsqkrhxqurt8pmzmjjxf2rytt.tugboat.vfs.va.gov/outreach-and-events/events/73053/
 3. On the listing page, while the event is ongoing (i.e. before 5:00 pm ET), the shown date should be today's date: https://pr795-sqczpa1lsqkrhxqurt8pmzmjjxf2rytt.tugboat.vfs.va.gov/outreach-and-events/events/
    <img width="854" alt="image" src="https://github.com/user-attachments/assets/5e3b2e20-bc40-4e35-a74f-24f5c5f8a15d">
4. On the listing page, when the event is completed for the day (after 5:00 pm ET), the shown date should be tomorrow's date: https://pr795-sqczpa1lsqkrhxqurt8pmzmjjxf2rytt.tugboat.vfs.va.gov/outreach-and-events/events/

### Testing new ongoing events that are not recurring
**Note: this test is optional, in the event that you want to use custom test events in addition to examining existing events.**

In all cases, you can create new content at this CMS instance: https://main-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/

This CMS is the data source for the Next Build Tugboat instance we are currently testing. Publish the events to the National Outreach & events calendar, so that you know where to look for them. 

1. Create a new event that is not recurring. Make the date & time match something that you can test in the near future, so that you can observe it shifting from being visible to not being visible. Make the end time at least 1 hour in the future, so that it has time to republish.
2. Create a new event that *is* recurring. Again, make the date & times match something where you can observe the time window when the event is 'in progress' and then when it is over. You want there to be a future recurrence of the event to exist. Again, make the end time at least 1 hour in the future so that you can test the window after the content is republished.
3. Visit the Tugboat management page for this test instance: https://tugboat.vfs.va.gov/670eb4b525a4ad7d760d45ae. Rebuild the test instance. This may take as long as 45 minutes. 
4. Once the site is rebuilt, visit the calendar page you published the events to, for example https://pr795-sqczpa1lsqkrhxqurt8pmzmjjxf2rytt.tugboat.vfs.va.gov/outreach-and-events/events/. Make sure you are in the window before your test events end, i.e. the event is 'ongoing'.
  a. For the non-recurring event, the event should show in the 'All upcoming' filter.
  b. For the recurring event, the event should show in the 'All upcoming' filter, *and* the date & time shown should be today's date.
5. Visit the individual recurring event while the event is still 'ongoing'. The date & time shown should be today's date.
6. Wait until the event time window has passed.
7. Visit the calendar page you published the events to, for example https://pr795-sqczpa1lsqkrhxqurt8pmzmjjxf2rytt.tugboat.vfs.va.gov/outreach-and-events/events/. 
  a. For the non-recurring event, the event should show in the 'Past events' filter.
  b. For the recurring event, the event should show in the 'All upcoming' filter, *and* the date & time shown should be _tomorrow's_ date.
8. Visit the individual recurring event after the event has finished for the day. The date & time shown should be _tomorrow's_ date.


## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

## Screenshots
Before is on the _right_, after is on the _left_. The difference can be observed in the 'When' time.
![image](https://github.com/user-attachments/assets/11198cd2-01e2-462e-aecd-485006df945c)


# Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository. 

## Standard Checks

```[tasklist]
- [x] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [x] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [x] Performance: Code does not introduce performance issues
- [x] Documentation: Changes are documented in their respective README.md files
- [x] Security: Packages have been approved in the TRM
```
