### PR TITLE
fix: Do not use assets URL for fonts

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -36,28 +36,28 @@ const Document = () => {
         {/* Preload main fonts */}
         <link
           rel="preload"
-          href={`${ASSETS_URL}sourcesanspro-bold-webfont.woff2`}
+          href="/generated/sourcesanspro-bold-webfont.woff2"
           as="font"
           type="font/woff2"
           crossOrigin="anonymous"
         />
         <link
           rel="preload"
-          href={`${ASSETS_URL}sourcesanspro-regular-webfont.woff2`}
+          href="/generated/sourcesanspro-regular-webfont.woff2"
           as="font"
           type="font/woff2"
           crossOrigin="anonymous"
         />
         <link
           rel="preload"
-          href={`${ASSETS_URL}bitter-bold.woff2`}
+          href="/generated/bitter-bold.woff2"
           as="font"
           type="font/woff2"
           crossOrigin="anonymous"
         />
         <link
           rel="preload"
-          href={`${ASSETS_URL}fa-solid-900.woff2`}
+          href="/generated/fa-solid-900.woff2"
           as="font"
           type="font/woff2"
           crossOrigin="anonymous"


### PR DESCRIPTION
- Do not use `${ASSETS_URL}` for anything other than `*.js` and `*.css`
- JS and CSS point to the assets bucket https://github.com/department-of-veterans-affairs/vsp-platform-revproxy/blob/main/template-rendering/revproxy-vagov/templates/nginx_website_server.conf.j2#L332
- All other resources are pointed at the [next]content bucket https://github.com/department-of-veterans-affairs/vsp-platform-revproxy/blob/main/template-rendering/revproxy-vagov/templates/nginx_website_server.conf.j2#L402