### PR TITLE
Bug Fix: changing maxPageListLength from 3 to 7 to match CMS

### DIFF
--- a/src/constants/pagination.ts
+++ b/src/constants/pagination.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_PAGE_LIST_LENGTH = 8

--- a/src/constants/pagination.ts
+++ b/src/constants/pagination.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_PAGE_LIST_LENGTH = 8
+export const DEFAULT_PAGE_LIST_LENGTH = 7

--- a/src/templates/layouts/pressReleaseListing/index.tsx
+++ b/src/templates/layouts/pressReleaseListing/index.tsx
@@ -19,6 +19,7 @@ import { ContentFooter } from '@/templates/common/contentFooter'
 import { useEffect } from 'react'
 import { LovellStaticPropsResource } from '@/lib/drupal/lovell/types'
 import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
+import { DEFAULT_PAGE_LIST_LENGTH } from '../../../constants/pagination'
 
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
@@ -77,7 +78,7 @@ export function PressReleaseListing({
               <VaPagination
                 page={currentPage}
                 pages={totalPages}
-                maxPageListLength={8}
+                maxPageListLength={DEFAULT_PAGE_LIST_LENGTH}
                 onPageSelect={(page) => {
                   const newPage =
                     page.detail.page > 1 ? `page-${page.detail.page}` : ''

--- a/src/templates/layouts/pressReleaseListing/index.tsx
+++ b/src/templates/layouts/pressReleaseListing/index.tsx
@@ -77,7 +77,7 @@ export function PressReleaseListing({
               <VaPagination
                 page={currentPage}
                 pages={totalPages}
-                maxPageListLength={3}
+                maxPageListLength={8}
                 onPageSelect={(page) => {
                   const newPage =
                     page.detail.page > 1 ? `page-${page.detail.page}` : ''

--- a/src/templates/layouts/storyListing/index.tsx
+++ b/src/templates/layouts/storyListing/index.tsx
@@ -18,6 +18,7 @@ import { ContentFooter } from '@/templates/common/contentFooter'
 import { useEffect } from 'react'
 import { LovellStaticPropsResource } from '@/lib/drupal/lovell/types'
 import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
+import { DEFAULT_PAGE_LIST_LENGTH } from '../../../constants/pagination'
 
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
@@ -80,7 +81,7 @@ export function StoryListing({
               <VaPagination
                 page={currentPage}
                 pages={totalPages}
-                maxPageListLength={8}
+                maxPageListLength={DEFAULT_PAGE_LIST_LENGTH}
                 onPageSelect={(page) => {
                   const newPage =
                     page.detail.page > 1 ? `page-${page.detail.page}` : ''

--- a/src/templates/layouts/storyListing/index.tsx
+++ b/src/templates/layouts/storyListing/index.tsx
@@ -80,7 +80,7 @@ export function StoryListing({
               <VaPagination
                 page={currentPage}
                 pages={totalPages}
-                maxPageListLength={3}
+                maxPageListLength={8}
                 onPageSelect={(page) => {
                   const newPage =
                     page.detail.page > 1 ? `page-${page.detail.page}` : ''


### PR DESCRIPTION
# Description
Currently in prod CMS this field is set to 7 but in `next-build` it was set and hardcoded to 3, This PR is changing this in `next-build` to 7 to better match what is currently in prod, and adding it as a constant so in future we only have to change it in one place instead of a few as we scale this thing out. 

## Ticket
Closes to #[19849](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19849)

## Developer Task

```[tasklist]
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
For local testing load up
http://localhost:3999/boston-health-care/news-releases/
http://localhost:3999/boston-health-care/stories/ (although this one does not have enough pages to see a difference)
and ensure that at the bottom the <VaPagination> component upon inspection is like
<img width="593" alt="image" src="https://github.com/user-attachments/assets/1ee9e067-b36c-4af1-bb98-40490280f38d" />


## QA steps
Check the footer, ensure it works

## Screenshots
Before:
<img width="922" alt="image" src="https://github.com/user-attachments/assets/5b9aec91-0eee-42d3-8dca-8acc4df90158" />

After:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/e3514361-9337-4235-8ab8-385c7de2e736" />


## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:


# Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository. 

## Standard Checks

```[tasklist]
- [x] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [x] Functionality: Change functions as expected with no additional bugs
- [x] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging an Approved Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` inside the `CMS`. This CMS flag must be turned on for editors to preview their work using the next build preview server.

Resource types (layouts) that have not been approved by design should NOT be pushed to production. Ensure that [slug.tsx](../src/pages/[[...slug]].tsx) does not include your resource type if it is not approved.

The status of layouts should be kept up to date inside [templates.md](./templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.

## Merging a Non-Approved Layout

Your new resource type should not be included inside [slug.tsx](../src/pages/[[...slug]].tsx). Items added here will go into production once merged into the `main` branch. It is imperative that we do not push anything live that has not been approved.

Ensure that this layout has been added to the [templates.md](./templates.md) file with the current status of the work.