### PR TITLE
Add a holiday check to the production tag process, including an override.

### DIFF
--- a/.github/workflows/production-tag.yml
+++ b/.github/workflows/production-tag.yml
@@ -2,11 +2,15 @@ name: Create Production Tag
 
 on:
   workflow_dispatch:
+    inputs:
+      override_code_freeze:
+        type: boolean
+        description: "Override code freeze and create production tag"
+        default: false
   workflow_run:
     workflows: ['Continuous Integration']
     types: [completed]
     branches: [main]
-
 concurrency:
   group: production-tag
   cancel-in-progress: true
@@ -16,11 +20,23 @@ env:
   DSVA_SCHEDULE_ENABLED: true
 
 jobs:
+  holiday-checker:
+    runs-on: ubuntu-latest
+    outputs:
+      is_holiday: ${{ steps.holiday-check.outputs.is_holiday }}
+    steps:
+      - name: Check if today is a holiday
+        id: holiday-check
+        uses: department-of-veterans-affairs/vsp-github-actions/holiday-checker@main
   create-production-tag:
     name: Create Production Tag
     runs-on: ubuntu-latest
-    # Run the workflow unless it was triggered by CI and that failed
-    if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure') }}
+    needs: holiday-checker
+    # Do not run the workflow during VA holidays unless we explicitly override it.
+    # Run the workflow unless it was triggered by CI and that failed.
+    if: >
+      (needs.holiday-checker.outputs.is_holiday == 'false' || (inputs && inputs.override_code_freeze))
+      && !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure')
     outputs:
       RELEASE_NAME: ${{ steps.export-release-name.outputs.RELEASE_NAME }}
     permissions:


### PR DESCRIPTION
# Description
This installs a holiday checker for the production tag creator for Next Build. It checks for whether we are in a holiday state, and does not cut a production tag

## Ticket
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19910

## Developer Task

```[tasklist]
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
This is testable from this branch for testing, both without and with the override in place.
- No override: https://github.com/department-of-veterans-affairs/next-build/actions/runs/12486271581
- Override: https://github.com/department-of-veterans-affairs/next-build/actions/runs/12486284360 (successfully passed to tag creation; workflow subsequently cancelled to not violate code freeze).
