### PR TITLE
[VACMS-20945]Display Vet Center nonTraditionalHours warning above hours

### DIFF
--- a/src/templates/components/hours/hours.stories.ts
+++ b/src/templates/components/hours/hours.stories.ts
@@ -65,3 +65,65 @@ export const Default: Story = {
     headerType: 'standard',
   },
 }
+
+export const NonTraditionalMessage: Story = {
+  args: {
+    allHours: [
+      {
+        day: 0,
+        all_day: false,
+        starthours: null,
+        endhours: null,
+        comment: 'Closed',
+      },
+      {
+        day: 1,
+        all_day: false,
+        starthours: 800,
+        endhours: 1630,
+        comment: '',
+      },
+      {
+        day: 2,
+        all_day: false,
+        starthours: 800,
+        endhours: 1630,
+        comment: '',
+      },
+      {
+        day: 3,
+        all_day: false,
+        starthours: 800,
+        endhours: 1630,
+        comment: '',
+      },
+      {
+        day: 4,
+        all_day: false,
+        starthours: 800,
+        endhours: 1630,
+        comment: '',
+      },
+      {
+        day: 5,
+        all_day: false,
+        starthours: 800,
+        endhours: 1630,
+        comment: '',
+      },
+      {
+        day: 6,
+        all_day: false,
+        starthours: null,
+        endhours: null,
+        comment: 'Closed',
+      },
+    ],
+    headerType: 'standard',
+    nonTraditionalMessage: {
+      id: '1',
+      type: 'paragraph--wysiwyg',
+      html: '<p>We also have non-traditional hours that change periodically given our community’s needs. Please call us to find out more.</p>',
+    },
+  },
+}

--- a/src/templates/components/hours/index.test.tsx
+++ b/src/templates/components/hours/index.test.tsx
@@ -44,14 +44,19 @@ describe('Hours Component', () => {
     expect(screen.getByText('Clinical hours')).toBeInTheDocument()
   })
 
-  it('renders "nonTraditional" status correctly', () => {
+  it('renders "nonTraditionalMessage" correctly', () => {
     render(
       <Hours
         allHours={[{ day: 2, starthours: 900, endhours: 1500, comment: '' }]}
-        headerType="nonTraditional"
+        headerType="standard"
+        nonTraditionalMessage={{
+          id: '1',
+          type: 'paragraph--wysiwyg',
+          html: '<p>nonTraditionalMessage</p>',
+        }}
       />
     )
     expect(screen.getByText('Hours')).toBeInTheDocument()
-    expect(screen.getByText(nonTraditionalWarning)).toBeInTheDocument()
+    expect(screen.getByText('nonTraditionalMessage')).toBeInTheDocument()
   })
 })

--- a/src/templates/components/hours/index.tsx
+++ b/src/templates/components/hours/index.tsx
@@ -1,11 +1,18 @@
 import { FieldOfficeHours } from '@/types/drupal/field_type'
+import { WysiwygField } from '@/templates/components/wysiwyg'
+import { Wysiwyg } from '@/types/formatted/wysiwyg'
 
 type HoursProps = {
   allHours: FieldOfficeHours[]
-  headerType: 'small' | 'standard' | 'clinical' | 'office' | 'nonTraditional'
+  headerType: 'small' | 'standard' | 'clinical' | 'office'
+  nonTraditionalMessage?: Wysiwyg
 }
 
-export const Hours = ({ allHours, headerType }: HoursProps) => {
+export const Hours = ({
+  allHours,
+  headerType,
+  nonTraditionalMessage,
+}: HoursProps) => {
   if (!allHours || allHours.length === 0) {
     return null
   }
@@ -35,9 +42,16 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
         )
       case 'standard':
         return (
-          <h3 className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
-            Hours
-          </h3>
+          <>
+            <h3 className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
+              Hours
+            </h3>
+            {nonTraditionalMessage && (
+              <div id="field-cc-non-traditional-hours">
+                <WysiwygField html={nonTraditionalMessage.html} />
+              </div>
+            )}
+          </>
         )
       case 'clinical':
         return (
@@ -54,18 +68,6 @@ export const Hours = ({ allHours, headerType }: HoursProps) => {
             <p>
               Hours may vary for different services. Select a service on this
               page to check the hours.
-            </p>
-          </>
-        )
-      case 'nonTraditional':
-        return (
-          <>
-            <h3 className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
-              Hours
-            </h3>
-            <p>
-              We also have non-traditional hours that change periodically given
-              our community’s needs. Please call us to find out more.
             </p>
           </>
         )

--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -3,7 +3,6 @@ import { GoogleMapsDirections } from '@/templates/common/googleMapsDirections'
 import { Hours } from '@/templates/components/hours'
 import { ImageAndStaticMap } from '@/templates/components/imageAndStaticMap'
 import { AlertBlock } from '@/templates/components/alertBlock'
-import { WysiwygField } from '@/templates/components/wysiwyg'
 import HealthServices from '@/templates/components/healthServices'
 import { FeaturedContent } from '@/templates/common/featuredContent'
 import { QaSection } from '@/templates/components/qaSection'
@@ -223,7 +222,11 @@ export function VetCenter({
                       </div>
                     </div>
 
-                    <Hours headerType="standard" allHours={officeHours} />
+                    <Hours
+                      headerType="standard"
+                      allHours={officeHours}
+                      nonTraditionalMessage={ccNonTraditionalHours}
+                    />
                   </section>
                 </div>
               </div>
@@ -247,15 +250,6 @@ export function VetCenter({
               <a href={`${path}/locations`}>View more {title} locations</a>
             </div>
           </div>
-
-          {ccNonTraditionalHours && (
-            <div
-              className="vads-u-font-weight--bold"
-              id="field-cc-non-traditional-hours"
-            >
-              <WysiwygField html={ccNonTraditionalHours.html} />
-            </div>
-          )}
 
           {/* Call Center Information */}
           {ccVetCenterCallCenter && (


### PR DESCRIPTION
# Description

Moves the displaying of Vet Center `nonTraditionalHours` messages by passing it along to the `Hours` component. This is being done so that the message can be displayed above the hours and below the header, per the latest designs.

## Generated description

This pull request includes changes to the `Hours` component and its associated files to support a new `nonTraditionalMessage` property. The most important changes include adding the `nonTraditionalMessage` property to the `Hours` component, updating the corresponding stories and tests, and removing the previous handling of non-traditional hours.

Changes to the `Hours` component:

* [`src/templates/components/hours/index.tsx`](diffhunk://#diff-1f88527a9c3897b8c85fa207a31b9a2ce024830fab5f0d957b71b138f8b2f708R2-R15): Added the `nonTraditionalMessage` property to the `Hours` component and updated the rendering logic to include `WysiwygField` if `nonTraditionalMessage` is present. Removed the previous handling of `nonTraditional` header type. [[1]](diffhunk://#diff-1f88527a9c3897b8c85fa207a31b9a2ce024830fab5f0d957b71b138f8b2f708R2-R15) [[2]](diffhunk://#diff-1f88527a9c3897b8c85fa207a31b9a2ce024830fab5f0d957b71b138f8b2f708R45-R54) [[3]](diffhunk://#diff-1f88527a9c3897b8c85fa207a31b9a2ce024830fab5f0d957b71b138f8b2f708L60-L71)

Updates to stories and tests:

* [`src/templates/components/hours/hours.stories.ts`](diffhunk://#diff-eb11410f1bccebf96d9c6734a9d4292b11d11b4b48b40f5fd39a3b7fee4cbdd4R68-R129): Added a new story `NonTraditionalMessage` to demonstrate the `nonTraditionalMessage` property.
* [`src/templates/components/hours/index.test.tsx`](diffhunk://#diff-7adc019ffff6180e3aae02c2c950abcd4098138b66c6e06f7eae530262414813L47-R60): Updated the test to check for the `nonTraditionalMessage` property instead of the previous `nonTraditional` status.

Changes to the `VetCenter` layout:

* [`src/templates/layouts/vetCenter/index.tsx`](diffhunk://#diff-53ebb0fee0ab18e4d0faa66c372a825bddedbadc876658a29239d656d11de5baL226-R229): Updated the `Hours` component usage to include the `nonTraditionalMessage` property and removed the previous handling of non-traditional hours. [[1]](diffhunk://#diff-53ebb0fee0ab18e4d0faa66c372a825bddedbadc876658a29239d656d11de5baL226-R229) [[2]](diffhunk://#diff-53ebb0fee0ab18e4d0faa66c372a825bddedbadc876658a29239d656d11de5baL251-L259)

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20945

## Developer Task

```md
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #next-build Slack channel to request a PR review.
- [x] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

This can be tested in either [Storybook ](http://localhost:6006/?path=/docs/components-hours--docs#non%20traditional%20message) or by pulling up a VC like [Portland, OR Vet Center](http://localhost:3999/portland-or-vet-center/)
Once there verify that the `ccNonTraditionalHours` message is displayed (if provided) and that it is being displayed below the Hours header but prior to the hours.

## QA steps

What needs to be checked to prove this works?
Vet Center displaying of `NonTraditionalHours` warning message.

What needs to be checked to prove it didn't break any related things?
Vet Centers and the displaying of their operating hours.

What variations of circumstances (users, actions, values) need to be checked?
With and without `NonTraditionalHours` being provided by the VC.

## Screenshots

Before: 
<img width="799" alt="Screenshot 2025-03-25 at 8 15 22 AM" src="https://github.com/user-attachments/assets/c86ab0b1-2347-4936-9777-b7ede8e7c5db" />


After: 
<img width="797" alt="Screenshot 2025-03-25 at 8 14 50 AM" src="https://github.com/user-attachments/assets/80693258-f2cd-4ca2-984e-bd475fc942f0" />


## Is this PR blocked by another PR?

No

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging an Approved Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` inside the `CMS`. This CMS flag must be turned on for editors to preview their work using the next build preview server.

Resource types (layouts) that have not been approved by design should NOT be pushed to production. Ensure that [slug.tsx](../src/pages/[[...slug]].tsx) does not include your resource type if it is not approved.

The status of layouts should be kept up to date inside [templates.md](./templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.

## Merging a Non-Approved Layout

Your new resource type should not be included inside [slug.tsx](../src/pages/[[...slug]].tsx). Items added here will go into production once merged into the `main` branch. It is imperative that we do not push anything live that has not been approved.

Ensure that this layout has been added to the [templates.md](./templates.md) file with the current status of the work.
