### PR TITLE
Add wait-for-cms action and use in content-release.

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -187,6 +187,9 @@ jobs:
     - name: Gather vets-website assets
       run: cd main && yarn setup
 
+    - name: Wait for the CMS to be ready
+      uses: ./.github/workflows/wait-for-cms-ready
+
     - name: Build site
       id: export-yarn-output
       uses: nick-fields/retry@v3

--- a/.github/workflows/wait-for-cms-ready/action.yml
+++ b/.github/workflows/wait-for-cms-ready/action.yml
@@ -1,0 +1,41 @@
+name: Wait for CMS to be ready
+description: Pause until we know that the CMS is online and ready to go
+
+inputs:
+  base_url:
+    description: Base url for the cms environment to wait for
+    required: false
+    default: 'https://prod.cms.va.gov'
+  interval:
+    description: How often to poll the environment for status (in seconds)
+    required: false
+    default: '15'
+  timeout:
+    description: How long should we wait for the cms to be ready (in seconds)
+    required: false
+    default: '4200'
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for CMS to be ready
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        timer=0
+
+        while true
+        do
+          if [ $timer -gt ${{ inputs.timeout }} ]; then
+            echo "Timeout exceeded."
+            exit 1
+          fi
+
+          if [[ "$(curl -s -o /dev/null -w '%{http_code}' ${{ inputs.base_url }})" != "200" ]]; then
+            sleep ${{ inputs.interval }}
+            timer=$(($timer + ${{ inputs.interval }}))
+          else
+            echo "Ready!"
+            break
+          fi
+        done


### PR DESCRIPTION
# Description
Content Release was not checking whether the CMS is available to be used as an API before trying to build. This caused Content Release to fail to build some pages, and then to push those "failed" (i.e. empty) pages to prod, resulting in missing pages in the deploy.

## Ticket
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20594

## Testing Steps
This is not testable from a non-`main` branch.

However, this is 100% analogous to an equivalent step in content-build:
- action: https://github.com/department-of-veterans-affairs/content-build/tree/main/.github/workflows/wait-for-cms-ready
- usage: https://github.com/department-of-veterans-affairs/content-build/blob/main/.github/workflows/content-release.yml#L159

