### PR TITLE
Insert 0 as metrics fallback if metric is empty.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -449,15 +449,15 @@ jobs:
           run: |
             jq --null-input '{}' | \
             jq '.series[0].metric = "${{env.METRIC_NAMESPACE}}.setup.duration"' | \
-            jq '.series[0].points[0] = [${{env.NOW}}, ${{env.SETUP_DURATION}}]' | \
+            jq '.series[0].points[0] = [${{env.NOW}}, ${{env.SETUP_DURATION || 0}}]' | \
             jq '.series[1].metric = "${{env.METRIC_NAMESPACE}}.build.duration"' | \
-            jq '.series[1].points[0] = [${{env.NOW}}, ${{env.BUILD_DURATION}}]' | \
+            jq '.series[1].points[0] = [${{env.NOW}}, ${{env.BUILD_DURATION || 0}}]' | \
             jq '.series[2].metric = "${{env.METRIC_NAMESPACE}}.deploy.duration"' | \
-            jq '.series[2].points[0] = [${{env.NOW}}, ${{env.DEPLOY_DURATION}}]' | \
+            jq '.series[2].points[0] = [${{env.NOW}}, ${{env.DEPLOY_DURATION || 0}}]' | \
             jq '.series[3].metric = "${{env.METRIC_NAMESPACE}}.overall.duration"' | \
-            jq '.series[3].points[0] = [${{env.NOW}}, ${{env.OVERALL_DURATION}}]' | \
+            jq '.series[3].points[0] = [${{env.NOW}}, ${{env.OVERALL_DURATION || 0}}]' | \
             jq '.series[4].metric = "${{env.METRIC_NAMESPACE}}.built.pages"' | \
-            jq '.series[4].points[0] = [${{env.NOW}}, ${{env.BUILT_PAGES}}]' | \
+            jq '.series[4].points[0] = [${{env.NOW}}, ${{env.BUILT_PAGES || 0}}]' | \
             jq '.series[].tags[0] = "env:${{env.DEPLOY_ENV}}"' | \
             jq '.series[].tags[1] = "build_number:${{github.run_number}}"' | \
             jq '.series[].tags[2] = "status:${{needs.build.result}}"' | \


### PR DESCRIPTION
# Description
In cases where the metrics sent from content release to Datadog are empty, they have been reporting `null` i.e. empty. This causes problems for the `jq` queries that construct the json that gets sent to Datadog, causing it to fail.

