### PR TITLE
Add a filter option to the api explorer

### DIFF
--- a/src/pages/_playground/api-explorer.tsx
+++ b/src/pages/_playground/api-explorer.tsx
@@ -321,6 +321,12 @@ export default function ApiExplorer() {
           <label className="vads-u-display--block vads-u-margin-bottom--1">
             Filters
           </label>
+          {queryState.filters.length === 0 && (
+            <p>
+              <strong>Note:</strong> Filtering by fields on a paragraph entity
+              doesn&apos;t work right now.
+            </p>
+          )}
           {queryState.filters.map((filter, index) => (
             <div
               key={index}

--- a/src/pages/_playground/api-explorer.tsx
+++ b/src/pages/_playground/api-explorer.tsx
@@ -321,7 +321,7 @@ export default function ApiExplorer() {
           <label className="vads-u-display--block vads-u-margin-bottom--1">
             Filters
           </label>
-          {queryState.filters.length === 0 && (
+          {queryState.filters.length > 0 && (
             <p>
               <strong>Note:</strong> Filtering by fields on a paragraph entity
               doesn&apos;t work right now.

--- a/src/pages/_playground/api-explorer.tsx
+++ b/src/pages/_playground/api-explorer.tsx
@@ -116,7 +116,7 @@ export default function ApiExplorer() {
   }
 
   const handleIncludesChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const includes = e.target.value.split('\n').filter((line) => line.trim())
+    const includes = e.target.value.split('\n') //.filter((line) => line.trim())
     setQueryState((prev) => ({ ...prev, includes }))
   }
 
@@ -159,28 +159,17 @@ export default function ApiExplorer() {
   const executeQuery = async () => {
     setQueryState((prev) => ({ ...prev, loading: true, error: null }))
     try {
-      const params = new DrupalJsonApiParams()
-        .addInclude(queryState.includes)
-        .addPageLimit(queryState.pageLimit)
-
-      // Add filters to the query
-      queryState.filters.forEach((filter) => {
-        if (filter.field && filter.operator && filter.value) {
-          params.addFilter(filter.field, filter.operator, filter.value)
-        }
-      })
-
-      const queryParams = params.getQueryObject()
+      const params = {
+        resourceType: queryState.resourceType,
+        includes: queryState.includes.filter((i) => i.trim()),
+        pageLimit: queryState.pageLimit,
+        filters: queryState.filters,
+      }
 
       // Store the request info for debugging
       const debugInfo = {
         requestUrl: '/api/drupal-query',
-        requestParams: {
-          resourceType: queryState.resourceType,
-          includes: queryState.includes,
-          pageLimit: queryState.pageLimit,
-          filters: queryState.filters,
-        },
+        requestParams: params,
       }
 
       const response = await fetch('/api/drupal-query', {
@@ -188,12 +177,7 @@ export default function ApiExplorer() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          resourceType: queryState.resourceType,
-          includes: queryState.includes,
-          pageLimit: queryState.pageLimit,
-          filters: queryState.filters,
-        }),
+        body: JSON.stringify(params),
       })
 
       if (!response.ok) {

--- a/src/pages/_playground/api-explorer.tsx
+++ b/src/pages/_playground/api-explorer.tsx
@@ -116,7 +116,7 @@ export default function ApiExplorer() {
   }
 
   const handleIncludesChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const includes = e.target.value.split('\n') //.filter((line) => line.trim())
+    const includes = e.target.value.split('\n')
     setQueryState((prev) => ({ ...prev, includes }))
   }
 

--- a/src/pages/api/drupal-query.ts
+++ b/src/pages/api/drupal-query.ts
@@ -2,6 +2,12 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { drupalClient } from '@/lib/drupal/drupalClient'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 
+interface Filter {
+  field: string
+  operator: string
+  value?: string
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -11,7 +17,7 @@ export default async function handler(
   }
 
   try {
-    const { resourceType, includes, pageLimit } = req.body
+    const { resourceType, includes, pageLimit, filters } = req.body
 
     if (!resourceType) {
       return res.status(400).json({ error: 'Resource type is required' })
@@ -26,6 +32,15 @@ export default async function handler(
     if (pageLimit) {
       params.addPageLimit(pageLimit)
     }
+
+    // Add filters to the query parameters
+    filters.forEach((filter: Filter) => {
+      if (filter.field && filter.operator) {
+        // The IS NULL and IS NOT NULL operators need null as the value.
+        // Everything else should have a proper value supplied
+        params.addFilter(filter.field, filter.value ?? null, filter.operator)
+      }
+    })
 
     const data = await drupalClient.getResourceCollection(resourceType, {
       params: params.getQueryObject(),


### PR DESCRIPTION
# Description

Adds a filter option to the API explorer so we can find entities that have the data we need to reshape.

![image](https://github.com/user-attachments/assets/fe7c5ad8-557f-4927-be22-e6b785598097)


## Generated description
This pull request introduces a new filtering feature to the API Explorer, allowing users to add, remove, and update filters for their queries. The changes include modifications to both the frontend and backend to support this new functionality.

### Frontend changes in `src/pages/_playground/api-explorer.tsx`:

* Added a new `Filter` interface and integrated it into the `QueryState` interface. [[1]](diffhunk://#diff-f7fabf4e20e95c192c9124c7be6cd43bf315666f1c091c2be8f67fc03fcfba64R71-R76) [[2]](diffhunk://#diff-f7fabf4e20e95c192c9124c7be6cd43bf315666f1c091c2be8f67fc03fcfba64R90)
* Modified the initial state of `queryState` to include an empty `filters` array and changed the default `pageLimit` value.
* Implemented `addFilter`, `removeFilter`, and `updateFilter` functions to manage the filters in the state.
* Updated the `executeQuery` function to add filters to the query parameters before executing the query.
* Added UI elements to allow users to input, update, and remove filters dynamically.

### Backend changes in `src/pages/api/drupal-query.ts`:

* Added a new `Filter` interface to handle filter parameters in the API request.
* Modified the request handler to extract filters from the request body and add them to the query parameters. [[1]](diffhunk://#diff-113fe32dcc5b614d9c8db2e7c832aa34769eb5cca9d60457fe38b593bd816affL14-R20) [[2]](diffhunk://#diff-113fe32dcc5b614d9c8db2e7c832aa34769eb5cca9d60457fe38b593bd816affR36-R44)


