### PR TITLE
Release Date bug fix to maintain parity with prod CMS

### DIFF
--- a/src/data/queries/pressReleaseTeaser.ts
+++ b/src/data/queries/pressReleaseTeaser.ts
@@ -19,6 +19,6 @@ export const formatter: QueryFormatter<NodePressRelease, PressReleaseTeaser> = (
     title: entity.title,
     link: entity.path.alias,
     introText: entity.field_intro_text,
-    lastUpdated: entity.field_last_saved_by_an_editor || entity.created,
+    lastUpdated: entity.field_release_date || entity.created,
   }
 }

--- a/src/data/queries/pressReleaseTeaser.ts
+++ b/src/data/queries/pressReleaseTeaser.ts
@@ -20,10 +20,11 @@ export const formatter: QueryFormatter<NodePressRelease, PressReleaseTeaser> = (
     link: entity.path.alias,
     introText: entity.field_intro_text,
     /*
-     * Updating this to field_release_date from field_last_saved_by_an_editor
-     * to maintain consistency with content-build
+     * Adding releaseDate to maintain consistency with content-build
+     * lastUpdated is no longer used in the Press Release Teaser
      * see https://github.com/department-of-veterans-affairs/next-build/pull/894/files
      */
-    lastUpdated: entity.field_release_date || entity.created,
+    lastUpdated: entity.field_last_saved_by_an_editor || entity.created,
+    releaseDate: entity.field_release_date || entity.created,
   }
 }

--- a/src/data/queries/pressReleaseTeaser.ts
+++ b/src/data/queries/pressReleaseTeaser.ts
@@ -19,6 +19,11 @@ export const formatter: QueryFormatter<NodePressRelease, PressReleaseTeaser> = (
     title: entity.title,
     link: entity.path.alias,
     introText: entity.field_intro_text,
+    /*
+     * Updating this to field_release_date from field_last_saved_by_an_editor
+     * to maintain consistency with content-build
+     * see https://github.com/department-of-veterans-affairs/next-build/pull/894/files
+     */
     lastUpdated: entity.field_release_date || entity.created,
   }
 }

--- a/src/data/queries/tests/__snapshots__/pressReleaseTeaser.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/pressReleaseTeaser.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`node--press_releaseTeaser formatData outputs formatted data 1`] = `
   "headingLevel": "h2",
   "id": "6153ed5b-85c2-4ead-9893-3d656ad5d758",
   "introText": "We invite you to come and read our 2019 Annual Report. ",
-  "lastUpdated": "2021-04-12T14:25:27+00:00",
+  "lastUpdated": "2020-06-19T10:25:28-04:00",
   "link": "/wilmington-health-care/news-releases/wilmington-vamc-2019-annual-report",
   "published": false,
   "title": "Wilmington VAMC 2019 Annual Report",

--- a/src/data/queries/tests/__snapshots__/pressReleaseTeaser.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/pressReleaseTeaser.test.tsx.snap
@@ -5,9 +5,10 @@ exports[`node--press_releaseTeaser formatData outputs formatted data 1`] = `
   "headingLevel": "h2",
   "id": "6153ed5b-85c2-4ead-9893-3d656ad5d758",
   "introText": "We invite you to come and read our 2019 Annual Report. ",
-  "lastUpdated": "2020-06-19T10:25:28-04:00",
+  "lastUpdated": "2021-04-12T14:25:27+00:00",
   "link": "/wilmington-health-care/news-releases/wilmington-vamc-2019-annual-report",
   "published": false,
+  "releaseDate": "2020-06-19T10:25:28-04:00",
   "title": "Wilmington VAMC 2019 Annual Report",
   "type": "node--press_release",
 }

--- a/src/data/queries/tests/pressReleaseTeaser.test.tsx
+++ b/src/data/queries/tests/pressReleaseTeaser.test.tsx
@@ -29,6 +29,34 @@ describe(`${RESOURCE_TYPES.PRESS_RELEASE}Teaser formatData`, () => {
     const formattedData = formatter(modifiedMock)
     expect(formattedData.link).toBe(modifiedMock.path.alias)
   })
+
+  // Unit test just for lastUpdated field to ensure it's set correctly
+  test('sets lastUpdated field correctly', () => {
+    const withReleaseDate = {
+      ...nodePressReleaseTeaserMock,
+      field_release_date: '2024-03-20T10:00:00Z',
+      created: '2024-03-15T10:00:00Z',
+    }
+    expect(formatter(withReleaseDate).lastUpdated).toBe('2024-03-20T10:00:00Z')
+
+    const withoutReleaseDate = {
+      ...nodePressReleaseTeaserMock,
+      field_release_date: null,
+      created: '2024-03-15T10:00:00Z',
+    }
+    expect(formatter(withoutReleaseDate).lastUpdated).toBe(
+      '2024-03-15T10:00:00Z'
+    )
+
+    const releaseDataUndefined = {
+      ...nodePressReleaseTeaserMock,
+      field_release_date: undefined,
+      created: '2024-03-15T10:00:00Z',
+    }
+    expect(formatter(releaseDataUndefined).lastUpdated).toBe(
+      '2024-03-15T10:00:00Z'
+    )
+  })
 })
 
 describe('DrupalJsonApiParams configuration for pressReleaseTeaser', () => {

--- a/src/data/queries/tests/pressReleaseTeaser.test.tsx
+++ b/src/data/queries/tests/pressReleaseTeaser.test.tsx
@@ -37,14 +37,14 @@ describe(`${RESOURCE_TYPES.PRESS_RELEASE}Teaser formatData`, () => {
       field_release_date: '2024-03-20T10:00:00Z',
       created: '2024-03-15T10:00:00Z',
     }
-    expect(formatter(withReleaseDate).lastUpdated).toBe('2024-03-20T10:00:00Z')
+    expect(formatter(withReleaseDate).releaseDate).toBe('2024-03-20T10:00:00Z')
 
     const withoutReleaseDate = {
       ...nodePressReleaseTeaserMock,
       field_release_date: null,
       created: '2024-03-15T10:00:00Z',
     }
-    expect(formatter(withoutReleaseDate).lastUpdated).toBe(
+    expect(formatter(withoutReleaseDate).releaseDate).toBe(
       '2024-03-15T10:00:00Z'
     )
 
@@ -53,7 +53,7 @@ describe(`${RESOURCE_TYPES.PRESS_RELEASE}Teaser formatData`, () => {
       field_release_date: undefined,
       created: '2024-03-15T10:00:00Z',
     }
-    expect(formatter(releaseDataUndefined).lastUpdated).toBe(
+    expect(formatter(releaseDataUndefined).releaseDate).toBe(
       '2024-03-15T10:00:00Z'
     )
   })

--- a/src/lib/utils/helpers.test.ts
+++ b/src/lib/utils/helpers.test.ts
@@ -8,6 +8,7 @@ import {
   toString,
   escape,
   numToWord,
+  formatDate,
 } from './helpers'
 
 describe('truncateWordsOrChar', () => {
@@ -276,5 +277,36 @@ describe('numToWord function', () => {
 
   test('handles zero', () => {
     expect(numToWord(0)).toBe('zero')
+  })
+})
+
+describe('formatDate', () => {
+  test('formats standard date strings correctly', () => {
+    expect(formatDate('2024-03-20')).toBe('March 20, 2024')
+    expect(formatDate('2024-12-25')).toBe('December 25, 2024')
+    expect(formatDate('2024-01-05')).toBe('January 5, 2024')
+  })
+
+  test('handles ISO date strings with timezone offsets', () => {
+    expect(formatDate('2024-03-20T10:25:28-04:00')).toBe('March 20, 2024')
+    expect(formatDate('2024-03-20T14:27:39+00:00')).toBe('March 20, 2024')
+  })
+
+  test('handles UTC timestamps', () => {
+    expect(formatDate('2024-03-20T14:30:00Z')).toBe('March 20, 2024')
+  })
+
+  test('maintains consistent output regardless of input timezone', () => {
+    const date = '2024-03-20'
+    const dateUTC = '2024-03-20T00:00:00Z'
+    const dateEST = '2024-03-20T00:00:00-05:00'
+    expect(formatDate(date)).toBe('March 20, 2024')
+    expect(formatDate(dateUTC)).toBe('March 20, 2024')
+    expect(formatDate(dateEST)).toBe('March 20, 2024')
+  })
+
+  test('handles invalid inputs', () => {
+    expect(() => formatDate('invalid-date')).not.toThrow()
+    expect(formatDate('invalid-date')).toBe('Invalid Date')
   })
 })

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -32,6 +32,7 @@ export function formatDate(input: string): string {
     month: 'long',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   })
 }
 

--- a/src/mocks/formattedPressReleases.mock.js
+++ b/src/mocks/formattedPressReleases.mock.js
@@ -5,6 +5,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'Wilmington VAMC 2019 Annual Report',
     lastUpdated: '2021-04-12T14:25:27+00:00',
+    releaseDate: '2021-04-12T14:25:27+00:00',
     link: '/wilmington-health-care/news-releases/wilmington-vamc-2019-annual-report',
     introText: 'We invite you to come and read our 2019 Annual Report. ',
   },
@@ -14,6 +15,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'Houston health care Placeholder - News release',
     lastUpdated: '2021-04-05T14:42:45+00:00',
+    releaseDate: '2021-04-05T14:42:45+00:00',
     link: '/houston-health-care/news-releases/houston-health-care-placeholder-news-release',
     introText: 'Houston health care Placeholder - News release',
   },
@@ -23,6 +25,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'Virtual town hall discusses vaccine hesitancy for BIPOC Veterans',
     lastUpdated: '2021-04-26T15:12:03+00:00',
+    releaseDate: '2021-04-26T15:12:03+00:00',
     link: '/central-arkansas-health-care/news-releases/virtual-town-hall-discusses-vaccine-hesitancy-for-bipoc-veterans',
     introText:
       'Virtual Town Hall Discusses COVID-19 Vaccine Hesitancy for BIPOC Veterans WEBEX Event Wednesday, April 28',
@@ -33,6 +36,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'Minneapolis health care Placeholder - News release',
     lastUpdated: '2021-04-16T16:14:29+00:00',
+    releaseDate: '2021-04-16T16:14:29+00:00',
     link: '/minneapolis-health-care/news-releases/minneapolis-health-care-placeholder-news-release',
     introText: 'Minneapolis health care Placeholder - News release',
   },
@@ -42,6 +46,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'Town Hall Meeting for Veterans at Southeastern Veterans Center',
     lastUpdated: '2020-04-22T19:05:51+00:00',
+    releaseDate: '2020-04-22T19:05:51+00:00',
     link: '/coatesville-health-care/news-releases/town-hall-meeting-for-veterans-at-southeastern-veterans',
     introText:
       'Coatesville VA Medical Center and Spring City VA Outpatient Clinic Leaders to Host Town Hall Meeting for Veterans at Southeastern Veterans Center',
@@ -52,6 +57,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'Palo Alto health care Placeholder - News release',
     lastUpdated: '2021-04-08T19:12:52+00:00',
+    releaseDate: '2021-04-08T19:12:52+00:00',
     link: '/palo-alto-health-care/news-releases/palo-alto-health-care-placeholder-news-release',
     introText: 'Palo Alto health care Placeholder - News release',
   },
@@ -61,6 +67,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'Fayetteville Coastal Placeholder - News release',
     lastUpdated: '2021-03-18T20:10:27+00:00',
+    releaseDate: '2021-03-18T20:10:27+00:00',
     link: '/fayetteville-coastal-health-care/news-releases/fayetteville-coastal-placeholder-news-release',
     introText: 'Fayetteville Coastal Placeholder News release',
   },
@@ -71,6 +78,7 @@ export const formattedPressReleases = [
     title:
       'Fayetteville NC VA Health Care System Encourages Veterans ‘Reach Out’ For Mental Health Assistance',
     lastUpdated: '2021-09-21T13:11:45+00:00',
+    releaseDate: '2021-09-21T13:11:45+00:00',
     link: '/fayetteville-coastal-health-care/news-releases/fayetteville-nc-va-health-care-system-encourages-veterans-reach-out-for-mental-health-assistance-0',
     introText:
       'FAYETTEVILLE, NC — In conjunction with September’s Suicide Prevention Month, Fayetteville NC VA Coastal Health Care System is raising awareness of its mental health resources available for Veterans throughout Southeastern North Carolina.',
@@ -81,6 +89,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'VA Innovation: Here’s an idea that won’t keep you awake at night',
     lastUpdated: '2021-08-24T16:39:57+00:00',
+    releaseDate: '2021-08-24T16:39:57+00:00',
     link: '/asheville-health-care/news-releases/va-innovation-heres-an-idea-that-wont-keep-you-awake-at-night',
     introText:
       'Let’s face it – for most people, it’s hard to sleep in a hospital. That’s because it’s an unfamiliar setting with unfamiliar people and unfamiliar sounds all around you. Couple that with the stress of being treated, and it makes the perfect recipe for a lack of restful sleep.  \r\n',
@@ -91,6 +100,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'Columbus VA Transitions to New Electronic Health Record',
     lastUpdated: '2022-05-02T11:15:12+00:00',
+    releaseDate: '2022-05-02T11:15:12+00:00',
     link: '/central-ohio-health-care/news-releases/columbus-va-transitions-to-new-electronic-health-record',
     introText:
       'The VA Central Ohio Healthcare System transitioned to VA’s new electronic health record (EHR), April 30. ',
@@ -101,6 +111,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'VA SURVEY OF VETERAN ENROLLEES’ HEALTH AND USE OF HEALTH CARE',
     lastUpdated: '2022-04-22T13:23:04+00:00',
+    releaseDate: '2022-04-22T13:23:04+00:00',
     link: '/mountain-home-health-care/news-releases/va-survey-of-veteran-enrollees-health-and-use-of-health-care',
     introText:
       'The Survey of Enrollees is a nationwide survey of Veterans enrolled in the VA Health Care system. The survey is conducted every year. The survey asks questions about your use of health care, insurance benefits, and your health status. ',
@@ -111,6 +122,7 @@ export const formattedPressReleases = [
     published: true,
     title: 'State Senate Honors JHQVAMC with Resolution',
     lastUpdated: '2022-06-08T12:14:47+00:00',
+    releaseDate: '2022-06-08T12:14:47+00:00',
     link: '/mountain-home-health-care/news-releases/state-senate-honors-jhqvamc-with-resolution',
     introText:
       'State Senator Rusty Crowe of Tennessee’s District 3 presented James H. Quillen VA Medical Center (JHQVAMC) with Senate Joint Resolution 1114 during a ceremony June 6, 2022, honoring the medical center for its recognition as a top hospital for nurse-to-patient communication by a national publication. ',

--- a/src/templates/components/pressReleaseTeaser/index.test.tsx
+++ b/src/templates/components/pressReleaseTeaser/index.test.tsx
@@ -7,6 +7,7 @@ const teaserData = {
   published: true,
   title: 'Wilmington VAMC 2019 Annual Report',
   lastUpdated: '2021-04-12T14:27:39+00:00',
+  releaseDate: '2021-04-12T14:27:39+00:00',
   link: '/wilmington-health-care/news-releases/wilmington-vamc-2019-annual-report',
   introText: 'We invite you to come and read our 2019 Annual Report. ',
 }

--- a/src/templates/components/pressReleaseTeaser/index.tsx
+++ b/src/templates/components/pressReleaseTeaser/index.tsx
@@ -9,7 +9,7 @@ export function PressReleaseTeaser({
   title,
   link,
   introText,
-  lastUpdated,
+  releaseDate,
 }: FormattedPressReleaseTeaser) {
   const TitleTag = ({ children, className }) => {
     const Heading = headingLevel ? headingLevel : 'h2'
@@ -24,7 +24,7 @@ export function PressReleaseTeaser({
             {title}
           </va-link>
         </TitleTag>
-        <strong>{formatDate(lastUpdated)}</strong>
+        <strong>{formatDate(releaseDate)}</strong>
         <p className="vads-u-margin-top--0">
           {truncateWordsOrChar(introText, 60, true)}
         </p>

--- a/src/types/formatted/pressRelease.ts
+++ b/src/types/formatted/pressRelease.ts
@@ -8,6 +8,7 @@ export type PressReleaseTeaser = PublishedEntity & {
   headingLevel?: ComponentType | keyof JSX.IntrinsicElements
   link: string
   introText: string
+  releaseDate: string
 }
 
 export type PressReleaseDownload = {


### PR DESCRIPTION
# Description
This PR addresses 2 seperate issues resulting in some date mismatches in `next-build` that are not related to each other:

1. Changing the date from `field_last_saved_by_an_editor` to `field_release_date` to maintain parity with Prod CMS/content build. (First 2 instances in the ticket)
2. changing the `formate_date` function in `next-build` to have a timezone parameter and set that to UTC by default rather than system time (last example in the ticket)

## Ticket
Relates to #[20150](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20150).

## Developer Task

```[tasklist]
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
For case #1 
- [ ] Go to https://web-kqjsor0i3mjdwsy9gojxhhyvdzh0wubb.tugboat.vfs.va.gov/boston-health-care/news-releases/page-2/
- [x] Go to https://www.va.gov/boston-health-care/news-releases/page-2/
- [x] Load up your local server and go to http://localhost:3999/boston-health-care/news-releases/page-2/
- [x] Look for MEDIA ADVISORY listing
- [x] Verify locally and on tugboat preview that `October 11, 2024` is the date associated with the listing and not `October 15, 2024`
- [x] In the same overall path search for the header `Interprofessional team key in roll out of new Alzheimer’s therapy`
- [x] Verify locally that the date it is `August 20, 2024` and not `August 21, 2024` 
- [x] Run unit tests `npm run test`

For case #2 

- [x]  Go to https://www.va.gov/atlanta-health-care/news-releases/
- [x] On your local server go to http://localhost:3999/atlanta-health-care/news-releases/
- [x] See this header [VA Southeast Network Announces New Chief Medical Officer: Dr. Susan Roberts Brings Clinical Leadership, Proven Experience to Network](http://localhost:3999/atlanta-health-care/news-releases/va-southeast-network-announces-new-chief-medical-officer-dr-susan-roberts-brings-clinical-leadership-proven)
- [x] Verify the date is October 9, 2024 locally and on prod and is the same
- [x] Run the date helper unit tests

## QA steps
What needs to be checked to prove this works?  
check the dates and ensure there is parity 
What needs to be checked to prove it didn't break any related things?  
What variations of circumstances (users, actions, values) need to be checked?

## Screenshots
Case 1:
Before:
Next build tugboat
<img width="1095" alt="image" src="https://github.com/user-attachments/assets/71905bfe-2403-430c-b1f1-c971403978ed" />


After:

<img width="983" alt="image" src="https://github.com/user-attachments/assets/04136dce-b607-43b1-afcc-f6cc1cd814d5" />

Case 2:
Before:
Next build tugboat
<img width="809" alt="image" src="https://github.com/user-attachments/assets/2b60480c-c532-48af-a6ac-dcfd8f771a1d" />


After:

<img width="970" alt="image" src="https://github.com/user-attachments/assets/87d07f4b-c881-4da2-8fe9-95cd5974d96c" />

Case 3:

Before:
Next build tugboat
<img width="835" alt="image" src="https://github.com/user-attachments/assets/382d1f8d-1456-4f4e-baac-7d5c1d05a9f8" />

After:

<img width="828" alt="image" src="https://github.com/user-attachments/assets/f916af56-9fee-4fc0-88a9-23f13521e5d9" />

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:


# Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository. 

## Standard Checks

```[tasklist]
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging an Approved Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` inside the `CMS`. This CMS flag must be turned on for editors to preview their work using the next build preview server.

Resource types (layouts) that have not been approved by design should NOT be pushed to production. Ensure that [slug.tsx](../src/pages/[[...slug]].tsx) does not include your resource type if it is not approved.

The status of layouts should be kept up to date inside [templates.md](./templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.

## Merging a Non-Approved Layout

Your new resource type should not be included inside [slug.tsx](../src/pages/[[...slug]].tsx). Items added here will go into production once merged into the `main` branch. It is imperative that we do not push anything live that has not been approved.

Ensure that this layout has been added to the [templates.md](./templates.md) file with the current status of the work.