### PR TITLE
Resizing fix for <va-link>  elements on events page

### DIFF
--- a/src/templates/layouts/event/index.test.tsx
+++ b/src/templates/layouts/event/index.test.tsx
@@ -212,4 +212,34 @@ describe('<Event /> Component', () => {
     render(<Event {...data} />)
     expect(screen.getByText('3307 10th Avenue Southeast')).toBeInTheDocument()
   })
+
+  describe('va-links in paragraph tags', () => {
+    it('always wraps outreach link in paragraph tag', () => {
+      render(<Event {...data} />)
+      const outreachLink = document.querySelector(
+        'va-link[href="/outreach-and-events/events/"]'
+      )
+      expect(outreachLink).not.toBeNull()
+      expect(outreachLink?.parentElement?.tagName.toLowerCase()).toBe('p')
+    })
+
+    it('wraps administration link in paragraph tag when present', () => {
+      render(
+        <Event
+          {...data}
+          administration={{
+            id: 1,
+            name: 'Test Administration',
+          }}
+          listing="/test-listing"
+          listingOffice="Test Office"
+        />
+      )
+      const seeMoreLink = document.querySelector(
+        'va-link[id="see-more-events"]'
+      )
+      expect(seeMoreLink).not.toBeNull()
+      expect(seeMoreLink?.parentElement?.tagName.toLowerCase()).toBe('p')
+    })
+  })
 })

--- a/src/templates/layouts/event/index.tsx
+++ b/src/templates/layouts/event/index.tsx
@@ -332,21 +332,23 @@ export const Event = ({
         {administration?.id != 7 &&
           listingOffice != 'Outreach and events' &&
           administration?.name && (
-            <va-link
-              class="vads-u-display--block vads-u-margin-top--2"
-              href={listing}
-              onClick={() =>
-                recordEvent({ event: 'nav-secondary-button-click' })
-              }
-              id="see-more-events"
-              text={`Browse the ${administration.name} events calendar`}
-            ></va-link>
+            <p className="vads-u-margin-top--2">
+              <va-link
+                href={listing}
+                onClick={() =>
+                  recordEvent({ event: 'nav-secondary-button-click' })
+                }
+                id="see-more-events"
+                text={`Browse the ${administration.name} events calendar`}
+              ></va-link>
+            </p>
           )}
-        <va-link
-          class="vads-u-padding-bottom--3 vads-u-margin-top--2 vads-u-display--block"
-          href="/outreach-and-events/events/"
-          text="Browse the VA outreach events calendar"
-        ></va-link>
+        <p className="vads-u-padding-bottom--3 vads-u-margin-top--2">
+          <va-link
+            href="/outreach-and-events/events/"
+            text="Browse the VA outreach events calendar"
+          ></va-link>
+        </p>
         <ContentFooter lastUpdated={lastUpdated} />
       </div>
     </div>


### PR DESCRIPTION
# Description
On the Event Detail pages, there are 2 <va-link> components at the bottom of the page under the heading "Other VA Events". In order for these component links to correctly scale and respond correctly to the user's browser font settings they need to be wrapped in a semantic <p> tag.

## Ticket
Relates to #[20598](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20598)

## Developer Task

```
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

- [ ] Load up https://www.va.gov/cincinnati-health-care/events/76943/
- [ ] Pull this branch 
- [ ] Load http://localhost:3999/cincinnati-health-care/events/76943/
- [ ] Change chrome browser setting in the : menu on top right, settings and appearance to very large
- [ ] compare the bottom va-links in `Other VA events` header
- [ ] ensure that the text resizes in localhost
- [ ] run local unit tests

## QA steps

- above steps + manual QA on tugboat

## Screenshots
Before: (Prod)
![image](https://github.com/user-attachments/assets/d27e9286-20d7-49c8-8406-f1cdd7430b07)

After:(local)
![image](https://github.com/user-attachments/assets/727c4de5-df35-4bf4-ad44-c5f1888b7190)

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:


# Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository. 

## Standard Checks

```
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging an Approved Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` inside the `CMS`. This CMS flag must be turned on for editors to preview their work using the next build preview server.

Resource types (layouts) that have not been approved by design should NOT be pushed to production. Ensure that [slug.tsx](../src/pages/[[...slug]].tsx) does not include your resource type if it is not approved.

The status of layouts should be kept up to date inside [templates.md](./templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.

## Merging a Non-Approved Layout

Your new resource type should not be included inside [slug.tsx](../src/pages/[[...slug]].tsx). Items added here will go into production once merged into the `main` branch. It is imperative that we do not push anything live that has not been approved.

Ensure that this layout has been added to the [templates.md](./templates.md) file with the current status of the work.
