### PR TITLE
Stories Pages defects

### DIFF
--- a/src/templates/common/socialLinks/index.tsx
+++ b/src/templates/common/socialLinks/index.tsx
@@ -127,19 +127,19 @@ export const SocialLinks = ({
                 size="3"
               />
               <va-link
-                className="va-js-share-link"
+                class="va-js-share-link"
                 href={`https://www.facebook.com/sharer/sharer.php?href=${path}`}
                 text="Share on Facebook"
               />
             </li>
-            <li>
+            <li className="vads-u-flex--1">
               <va-icon
                 class="va-c-social-icon vads-u-margin-right--0p5"
                 icon="x"
                 size="3"
               />
               <va-link
-                className="va-js-share-link"
+                class="va-js-share-link"
                 href={`https://twitter.com/intent/tweet?text=${title}&url=${path}`}
                 text="Share on X (formerly Twitter)"
               />

--- a/src/templates/common/socialLinks/index.tsx
+++ b/src/templates/common/socialLinks/index.tsx
@@ -120,7 +120,7 @@ export const SocialLinks = ({
           </>
         ) : (
           <>
-            <li className="vads-u-margin-bottom--2p5 ">
+            <li className="vads-u-margin-right--5 medium-screen:vads-u-margin-right--2p5">
               <va-icon
                 class="va-c-social-icon vads-u-margin-right--0p5"
                 icon="facebook"

--- a/src/templates/components/personProfile/index.test.tsx
+++ b/src/templates/components/personProfile/index.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from 'test-utils'
 import { PersonProfile } from '@/templates/components/personProfile/index'
 import { PersonProfile as FormattedPersonProfile } from '@/types/formatted/personProfile'
 import { MediaImage } from '@/types/formatted/media'
+import { StaffNewsProfile } from '@/templates/components/personProfile/index'
 
 const mediaImage: MediaImage = {
   id: '3',
@@ -153,5 +154,26 @@ describe('PersonProfile with invalid data', () => {
     render(<PersonProfile {...personProfileData} />)
 
     expect(screen.queryByText(/Download full bio/)).not.toBeInTheDocument()
+  })
+})
+
+describe('StaffNewsProfile', () => {
+  test('renders byline with title and description', () => {
+    const props = {
+      title: 'John Smith',
+      description: 'Staff Writer',
+    }
+    render(<StaffNewsProfile {...props} />)
+    expect(screen.getByText('By John Smith, Staff Writer')).toBeInTheDocument()
+    expect(screen.getByText('By John Smith, Staff Writer').tagName).toBe('P')
+  })
+
+  test('renders byline with title only when description is missing', () => {
+    const props = {
+      title: 'John Smith',
+    }
+    render(<StaffNewsProfile {...props} />)
+    expect(screen.getByText('By John Smith')).toBeInTheDocument()
+    expect(screen.getByText('By John Smith').tagName).toBe('P')
   })
 })

--- a/src/templates/components/personProfile/index.tsx
+++ b/src/templates/components/personProfile/index.tsx
@@ -136,11 +136,9 @@ export const StaffNewsProfile = ({
   description,
 }: PersonProfileTeaserProps): JSX.Element => {
   return (
-    <div className="vads-u-font-size--sm vads-u-margin-bottom--2p5">
-      <div className="vads-u-margin-bottom--0p5 vads-u-font-weight--bold">
-        By {title}
-        {description ? `, ${description}` : null}
-      </div>
-    </div>
+    <p className="vads-u-margin-bottom--0p5 vads-u-font-weight--bold">
+      By {title}
+      {description ? `, ${description}` : null}
+    </p>
   )
 }

--- a/src/templates/components/storyListingLink/index.test.tsx
+++ b/src/templates/components/storyListingLink/index.test.tsx
@@ -25,7 +25,7 @@ describe('<StoryListingLink /> Component', () => {
     expect(linkElement).toHaveAttribute('text', 'See all stories')
     expect(linkElement).toHaveAttribute('active')
     expect(linkElement).toHaveAttribute(
-      'classname',
+      'class',
       'vads-u-display--block vads-u-margin-bottom--7'
     )
   })

--- a/src/templates/components/storyListingLink/index.test.tsx
+++ b/src/templates/components/storyListingLink/index.test.tsx
@@ -18,18 +18,20 @@ describe('<StoryListingLink /> Component', () => {
     jest.clearAllMocks()
   })
 
-  it('renders an anchor element with correct attributes', () => {
-    const linkElement = screen.getByText('See all stories')
+  it('renders a va-link element with correct attributes', () => {
+    const linkElement = document.querySelector('va-link')
     expect(linkElement).toBeInTheDocument()
-    expect(linkElement.tagName).toBe('A')
     expect(linkElement).toHaveAttribute('href', path)
-    expect(linkElement).toHaveAttribute('id', 'news-stories-listing-link')
-    expect(linkElement).toHaveClass('vads-u-display--block')
-    expect(linkElement).toHaveClass('vads-u-margin-bottom--7')
+    expect(linkElement).toHaveAttribute('text', 'See all stories')
+    expect(linkElement).toHaveAttribute('active')
+    expect(linkElement).toHaveAttribute(
+      'classname',
+      'vads-u-display--block vads-u-margin-bottom--7'
+    )
   })
 
   it('invokes recordEvent function with correct event when clicked', () => {
-    const linkElement = screen.getByText('See all stories')
+    const linkElement = document.querySelector('va-link')
     fireEvent.click(linkElement)
     expect(recordEvent).toHaveBeenCalledTimes(1)
     expect(recordEvent).toHaveBeenCalledWith({

--- a/src/templates/components/storyListingLink/index.tsx
+++ b/src/templates/components/storyListingLink/index.tsx
@@ -3,18 +3,18 @@ import { StoryListingLink as FormattedStoryListingLink } from '@/types/formatted
 
 export const StoryListingLink = ({ path }: FormattedStoryListingLink) => {
   return (
-    // @todo can <Link /> be used here?
-    <a
-      onClick={() =>
-        recordEvent({
-          event: 'nav-secondary-button-click',
-        })
-      }
-      className="vads-u-display--block vads-u-margin-bottom--7"
-      href={path}
-      id="news-stories-listing-link"
-    >
-      See all stories
-    </a>
+    <p>
+      <va-link
+        onClick={() =>
+          recordEvent({
+            event: 'nav-secondary-button-click',
+          })
+        }
+        className="vads-u-display--block vads-u-margin-bottom--7"
+        href={path}
+        text="See all stories"
+        active
+      />
+    </p>
   )
 }

--- a/src/templates/components/storyListingLink/index.tsx
+++ b/src/templates/components/storyListingLink/index.tsx
@@ -10,7 +10,7 @@ export const StoryListingLink = ({ path }: FormattedStoryListingLink) => {
             event: 'nav-secondary-button-click',
           })
         }
-        className="vads-u-display--block vads-u-margin-bottom--7"
+        class="vads-u-display--block vads-u-margin-bottom--7"
         href={path}
         text="See all stories"
         active


### PR DESCRIPTION
# Description
This PR addresses 3 small bug fixes including - 
- Encapsulating "See all stories" in a `va-link` `<p>` tag
- correct margin on share links for facebook and twitter on story detail page
- have correct tag and margin on the author byline aka Byline text is wrapped in a single `<p>` tag with only vads-u-margin-bottom--0p5 and vads-u-font-weight--bold classes

## Ticket
Relates to #[20557](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20557)
Relates to #[20558](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20558)
Relates to #[20559](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20559)
## Developer Task

```
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

- [x] Load up your local server
- [x] Go to https://main-kqjsor0i3mjdwsy9gojxhhyvdzh0wubb.tugboat.vfs.va.gov/boston-health-care/stories/turkey-drive-provides-over-300-meals-to-veterans-facing-food-insecurity/
- [x] Go to https://www.va.gov/boston-health-care/stories/turkey-drive-provides-over-300-meals-to-veterans-facing-food-insecurity/
- [x] go to localhost:3999/boston-health-care/stories/turkey-drive-provides-over-300-meals-to-veterans-facing-food-insecurity/
- [x] The "See all news releases" link uses the va-link with the active property
- [x] The component for "See all news releases" must be wrapped in a `<p>` tag
- [x] Go to Share on facebook, share on x section
- [x] Ensure the spacing is there between the 2 and it is wrapped in li tag
- [x] like below the margin
![image](https://github.com/user-attachments/assets/b5f534dc-1cc4-4c56-99b7-08313fc6e361)
- [x] Go to the author of the article section aka the "By ..." section
- [x] Ensure Byline text is wrapped in a single `<p>` tag with only vads-u-margin-bottom--0p5 and vads-u-font-weight--bold classes
- [x] run unit tests

## QA steps
QA review of this behavior and inspect elements 

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/c6caa2ac-6544-4c53-8a12-b1473b728cfc)

After:
![image](https://github.com/user-attachments/assets/357ad1ce-e0ae-4fb0-88c7-1d945d8b3ed0)

Before:
![image](https://github.com/user-attachments/assets/3210369e-5e18-47cb-888f-68fd3db8d5ef)

After:
![image](https://github.com/user-attachments/assets/6f252fda-65c3-4881-88ab-4d0222b963c9)

Before:
![image](https://github.com/user-attachments/assets/3e13e7de-5c84-4d90-887d-4de386a381f2)

After:
![image](https://github.com/user-attachments/assets/c157f440-4222-4c98-b010-863c69effc81)

## Is this PR blocked by another PR?
- Add the `DO NOT MERGE` label
- Add links to additional PRs here:


# Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository. 

## Standard Checks

```
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging an Approved Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` inside the `CMS`. This CMS flag must be turned on for editors to preview their work using the next build preview server.

Resource types (layouts) that have not been approved by design should NOT be pushed to production. Ensure that [slug.tsx](../src/pages/[[...slug]].tsx) does not include your resource type if it is not approved.

The status of layouts should be kept up to date inside [templates.md](./templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.

## Merging a Non-Approved Layout

Your new resource type should not be included inside [slug.tsx](../src/pages/[[...slug]].tsx). Items added here will go into production once merged into the `main` branch. It is imperative that we do not push anything live that has not been approved.

Ensure that this layout has been added to the [templates.md](./templates.md) file with the current status of the work.
