### PR TITLE
Vacms 20594 wait for cms

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -188,7 +188,7 @@ jobs:
       run: cd main && yarn setup
 
     - name: Wait for the CMS to be ready
-      uses: main/.github/workflows/wait-for-cms-ready
+      uses: "./main/.github/workflows/wait-for-cms-ready"
 
     - name: Build site
       id: export-yarn-output

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -467,7 +467,7 @@ jobs:
             jq '.series[].tags[3] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
 
         - name: Configure AWS credentials
-          uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+          uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
           with:
             aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -467,7 +467,7 @@ jobs:
             jq '.series[].tags[3] = "trigger:${{env.BUILD_TRIGGER}}"' > metrics.json
 
         - name: Configure AWS credentials
-          uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+          uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
           with:
             aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
             aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# Description
Content Release was not checking whether the CMS is available to be used as an API before trying to build. This caused Content Release to fail to build some pages, and then to push those "failed" (i.e. empty) pages to prod, resulting in missing pages in the deploy.

This corrects an issue with an earlier deploy: https://github.com/department-of-veterans-affairs/next-build/pull/892

## Ticket
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20594

## Testing Steps
This is not testable from a non-`main` branch.

However, this is 100% analogous to an equivalent step in content-build:
- action: https://github.com/department-of-veterans-affairs/content-build/tree/main/.github/workflows/wait-for-cms-ready
- usage: https://github.com/department-of-veterans-affairs/content-build/blob/main/.github/workflows/content-release.yml#L159

