### PR TITLE
[VACMS-20706]Adjust Vet Center hours display to latest design, add nonTraditionalHours

### DIFF
--- a/src/templates/components/hours/index.test.tsx
+++ b/src/templates/components/hours/index.test.tsx
@@ -39,4 +39,19 @@ describe('Hours Component', () => {
     )
     expect(screen.getByText('Clinical hours')).toBeInTheDocument()
   })
+
+  it('renders "nonTraditionalHours" status correctly', () => {
+    render(
+      <Hours
+        allHours={[{ day: 2, starthours: 900, endhours: 1500, comment: '' }]}
+        headerType="nonTraditionalHours"
+      />
+    )
+    expect(screen.getByText('Hours')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'We also have non-traditional hours that change periodically given our community’s needs. Please call us to find out more.'
+      )
+    ).toBeInTheDocument()
+  })
 })

--- a/src/templates/components/hours/index.test.tsx
+++ b/src/templates/components/hours/index.test.tsx
@@ -40,11 +40,11 @@ describe('Hours Component', () => {
     expect(screen.getByText('Clinical hours')).toBeInTheDocument()
   })
 
-  it('renders "nonTraditionalHours" status correctly', () => {
+  it('renders "nonTraditional" status correctly', () => {
     render(
       <Hours
         allHours={[{ day: 2, starthours: 900, endhours: 1500, comment: '' }]}
-        headerType="nonTraditionalHours"
+        headerType="nonTraditional"
       />
     )
     expect(screen.getByText('Hours')).toBeInTheDocument()

--- a/src/templates/components/hours/index.test.tsx
+++ b/src/templates/components/hours/index.test.tsx
@@ -3,6 +3,9 @@ import '@testing-library/jest-dom'
 import { Hours } from './'
 
 describe('Hours Component', () => {
+  const nonTraditionalWarning =
+    'We also have non-traditional hours that change periodically given our community’s needs. Please call us to find out more.'
+
   it('renders null when allHours is empty', () => {
     const { container } = render(<Hours allHours={[]} headerType="standard" />)
     expect(container).toBeEmptyDOMElement()
@@ -16,6 +19,7 @@ describe('Hours Component', () => {
       />
     )
     expect(screen.getByText('Hours')).toBeInTheDocument()
+    expect(screen.queryByText(nonTraditionalWarning)).not.toBeInTheDocument()
   })
 
   it('formats and displays office hours correctly', () => {
@@ -48,10 +52,6 @@ describe('Hours Component', () => {
       />
     )
     expect(screen.getByText('Hours')).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'We also have non-traditional hours that change periodically given our community’s needs. Please call us to find out more.'
-      )
-    ).toBeInTheDocument()
+    expect(screen.getByText(nonTraditionalWarning)).toBeInTheDocument()
   })
 })

--- a/src/templates/components/hours/index.tsx
+++ b/src/templates/components/hours/index.tsx
@@ -2,12 +2,7 @@ import { FieldOfficeHours } from '@/types/drupal/field_type'
 
 type HoursProps = {
   allHours: FieldOfficeHours[]
-  headerType:
-    | 'small'
-    | 'standard'
-    | 'clinical'
-    | 'office'
-    | 'nonTraditionalHours'
+  headerType: 'small' | 'standard' | 'clinical' | 'office' | 'nonTraditional'
 }
 
 export const Hours = ({ allHours, headerType }: HoursProps) => {
@@ -39,7 +34,6 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
           </h3>
         )
       case 'standard':
-      case 'nonTraditionalHours':
         return (
           <h3 className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
             Hours
@@ -63,18 +57,21 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
             </p>
           </>
         )
+      case 'nonTraditional':
+        return (
+          <>
+            <h3 className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
+              Hours
+            </h3>
+            <p>
+              We also have non-traditional hours that change periodically given
+              our community’s needs. Please call us to find out more.
+            </p>
+          </>
+        )
       default:
         return null
     }
-  }
-
-  const renderNonTraditionalHours = () => {
-    return (
-      <p>
-        We also have non-traditional hours that change periodically given our
-        community’s needs. Please call us to find out more.
-      </p>
-    )
   }
 
   return (
@@ -102,7 +99,6 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
             })}
           </ul>
         </div>
-        {headerType === 'nonTraditionalHours' && renderNonTraditionalHours()}
       </div>
     </div>
   )

--- a/src/templates/components/hours/index.tsx
+++ b/src/templates/components/hours/index.tsx
@@ -2,7 +2,12 @@ import { FieldOfficeHours } from '@/types/drupal/field_type'
 
 type HoursProps = {
   allHours: FieldOfficeHours[]
-  headerType: 'small' | 'standard' | 'clinical' | 'office'
+  headerType:
+    | 'small'
+    | 'standard'
+    | 'clinical'
+    | 'office'
+    | 'nonTraditionalHours'
 }
 
 export const Hours = ({ allHours, headerType }: HoursProps) => {
@@ -34,6 +39,7 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
           </h3>
         )
       case 'standard':
+      case 'nonTraditionalHours':
         return (
           <h3 className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
             Hours
@@ -62,6 +68,15 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
     }
   }
 
+  const renderNonTraditionalHours = () => {
+    return (
+      <p>
+        We also have non-traditional hours that change periodically given our
+        community’s needs. Please call us to find out more.
+      </p>
+    )
+  }
+
   return (
     <div className="vads-u-margin-bottom--0" data-template="hours">
       <div className="clinicalhours">
@@ -74,7 +89,9 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
               const DayTag = headerType === 'clinical' ? 'strong' : 'span'
               return (
                 <li key={index}>
-                  <DayTag className="abbrv-day">{dayNames[dayIndex]}.</DayTag>{' '}
+                  <DayTag className="abbrv-day vads-u-font-weight--bold">
+                    {dayNames[dayIndex]}:
+                  </DayTag>{' '}
                   {hoursItem.starthours === null
                     ? 'Closed'
                     : `${formatHours(hoursItem.starthours)} to ${formatHours(
@@ -85,6 +102,7 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
             })}
           </ul>
         </div>
+        {headerType === 'nonTraditionalHours' && renderNonTraditionalHours()}
       </div>
     </div>
   )


### PR DESCRIPTION
# Description
This takes the displaying of Hours (currently only used by Vet Centers) and updates it to the latest designs. Additionally, it adds `nonTraditionalHours` to handle the displaying of those for Vet Centers and their Outstations

## Generated description


This pull request introduces a new header type `nonTraditionalHours` to the `Hours` component and updates the corresponding tests and styles.

Key changes include:

### Component Updates:
* [`src/templates/components/hours/index.tsx`](diffhunk://#diff-1f88527a9c3897b8c85fa207a31b9a2ce024830fab5f0d957b71b138f8b2f708R65-R76): Added a new case for `nonTraditionalHours` in the `Hours` component to display a specific message about non-traditional hours.

### Type Updates:
* [`src/templates/components/hours/index.tsx`](diffhunk://#diff-1f88527a9c3897b8c85fa207a31b9a2ce024830fab5f0d957b71b138f8b2f708L5-R10): Updated the `HoursProps` type to include the new `nonTraditionalHours` header type.

### Style Updates:
* [`src/templates/components/hours/index.tsx`](diffhunk://#diff-1f88527a9c3897b8c85fa207a31b9a2ce024830fab5f0d957b71b138f8b2f708L77-R96): Modified the `DayTag` element to include a bold font weight for better visibility.

### Test Updates:
* [`src/templates/components/hours/index.test.tsx`](diffhunk://#diff-7adc019ffff6180e3aae02c2c950abcd4098138b66c6e06f7eae530262414813R42-R56): Added a new test case to verify the correct rendering of the `nonTraditionalHours` status.

## Ticket

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20706

## Developer Task

```md
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #accelerated-publishing Slack channel to request a PR review.
- [x] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

This can be viewed from storybook, head over to http://localhost:6006/?path=/docs/layouts-vetcenter--docs and see the Hours display change when switching to this branch. 

## QA steps
Tugboat URL for Vet Center: https://pr935-io79eedsc6kdsk7efp9q6vhxsabsznys.tugboat.vfs.va.gov/portland-or-vet-center/
What needs to be checked to prove this works?  
Head into the tugboat and check various Vet Centers to confirm displaying of hours 
What needs to be checked to prove it didn't break any related things?  
Vet Center Hours displaying as expected
What variations of circumstances (users, actions, values) need to be checked?
From local, adjust Vet Center to display hours with `nonTraditionalHours` instead of `standard` to see the displaying of the additional text.

## Screenshots

Before: 
<img width="719" alt="Screenshot 2025-03-20 at 1 26 25 PM" src="https://github.com/user-attachments/assets/4166f371-bee9-443c-a342-37d9ec7ad4f8" />

After: 
<img width="985" alt="Screenshot 2025-03-20 at 1 27 07 PM" src="https://github.com/user-attachments/assets/15670be3-5a36-4f20-9893-5835f4cf6347" />

<img width="765" alt="Screenshot 2025-03-20 at 1 36 56 PM" src="https://github.com/user-attachments/assets/fea8df8e-cea7-4687-9a0d-9804aa1a41e5" />


## Is this PR blocked by another PR?
Nope


---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging an Approved Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` inside the `CMS`. This CMS flag must be turned on for editors to preview their work using the next build preview server.

Resource types (layouts) that have not been approved by design should NOT be pushed to production. Ensure that [slug.tsx](../src/pages/[[...slug]].tsx) does not include your resource type if it is not approved.

The status of layouts should be kept up to date inside [templates.md](./templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.

## Merging a Non-Approved Layout

Your new resource type should not be included inside [slug.tsx](../src/pages/[[...slug]].tsx). Items added here will go into production once merged into the `main` branch. It is imperative that we do not push anything live that has not been approved.

Ensure that this layout has been added to the [templates.md](./templates.md) file with the current status of the work.
