### PR TITLE
Remove fa-solid-900.woff reference.

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -55,13 +55,6 @@ const Document = () => {
           type="font/woff2"
           crossOrigin="anonymous"
         />
-        <link
-          rel="preload"
-          href={`${ASSETS_URL}fa-solid-900.woff2`}
-          as="font"
-          type="font/woff2"
-          crossOrigin="anonymous"
-        />
 
         {/* Load Icons */}
         <link


### PR DESCRIPTION
# Description
 Removes references to fa-solid-900.woff, which is a font file that is no longer generated.

## Ticket
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20219
