### PR TITLE
Fixing Media Contacts bug 

### DIFF
--- a/src/templates/layouts/pressRelease/index.test.tsx
+++ b/src/templates/layouts/pressRelease/index.test.tsx
@@ -110,6 +110,18 @@ describe('<pressRelease> with valid data', () => {
     expect(screen.queryByText('null')).toBeNull()
   })
 
+  test('does not render Media contacts header when no contacts exist', () => {
+    data.contacts = []
+    render(<PressRelease {...data} />)
+    expect(screen.queryByText('Media contacts')).not.toBeInTheDocument()
+  })
+
+  test('does not render Media contacts header when contacts is null', () => {
+    data.contacts = null
+    render(<PressRelease {...data} />)
+    expect(screen.queryByText('Media contacts')).not.toBeInTheDocument()
+  })
+
   test('renders the downloads', () => {
     render(<PressRelease {...data} />)
     downloads.forEach((download) => {

--- a/src/templates/layouts/pressRelease/index.tsx
+++ b/src/templates/layouts/pressRelease/index.tsx
@@ -62,7 +62,7 @@ export const PressRelease = ({
                   <div dangerouslySetInnerHTML={{ __html: fullText }}></div>
                 </section>
                 <section className="vads-u-margin-bottom--6">
-                  {contacts && (
+                  {contacts?.length > 0 && (
                     <div className="vads-u-font-weight--bold">
                       Media contacts
                     </div>


### PR DESCRIPTION
# Description
This PR fixes the bug such that the Media Contacts header does no appear if there are no contacts/the array is empty. It adds extra validation and adds some tests. 
## Ticket
Closes #[20172](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20172)

## Developer Task

```[tasklist]
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [x] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
For local testing
Load up http://localhost:3999/boston-health-care/news-releases/va-boston-clinical-researchers-honored-with-presidential-early-career-award/
Load up http://localhost:3999/boston-health-care/news-releases/va-new-england-healthcare-system-announces-new-deputy-executive-director/
contacts is empty in the latter and Media contacts header is missing vs in the first one it is visible
Tugboat Preview should not have Media Contacts at the bottom
Also run ` npm test -- src/templates/layouts/pressRelease`  for unit tests

## QA steps
What needs to be checked to prove this works?  
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

## Screenshots
Before:
<img width="819" alt="image" src="https://github.com/user-attachments/assets/5a3a1372-2b36-42af-97c7-f92280acc933" />

After:
<img width="768" alt="image" src="https://github.com/user-attachments/assets/39987a4d-b4cd-4955-ba02-9095c4a5e5c4" />


## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:


# Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository. 

## Standard Checks

```[tasklist]
- [x] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [x] Test Coverage: 80% coverage
- [x] Functionality: Change functions as expected with no additional bugs
- [x] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging an Approved Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` inside the `CMS`. This CMS flag must be turned on for editors to preview their work using the next build preview server.

Resource types (layouts) that have not been approved by design should NOT be pushed to production. Ensure that [slug.tsx](../src/pages/[[...slug]].tsx) does not include your resource type if it is not approved.

The status of layouts should be kept up to date inside [templates.md](./templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.

## Merging a Non-Approved Layout

Your new resource type should not be included inside [slug.tsx](../src/pages/[[...slug]].tsx). Items added here will go into production once merged into the `main` branch. It is imperative that we do not push anything live that has not been approved.

Ensure that this layout has been added to the [templates.md](./templates.md) file with the current status of the work.