### PR TITLE
Correct cron time and do not run at 3:30 pm ET.

### DIFF
--- a/.github/workflows/content-release-prod.yml
+++ b/.github/workflows/content-release-prod.yml
@@ -5,7 +5,15 @@ on:
   # Runs automatically every 30 minutes from 8am to 8pm Monday to Friday.
   # This currently UTC -> EDT.
   schedule:
-    - cron: "*/30 0,12-23 * * 1-5"
+    # Content release to prod is every 30 minutes between the hours of 8 am - 8 pm ET,
+    # with the exception of 3:30 pm ET to allow for CMS deploy.
+    # cron times are UTC
+    # Every 30 minutes, at 12:00 AM through 12:59 AM, 01:00 PM through 7:59 PM, and 09:00 PM through 11:59 PM, Monday through Friday
+    - cron: "*/30 0,13-19,21-23 * * 1-5"
+    # At 08:00 PM, Monday through Friday
+    - cron: "0 20 * * 1-5"
+
+
   # Runs on API call. Used for CMS-driven build triggers.
   repository_dispatch:
     types: [content-release]


### PR DESCRIPTION
# Description
Content release to prod is meant to happen every 30 minutes between 8 am and 8 pm ET. However, we do not want to run content release at 3:30 pm ET, because CMS deploy happens then and we have seen build failures relating to CMS being offline.

This PR also corrects the start time; before this PR, it was starting at 7 am ET. This was probably a remnant of Daylight Saving Time; also, cron syntax can be confusing.

## Ticket
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20644

## Developer Task

```[tasklist]
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
The cron syntax should be reviewed by someone familiar with cron syntax to confirm. We will not be able to test this until merge to `main`, as [cron scheduling for GHA jobs is only available on the `main` branch](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).