### PR TITLE
Modifications to ensure fonts are downloaded to Tugboat instances.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -64,7 +64,7 @@ services:
         - yarn install
 
         # Get vets-website assets in the right place
-        - BUILD_TYPE=vagovprod node ./scripts/yarn/vets-website-assets.js
+        - BUILD_TYPE=tugboat node ./scripts/yarn/vets-website-assets.js
 
         # Build the static pages. Set for self-signed certs
         - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt BUILD_OPTION=static yarn export

--- a/scripts/yarn/vets-website-assets.js
+++ b/scripts/yarn/vets-website-assets.js
@@ -32,6 +32,7 @@ const localBucket = path.resolve(
 // Available bucket options, default is the vagovprod bucket.
 const BUILD_TYPE_BUCKET = {
   localhost: localBucket,
+  tugboat: devBucket,
   vagovdev: devBucket,
   vagovstaging: stagingBucket,
   vagovprod: prodBucket,
@@ -90,6 +91,16 @@ async function moveAssetsFromVetsWebsite() {
   try {
     fs.copySync(`${vetsWebsiteAssetPath}/img`, './public/img/')
     console.log('Copied image assets from vets-website.')
+
+    let fontsDir = fs.readdirSync(`${vetsWebsiteAssetPath}/fonts`)
+    for (let i = 0; i < fontsDir.length; i += 1) {
+      const font = fontsDir[i]
+      fs.copySync(
+        `${vetsWebsiteAssetPath}/fonts/${font}`,
+        `${destinationPath}/${font}`
+      )
+    }
+    console.log('Copied font files from vets-website.')
   } catch (err) {
     console.error(err)
   }

--- a/scripts/yarn/vets-website-assets.js
+++ b/scripts/yarn/vets-website-assets.js
@@ -92,7 +92,7 @@ async function moveAssetsFromVetsWebsite() {
     fs.copySync(`${vetsWebsiteAssetPath}/img`, './public/img/')
     console.log('Copied image assets from vets-website.')
 
-    let fontsDir = fs.readdirSync(`${vetsWebsiteAssetPath}/fonts`)
+    const fontsDir = fs.readdirSync(`${vetsWebsiteAssetPath}/fonts`)
     for (let i = 0; i < fontsDir.length; i += 1) {
       const font = fontsDir[i]
       fs.copySync(


### PR DESCRIPTION
# Description
This fixes a problem where fonts were neither being downloaded to Tugboat nor able to be referenced from an S3 asset bucket.

## Generated description


This pull request includes updates to the build configuration and asset management scripts to support a new build type, `tugboat`, and improve the copying of asset files.

### Build Configuration Updates:
* [`.tugboat/config.yml`](diffhunk://#diff-fbd0812762ff8d2c67fa66a4956c3b55557ad0889505294f524192000b2ce50eL67-R67): Changed the `BUILD_TYPE` from `vagovprod` to `tugboat` to accommodate the new build type.

### Asset Management Improvements:
* [`scripts/yarn/vets-website-assets.js`](diffhunk://#diff-a52b6e021d8aeb65157b69c6a3681c8c067c8f88011ed8ecb15b87bebab72f2aR35): Added a new `tugboat` option to the `BUILD_TYPE_BUCKET` to map it to the `devBucket`.
* [`scripts/yarn/vets-website-assets.js`](diffhunk://#diff-a52b6e021d8aeb65157b69c6a3681c8c067c8f88011ed8ecb15b87bebab72f2aR94-R103): Enhanced the `moveAssetsFromVetsWebsite` function to include copying font files from the `vets-website` directory to the destination path, ensuring all necessary assets are transferred.

## Ticket
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20819.


## Testing Steps
Ensure that font files are loading correctly in the Network tab of the web inspector . https://pr954-5ftl2zah8bwhtjikefw48nmz4irmirn0.tugboat.vfs.va.gov/boston-health-care/events/ is an example URL.

## Screenshots

Before:
<img width="1050" alt="image" src="https://github.com/user-attachments/assets/a7914d2a-3107-4b70-810e-742412cc4891" />

After: 
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/73df71d2-8b32-4397-9054-3f96dadc64c5" />


