### PR TITLE
Operational status flags

### DIFF
--- a/src/templates/layouts/healthCareLocalFacility/OperatingStatus.test.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/OperatingStatus.test.tsx
@@ -32,7 +32,7 @@ describe('HealthCareLocalFacility OperatingStatusFlags', () => {
 
   test.each([
     ['notice', 'info', 'Facility notice'],
-    ['limited', 'warning', 'Limited services and hours'],
+    ['limited', 'info', 'Limited services and hours'],
     ['temporary_closure', 'warning', 'Temporary facility closure'],
     ['temporary_location', 'warning', 'Temporary location'],
     ['virtual_care', 'warning', 'Virtual care only'],

--- a/src/templates/layouts/healthCareLocalFacility/OperatingStatus.test.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/OperatingStatus.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import { OperatingStatusFlags } from './OperatingStatus'
+import { ComponentProps } from 'react'
+
+const mockData: ComponentProps<typeof OperatingStatusFlags> = {
+  operatingStatusFacility: 'normal',
+  menu: {
+    rootPath: '/test-nav-path',
+    data: {
+      name: 'test-nav',
+      description: 'test-nav-description',
+      links: [
+        {
+          url: {
+            path: '/test-nav-path',
+          },
+          description: 'test-nav-description',
+          expanded: true,
+          label: 'test-nav-label',
+          links: [],
+        },
+      ],
+    },
+  },
+}
+
+describe('HealthCareLocalFacility OperatingStatusFlags', () => {
+  test('Renders null for normal status', () => {
+    const { container } = render(<OperatingStatusFlags {...mockData} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  test.each([
+    ['notice', 'info', 'Facility notice'],
+    ['limited', 'warning', 'Limited services and hours'],
+    ['temporary_closure', 'warning', 'Temporary facility closure'],
+    ['temporary_location', 'warning', 'Temporary location'],
+    ['virtual_care', 'warning', 'Virtual care only'],
+    ['coming_soon', 'warning', 'Coming soon'],
+    ['closed', 'warning', 'Facility closed'],
+  ])(
+    'renders va-alert with correct status and text for status "%s"',
+    (operatingStatus, expectedAlertStatus, expectedText) => {
+      const { container } = render(
+        <OperatingStatusFlags
+          menu={mockData.menu}
+          operatingStatusFacility={operatingStatus}
+        />
+      )
+
+      const alert = container.querySelector('va-alert')
+      expect(alert).toBeInTheDocument()
+      expect(alert).toHaveAttribute('status', expectedAlertStatus)
+
+      const link = container.querySelector('va-link', { name: expectedText })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        mockData.menu.data.links[0].url.path + '/operating-status'
+      )
+      expect(link).toHaveAttribute('text', expectedText)
+    }
+  )
+})

--- a/src/templates/layouts/healthCareLocalFacility/OperatingStatus.test.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/OperatingStatus.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { OperatingStatusFlags } from './OperatingStatus'
 import { ComponentProps } from 'react'
 

--- a/src/templates/layouts/healthCareLocalFacility/OperatingStatus.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/OperatingStatus.tsx
@@ -40,13 +40,15 @@ export const OperatingStatusFlags = ({
   if (Object.keys(presentations).includes(operatingStatusFacility)) {
     const { status, text } = presentations[operatingStatusFacility]
     return (
-      <va-alert status={status} slim visible>
-        <va-link
-          class="vads-u-font-weight--bold operating-status-link"
-          href={`${linkBasePath}/operating-status`}
-          text={text}
-        />
-      </va-alert>
+      <div className="vads-u-display--inline-block vads-u-margin-bottom--1">
+        <va-alert status={status} slim visible>
+          <va-link
+            class="vads-u-font-weight--bold operating-status-link"
+            href={`${linkBasePath}/operating-status`}
+            text={text}
+          />
+        </va-alert>
+      </div>
     )
   }
 

--- a/src/templates/layouts/healthCareLocalFacility/OperatingStatus.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/OperatingStatus.tsx
@@ -26,7 +26,7 @@ export const OperatingStatusFlags = ({
     { status: 'info' | 'warning' | 'error'; text: string }
   > = {
     notice: { status: 'info', text: 'Facility notice' },
-    limited: { status: 'warning', text: 'Limited services and hours' },
+    limited: { status: 'info', text: 'Limited services and hours' },
     temporary_closure: {
       status: 'warning',
       text: 'Temporary facility closure',

--- a/src/templates/layouts/healthCareLocalFacility/OperatingStatus.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/OperatingStatus.tsx
@@ -1,0 +1,55 @@
+import { FacilityOperatingStatusFlags } from '@/types/drupal/node'
+import { HealthCareLocalFacility as FormattedHealthCareLocalFacility } from '@/types/formatted/healthCareLocalFacility'
+
+/**
+ * Return a <va-alert> with the appropriate status and link to the operating
+ * status page.
+ *
+ * Returns null if the operating status is 'normal' or if the menu data doesn't
+ * have the expected link.
+ */
+export const OperatingStatusFlags = ({
+  operatingStatusFacility,
+  menu,
+}: Pick<
+  FormattedHealthCareLocalFacility,
+  'operatingStatusFacility' | 'menu'
+>) => {
+  const linkBasePath = menu.data.links[0].url.path
+
+  if (!linkBasePath || operatingStatusFacility === 'normal') {
+    return null
+  }
+
+  const presentations: Record<
+    FacilityOperatingStatusFlags,
+    { status: 'info' | 'warning' | 'error'; text: string }
+  > = {
+    notice: { status: 'info', text: 'Facility notice' },
+    limited: { status: 'warning', text: 'Limited services and hours' },
+    temporary_closure: {
+      status: 'warning',
+      text: 'Temporary facility closure',
+    },
+    temporary_location: { status: 'warning', text: 'Temporary location' },
+    virtual_care: { status: 'warning', text: 'Virtual care only' },
+    coming_soon: { status: 'warning', text: 'Coming soon' },
+    closed: { status: 'warning', text: 'Facility closed' },
+  }
+
+  if (Object.keys(presentations).includes(operatingStatusFacility)) {
+    const { status, text } = presentations[operatingStatusFacility]
+    return (
+      <va-alert status={status} slim visible>
+        <va-link
+          class="vads-u-font-weight--bold operating-status-link"
+          href={`${linkBasePath}/operating-status`}
+          text={text}
+        />
+      </va-alert>
+    )
+  }
+
+  // Fallthrough for unexpected statuses
+  return null
+}

--- a/src/templates/layouts/healthCareLocalFacility/index.test.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.test.tsx
@@ -11,11 +11,21 @@ const mockData: FormattedHealthCareLocalFacility = {
   introText: 'Test intro text',
   operatingStatusFacility: 'normal',
   menu: {
-    rootPath: 'test-nav-path',
+    rootPath: '/test-nav-path',
     data: {
       name: 'test-nav',
       description: 'test-nav-description',
-      links: [],
+      links: [
+        {
+          url: {
+            path: '/test-nav-path',
+          },
+          description: 'test-nav-description',
+          expanded: true,
+          label: 'test-nav-label',
+          links: [],
+        },
+      ],
     },
   },
 }

--- a/src/templates/layouts/healthCareLocalFacility/index.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.tsx
@@ -5,13 +5,13 @@ import { SideNavMenu } from '@/types/formatted/sideNav'
 
 import { LocationServices } from './LocationServices'
 import { HealthServices } from './HealthServices'
+import { OperatingStatusFlags } from './OperatingStatus'
 
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
   sideNav?: SideNavMenu
 }
 declare const window: customWindow
-
 
 export function HealthCareLocalFacility({
   title,
@@ -58,7 +58,10 @@ export function HealthCareLocalFacility({
             <div className="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--4">
               <div className="usa-width-two-thirds">
                 <div>
-                  <div>TODO: Operating status flags</div>
+                  <OperatingStatusFlags
+                    operatingStatusFacility={operatingStatusFacility}
+                    menu={menu}
+                  />
                   <section>
                     <script type="application/ld+json">
                       {/* TODO: Fill this in */}
@@ -91,50 +94,4 @@ export function HealthCareLocalFacility({
       </div>
     </div>
   )
-}
-
-/**
- * TODO: Fix up the links by passing in the sidebar data, then add the tests for
- * it.
- */
-const OperatingStatusFlags = ({
-  operatingStatusFacility,
-}: Pick<FormattedHealthCareLocalFacility, 'operatingStatusFacility'>) => {
-  if (operatingStatusFacility == 'notice') {
-    return (
-      <va-alert status="info" slim visible>
-        <va-link
-          class="vads-u-font-weight--bold operating-status-link"
-          href="{{ facilitySidebar.links.0.url.path }}/operating-status"
-          text="Facility notice"
-        />
-      </va-alert>
-    )
-  }
-
-  if (operatingStatusFacility == 'limited') {
-    return (
-      <va-alert status="warning" slim visible>
-        <va-link
-          class="vads-u-font-weight--bold operating-status-link"
-          href="{{ facilitySidebar.links.0.url.path }}/operating-status"
-          text="Limited services and hours"
-        />
-      </va-alert>
-    )
-  }
-
-  if (operatingStatusFacility == 'closed') {
-    return (
-      <va-alert status="error" slim visible>
-        <va-link
-          class="vads-u-font-weight--bold operating-status-link"
-          href="{{ facilitySidebar.links.0.url.path }}/operating-status"
-          text="Facility closed"
-        />
-      </va-alert>
-    )
-  }
-
-  return null
 }

--- a/src/types/drupal/node.ts
+++ b/src/types/drupal/node.ts
@@ -131,6 +131,10 @@ export type FacilityOperatingStatusFlags =
   | 'normal'
   | 'notice'
   | 'limited'
+  | 'temporary_closure'
+  | 'temporary_location'
+  | 'virtual_care'
+  | 'coming_soon'
   | 'closed'
   | string // TODO: Remove the catch-all; needed right now for importing JSON mock data; can remove after we implement runtime data validation
 


### PR DESCRIPTION
# Description

Adds the little operational status alert banner when needed.

## Generated description


This pull request includes significant changes to the `healthCareLocalFacility` layout to implement and test the `OperatingStatusFlags` component. The updates involve adding new status types, integrating the component into the layout, and ensuring comprehensive test coverage.

### New Feature Implementation:

* **`OperatingStatusFlags` Component:**
  - Added a new `OperatingStatusFlags` component to handle various facility operating statuses and display appropriate alerts.
  - Integrated the `OperatingStatusFlags` component into the `HealthCareLocalFacility` layout.

### Testing Enhancements:

* **Unit Tests for `OperatingStatusFlags`:**
  - Created unit tests for the `OperatingStatusFlags` component to verify rendering based on different operating statuses.

### Data and Type Updates:

* **Mock Data Adjustments:**
  - Updated mock data in `index.test.tsx` to include the necessary structure for testing the `OperatingStatusFlags` component.
* **Type Definitions:**
  - Extended the `FacilityOperatingStatusFlags` type to include new statuses such as `temporary_closure`, `temporary_location`, `virtual_care`, and `coming_soon`.

### Code Refactoring:

* **Removed Legacy Code:**
  - Deleted the old `OperatingStatusFlags` implementation from `index.tsx` to avoid redundancy.

## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20772

## Screenshots

Limited:
![image](https://github.com/user-attachments/assets/d243d690-7b74-4149-ab88-4d62b2ebb458)

Temporary closure:
![image](https://github.com/user-attachments/assets/f263c598-f570-415f-8e7a-aa88ed9bba3e)

Temporary location:
![image](https://github.com/user-attachments/assets/6ac8f7bb-abd3-4d60-9988-05d74c567c8e)

Virtual care:
![image](https://github.com/user-attachments/assets/8e994967-b275-49ff-b809-fa0ce6fe856e)

Coming soon:
![image](https://github.com/user-attachments/assets/3409ecbe-7634-45c7-8ef5-dd3ab0a4a33c)

Closed:
![image](https://github.com/user-attachments/assets/2b5d20d7-45be-4b21-a407-5f1f828f9990)
