### PR TITLE
Update pull_request_template.md to remove tasklist syntax

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Relates to #[TICKET_NUMBER](https://github.com/department-of-veterans-affairs/va
 
 ## Developer Task
 
-```[tasklist]
+```
 - [ ] PR submitted against the `main` branch of `next-build`.
 - [ ] Link to the issue that this PR addresses (if applicable).
 - [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
@@ -42,7 +42,7 @@ This section lists items that need to be checked or updated when making changes 
 
 ## Standard Checks
 
-```[tasklist]
+```
 - [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
 - [ ] Test Coverage: 80% coverage
 - [ ] Functionality: Change functions as expected with no additional bugs


### PR DESCRIPTION
# Description
Tasklists are being retired. See https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#tasklist-blocks-will-be-retired-and-replaced-with-sub-issues.

