### PR TITLE
Enable events & listings on staging.

### DIFF
--- a/envs/.env.staging
+++ b/envs/.env.staging
@@ -19,3 +19,5 @@ NEXT_PUBLIC_GOOGLE_TAG_MANAGER_PREVIEW=env-661
 
 # Feature flags for enabling content types. These should only be added when you are preparing to go to prod and are testing on staging.
 # It is better to test these from the CMS backend for staging than here.
+FEATURE_NEXT_BUILD_CONTENT_EVENT_LISTING=true
+FEATURE_NEXT_BUILD_CONTENT_EVENT=true


### PR DESCRIPTION
#Description
This turns on Events & Event Listings for the Staging environment (staging.va.gov). This is necessary for Collab Cycle.