### PR TITLE
Use the currently passed-in value for vagovprod to load Medallia scripts.

### DIFF
--- a/src/templates/common/medallia/index.tsx
+++ b/src/templates/common/medallia/index.tsx
@@ -9,7 +9,7 @@ import {
 import { BUILD_TYPES } from '@/lib/constants/environment'
 
 export function MedalliaAssets() {
-  const scriptId = process.env.BUILD_TYPE === BUILD_TYPES.PROD ? 2 : 5
+  const scriptId = process.env.BUILD_TYPE === 'prod' ? 2 : 5
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_BUILD_TYPE === BUILD_TYPES.LOCAL) {


### PR DESCRIPTION
# Description
The Medallia script responsible for providing feedback button interactivity is not loading on production for Next Build pages.

The problem is that the build script passes in `prod` as the value for the environment, but Next Build understands `vagovprod` to be the value for that environment. This is causing the staging script to load. See https://github.com/department-of-veterans-affairs/next-build/blob/3fdc28ceb9ea0887666867257443b17a4ae5afd7/src/templates/common/medallia/index.tsx#L12

This aligns the environment test for prod with the value that is currently being passed in to the build. This will be revisited in another ticket to bring environment usage into consistency: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20270

## Developer Task

```[tasklist]
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
This cannot be properly tested until it is in production.
