### PR TITLE
Update PR template to link directly to the ticket

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,12 @@ What does this PR address?
 (Select this text, hit the Copilot button, and select "Generate".)
 
 ## Ticket
-Relates to #[TICKET_NUMBER](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/TICKET_NUMBER). (or closes?)
+
+<!--
+https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
+-->
+
+Closes _link to ticket_
 
 ## Developer Task
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,9 @@
 # Description
+
 What does this PR address?
 
 ## Generated description
+
 (Select this text, hit the Copilot button, and select "Generate".)
 
 ## Ticket
@@ -9,7 +11,7 @@ Relates to #[TICKET_NUMBER](https://github.com/department-of-veterans-affairs/va
 
 ## Developer Task
 
-```
+```md
 - [ ] PR submitted against the `main` branch of `next-build`.
 - [ ] Link to the issue that this PR addresses (if applicable).
 - [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
@@ -20,32 +22,36 @@ Relates to #[TICKET_NUMBER](https://github.com/department-of-veterans-affairs/va
 ```
 
 ## Testing Steps
+
 Explain the steps needed for testing
 
 ## QA steps
+
 What needs to be checked to prove this works?  
 What needs to be checked to prove it didn't break any related things?  
 What variations of circumstances (users, actions, values) need to be checked?
 
 ## Screenshots
+
 Before:
 After:
 
-
 ## Is this PR blocked by another PR?
+
 - Add the `DO NOT MERGE` label
 - Add links to additional PRs here:
 
+---
 
-# Reviewer
+## Reviewer
 
 ### Reviewing a PR
 
-This section lists items that need to be checked or updated when making changes to this repository. 
+This section lists items that need to be checked or updated when making changes to this repository.
 
 ## Standard Checks
 
-```
+```md
 - [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
 - [ ] Test Coverage: 80% coverage
 - [ ] Functionality: Change functions as expected with no additional bugs


### PR DESCRIPTION
# Description

The PR template as it was made it cumbersome to go from the ticket to the implementation PR. Just pasting in the link directly makes this navigation easier and triggers the auto-close feature in GitHub, updating our project board appropriately.

Along the way, my markdown auto-formatter added some spaces to make the linter a little happier, and I added code fence languages to the weirdly-code-fenced blocks. 🤷 Again, all to serve Lord Linter, the Marquis of Markdown.

## Demonstration

See [this PR](https://github.com/department-of-veterans-affairs/next-build/pull/929) and [this issue](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20765).

Linking directly looks like this in the PR:
![image](https://github.com/user-attachments/assets/2bb18c4d-4de7-4c91-8440-7f9a62416c7e)

And in the linked issue:
![image](https://github.com/user-attachments/assets/42b5c2de-20ea-4c3e-a6b8-a0e8c1a07d20)
