### PR TITLE
Check banner object for field before trying to iterate over it.

### DIFF
--- a/src/data/queries/banners.ts
+++ b/src/data/queries/banners.ts
@@ -62,15 +62,15 @@ export const formatter: QueryFormatter<any, BannersData> = (entities) => {
           path: banner.path?.alias,
           findFacilities: banner.field_alert_find_facilities_cta,
           // Normalizes banner alert data as it can come from api as a single object or array
-          bannerAlertVamcs: []
-            .concat(banner.field_banner_alert_vamcs)
-            .map((vamc) => ({
-              id: vamc.target_id,
-              path: vamc.url,
-              office: {
-                path: vamc.office?.url || null,
-              },
-            })),
+          bannerAlertVamcs: banner.field_banner_alert_vamcs
+            ? [].concat(banner.field_banner_alert_vamcs).map((vamc) => ({
+                id: vamc.target_id,
+                path: vamc.url,
+                office: {
+                  path: vamc.office?.url || null,
+                },
+              }))
+            : [],
           type: banner.type.target_id,
         }
       default:


### PR DESCRIPTION
# Description
Banner data did not contain a field we were expecting and the banner code attempted to iterate over it.

This threw an error which caused the entire page to not be built, which is a problem for us.

## Ticket

## QA steps
Visit /boston-health-care/events on this Tugboat instance; it should show a page.


