### PR TITLE
[VACMS-20706]Adjust Vet Center components to latest designs

### DIFF
--- a/additional.d.ts
+++ b/additional.d.ts
@@ -28,6 +28,7 @@ declare namespace JSX {
     'va-back-to-top'
     'va-breadcrumbs'
     'va-button'
+    'va-card'
     'va-icon'
     'va-link'
     'va-link-action'

--- a/src/templates/common/featuredContent/index.test.tsx
+++ b/src/templates/common/featuredContent/index.test.tsx
@@ -28,6 +28,10 @@ describe('FeaturedContent with valid data', () => {
 
     expect(screen.queryByText(/Hello world/)).toBeInTheDocument()
     expect(screen.queryByText(/foo bar/)).toBeInTheDocument()
-    expect(screen.queryByText(/a link/)).toBeInTheDocument()
+    // Check for link inside va-link
+    const vaLinkElement = screen.getByTestId('featured-content-link')
+    expect(vaLinkElement).toBeInTheDocument()
+    expect(vaLinkElement).toHaveAttribute('href', '#')
+    expect(vaLinkElement).toHaveAttribute('text', 'a link')
   })
 })

--- a/src/templates/common/featuredContent/index.tsx
+++ b/src/templates/common/featuredContent/index.tsx
@@ -20,19 +20,13 @@ export function FeaturedContent({
         />
       )}
       {link && link.url && (
-        <a
-          className="vads-c-action-link--blue vads-u-display--block vads-u-padding-top--1"
+        <va-link
+          className="vads-u-display--block vads-u-padding-top--1"
           href={link.url}
-        >
-          <span>
-            {' '}
-            {link.label}{' '}
-            <i
-              className="fa fa-chevron-right vads-facility-hub-cta-arrow"
-              aria-hidden="true"
-            ></i>
-          </span>
-        </a>
+          text={link.label}
+          active={true}
+          data-testid="featured-content-link"
+        />
       )}
     </div>
   )

--- a/src/templates/common/featuredContent/index.tsx
+++ b/src/templates/common/featuredContent/index.tsx
@@ -7,7 +7,7 @@ export function FeaturedContent({
   link,
 }: ParagraphComponent<FormattedFeaturedContent>) {
   return (
-    <div className="vads-u-border--1px featured-content-list-item vads-u-flex--fill vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--0 medium-screen:vads-u-margin-bottom--2">
+    <div className="vads-u-border--1px featured-content-list-item vads-u-flex--fill vads-u-padding-bottom--2 vads-u-padding-x--1p5 vads-u-margin-y--0 medium-screen:vads-u-margin-bottom--2">
       {title && (
         <>
           <h3 className="vads-u-margin-bottom--2">{title}</h3>

--- a/src/templates/common/featuredContent/index.tsx
+++ b/src/templates/common/featuredContent/index.tsx
@@ -7,7 +7,7 @@ export function FeaturedContent({
   link,
 }: ParagraphComponent<FormattedFeaturedContent>) {
   return (
-    <va-card class="vads-u-flex--fill vads-u-margin-bottom--2 vads-u-margin-right--0 medium-screen:vads-u-margin-x--0p5 spotlight-card hydrated">
+    <va-card class="vads-u-flex--fill vads-u-margin-bottom--2 vads-u-margin-right--0 medium-screen:vads-u-margin-x--0p5 spotlight-card">
       {title && (
         <>
           <h3 className="vads-u-margin-top--0">{title}</h3>
@@ -21,7 +21,6 @@ export function FeaturedContent({
       )}
       {link && link.url && (
         <va-link
-          class="hydrated"
           href={link.url}
           text={link.label}
           active={true}

--- a/src/templates/common/featuredContent/index.tsx
+++ b/src/templates/common/featuredContent/index.tsx
@@ -7,10 +7,10 @@ export function FeaturedContent({
   link,
 }: ParagraphComponent<FormattedFeaturedContent>) {
   return (
-    <div className="vads-u-border--1px featured-content-list-item vads-u-flex--fill vads-u-padding-bottom--2 vads-u-padding-x--1p5 vads-u-margin-y--0 medium-screen:vads-u-margin-bottom--2">
+    <va-card class="vads-u-flex--fill vads-u-margin-bottom--2 vads-u-margin-right--0 medium-screen:vads-u-margin-x--0p5 spotlight-card hydrated">
       {title && (
         <>
-          <h3 className="vads-u-margin-bottom--2">{title}</h3>
+          <h3 className="vads-u-margin-top--0">{title}</h3>
         </>
       )}
       {description && (
@@ -21,13 +21,13 @@ export function FeaturedContent({
       )}
       {link && link.url && (
         <va-link
-          className="vads-u-display--block vads-u-padding-top--1"
+          class="hydrated"
           href={link.url}
           text={link.label}
           active={true}
           data-testid="featured-content-link"
         />
       )}
-    </div>
+    </va-card>
   )
 }

--- a/src/templates/common/featuredContent/index.tsx
+++ b/src/templates/common/featuredContent/index.tsx
@@ -7,13 +7,10 @@ export function FeaturedContent({
   link,
 }: ParagraphComponent<FormattedFeaturedContent>) {
   return (
-    <div className="feature featured-content-list-item vads-u-flex--fill vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--0 medium-screen:vads-u-margin-bottom--2">
+    <div className="vads-u-border--1px featured-content-list-item vads-u-flex--fill vads-u-padding-y--1p5 vads-u-padding-x--1p5 vads-u-margin-bottom--0 medium-screen:vads-u-margin-bottom--2">
       {title && (
         <>
-          <h3 className="force-small-header vads-u-margin-bottom--2">
-            {title}
-          </h3>
-          <hr className="featured-content-hr vads-u-margin-y--1p5 vads-u-border-color--primary"></hr>
+          <h3 className="vads-u-margin-bottom--2">{title}</h3>
         </>
       )}
       {description && (
@@ -24,7 +21,7 @@ export function FeaturedContent({
       )}
       {link && link.url && (
         <a
-          className="vads-u-display--block vads-u-padding-top--1"
+          className="vads-c-action-link--blue vads-u-display--block vads-u-padding-top--1"
           href={link.url}
         >
           <span>

--- a/src/templates/components/paragraph/index.test.tsx
+++ b/src/templates/components/paragraph/index.test.tsx
@@ -41,7 +41,11 @@ describe('FeaturedContent Component', () => {
     expect(
       screen.getByText('Featured content description.')
     ).toBeInTheDocument()
-    expect(screen.getByText('Read More')).toBeInTheDocument()
+    // Check for link inside va-link
+    const vaLinkElement = screen.getByTestId('featured-content-link')
+    expect(vaLinkElement).toBeInTheDocument()
+    expect(vaLinkElement).toHaveAttribute('href', '/featured-content-url')
+    expect(vaLinkElement).toHaveAttribute('text', 'Read More')
   })
 })
 

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -3,6 +3,7 @@ import { QaCollapsiblePanel } from '../qaCollapsiblePanel'
 import { QaGroup as FormattedQaGroup } from '@/types/formatted/qaGroup'
 import { Paragraph } from '@/templates/components/paragraph'
 import { FormattedParagraph } from '@/data/queries'
+import { slugifyString } from '@/lib/utils/slug'
 
 export function QaSection({
   header,
@@ -12,12 +13,7 @@ export function QaSection({
 }: FormattedQaSection | FormattedQaGroup) {
   const setHeaderh3 = header ? true : false
   // Prepare id for use by va-on-this-page component to identify the QaSection
-  const headerId = header
-    ? header
-        .toLowerCase()
-        .replace(/[^a-z0-9\s]/g, '')
-        .replace(/\s+/g, '-')
-    : ''
+  const headerId = header ? slugifyString(header) : ''
   return (
     <div data-template="paragraphs/q_a_section">
       {header && <h2 id={headerId}>{header}</h2>}

--- a/src/templates/components/qaSection/index.tsx
+++ b/src/templates/components/qaSection/index.tsx
@@ -11,9 +11,16 @@ export function QaSection({
   displayAccordion,
 }: FormattedQaSection | FormattedQaGroup) {
   const setHeaderh3 = header ? true : false
+  // Prepare id for use by va-on-this-page component to identify the QaSection
+  const headerId = header
+    ? header
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, '')
+        .replace(/\s+/g, '-')
+    : ''
   return (
     <div data-template="paragraphs/q_a_section">
-      {header && <h2>{header}</h2>}
+      {header && <h2 id={headerId}>{header}</h2>}
       {intro && <p>{intro}</p>}
       {displayAccordion ? (
         <QaCollapsiblePanel questions={questions} />

--- a/src/templates/layouts/vetCenter/index.test.tsx
+++ b/src/templates/layouts/vetCenter/index.test.tsx
@@ -218,6 +218,6 @@ describe('VetCenter with valid data', () => {
     expect(imgEl).toBeTruthy()
     expect(screen.queryByText(/Test introText/)).toBeInTheDocument()
     expect(screen.queryByText(/1010 Delafield Road/)).toBeInTheDocument()
-    expect(screen.queryByText(/In the spotlight at/)).toBeInTheDocument()
+    expect(screen.queryByText(/In the spotlight/)).toBeInTheDocument()
   })
 })

--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -274,7 +274,7 @@ export function VetCenter({
             className="vads-u-margin-top--0 vads-u-font-size--lg
           mobile-lg:vads-u-font-size--xl vads-u-margin-bottom--2"
           >
-            In the spotlight at {title}
+            In the spotlight
           </h2>
           <div
             id="field-vet-center-feature-content"


### PR DESCRIPTION
# Description

Brings Vet Center components up to date with latest designs [here](https://www.figma.com/design/EVd3q06ukAbVS61Q8MwRAT/Vet-Centers?node-id=1790-8784&t=hm7pw0FEJZzIMMCs-1)
Updates the Vet Center Featured Content to no longer have a blue background and instead an arrow pointing towards the link. Additionally, adds an ID to the qa section so that it can be capture by the "on this page" component.


## Generated description

This pull request includes several updates to the `FeaturedContent` component and its associated tests, as well as some changes to the `QaSection` component. The main changes involve updating the structure and attributes of the `FeaturedContent` component, adding utility functions, and modifying test cases to reflect these updates.

### Updates to `FeaturedContent` component:

* Updated the `FeaturedContent` component to use the `va-link` element instead of a standard `<a>` tag, including setting attributes such as `text`, `active`, and `data-testid`.
* Modified the structure and styling of the `FeaturedContent` component, including changes to the class names and removal of unnecessary elements.

### Test case updates:

* Updated test cases in `index.test.tsx` to check for the presence of the `va-link` element and its attributes instead of a standard link. [[1]](diffhunk://#diff-6fc73c8fe9ecb7339082075df514483eb4e6a4872d1ec032331fa42ffa6f12a1L31-R35) [[2]](diffhunk://#diff-21c3fe2d8ec624f86c4d9775f9d559e3b713a792e63425b2539e1a6f3184379aL44-R48)

### Utility function addition:

* Added the `slugifyString` utility function to the `QaSection` component to generate IDs for headers, improving accessibility and integration with the `va-on-this-page` component. [[1]](diffhunk://#diff-c3abf04af17f9b9448d4c90c8788ab387ee1584daa366fe31f14a50c622e1e54R6) [[2]](diffhunk://#diff-c3abf04af17f9b9448d4c90c8788ab387ee1584daa366fe31f14a50c622e1e54R15-R19)

## Ticket

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20706

## Developer Task

```md
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #next-build Slack channel to request a PR review.
- [x] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

Pull this down locally and head over to a Vet Center like http://localhost:3999/portland-or-vet-center/
On this page you will see the addition in the On this Page section as well as the changes to the In the Spotlight

## QA steps

What needs to be checked to prove this works?
Vet Centers, On this page section and In the Spotlight
What needs to be checked to prove it didn't break any related things?
Verifying that On this page section has no issues with various VC headers for QA Sections.
What variations of circumstances (users, actions, values) need to be checked?
Various VCs

## Screenshots

Before: 
<img width="821" alt="Screenshot 2025-03-26 at 7 55 45 AM" src="https://github.com/user-attachments/assets/251712ec-cbb4-4d11-b862-7817bd21baaf" />

<img width="846" alt="Screenshot 2025-03-26 at 7 56 42 AM" src="https://github.com/user-attachments/assets/8f823a19-6fe7-4dd4-be6a-f29865857726" />

After: 
<img width="868" alt="Screenshot 2025-03-26 at 11 47 41 AM" src="https://github.com/user-attachments/assets/c8ca4a82-ae45-4472-8a18-ce77fc488b99" />


<img width="803" alt="Screenshot 2025-03-26 at 7 54 04 AM" src="https://github.com/user-attachments/assets/f38bfb47-5c47-4edd-a5d6-8e3e11a2a470" />

## Is this PR blocked by another PR?

No

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging an Approved Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` inside the `CMS`. This CMS flag must be turned on for editors to preview their work using the next build preview server.

Resource types (layouts) that have not been approved by design should NOT be pushed to production. Ensure that [slug.tsx](../src/pages/[[...slug]].tsx) does not include your resource type if it is not approved.

The status of layouts should be kept up to date inside [templates.md](./templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.

## Merging a Non-Approved Layout

Your new resource type should not be included inside [slug.tsx](../src/pages/[[...slug]].tsx). Items added here will go into production once merged into the `main` branch. It is imperative that we do not push anything live that has not been approved.

Ensure that this layout has been added to the [templates.md](./templates.md) file with the current status of the work.
