### PR TITLE
Change event teaser assignment to allEventTeasers.

### DIFF
--- a/src/templates/layouts/eventListing/index.tsx
+++ b/src/templates/layouts/eventListing/index.tsx
@@ -38,7 +38,7 @@ export function EventListing({
   useEffect(() => {
     window.sideNav = menu
 
-    // This populates the whole events widget, even upcoming events. IDK!
+    // This populates the whole events widget.
     window.allEventTeasers = { entities: events }
   }, [menu, events])
 

--- a/src/templates/layouts/eventListing/index.tsx
+++ b/src/templates/layouts/eventListing/index.tsx
@@ -19,7 +19,7 @@ import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
   sideNav?: SideNavMenu
-  pastEvents?: {
+  allEventTeasers?: {
     entities: EventWidgetTeaser[]
   }
 }
@@ -39,7 +39,7 @@ export function EventListing({
     window.sideNav = menu
 
     // This populates the whole events widget, even upcoming events. IDK!
-    window.pastEvents = { entities: events }
+    window.allEventTeasers = { entities: events }
   }, [menu, events])
 
   return (


### PR DESCRIPTION
# Description
This changes the data assignment of events to be `allEventTeasers` to conform to changes in https://github.com/department-of-veterans-affairs/vets-website/pull/34528/files

