### PR TITLE
VACMS 19771 feedback analytics

### DIFF
--- a/src/templates/common/contentFooter/index.tsx
+++ b/src/templates/common/contentFooter/index.tsx
@@ -77,6 +77,7 @@ export function ContentFooter({
           <va-button
             label="Give feedback"
             id="mdFormButton"
+            disable-analytics
             onClick={() => {
               const isProduction =
                 process.env.NEXT_PUBLIC_BUILD_TYPE === BUILD_TYPES.PROD

--- a/src/templates/common/medallia/index.test.tsx
+++ b/src/templates/common/medallia/index.test.tsx
@@ -78,7 +78,7 @@ const mockEvent: MedalliaEvent = {
 }
 
 describe('MedalliaAssets Component', () => {
-  beforeEach(() => {
+  afterEach(() => {
     jest.clearAllMocks()
   })
   test('renders Script component with correct props', () => {
@@ -130,8 +130,6 @@ describe('MedalliaAssets Component', () => {
       'survey-status': 'Test Form',
       'survey-details': { feedbackUUID: 'abc-123', content: 'Test Content' },
     })
-
-    addEventListenerSpy.mockRestore()
   })
   test('adds listener and calls recordEvent when triggered for Medallia event with label', () => {
     const mockEventDetail = {
@@ -167,7 +165,5 @@ describe('MedalliaAssets Component', () => {
       'survey-status': 'Invite',
       'survey-details': {},
     })
-
-    addEventListenerSpy.mockRestore()
   })
 })

--- a/src/templates/common/medallia/index.test.tsx
+++ b/src/templates/common/medallia/index.test.tsx
@@ -82,11 +82,6 @@ describe('MedalliaAssets Component', () => {
     jest.clearAllMocks()
   })
   test('renders Script component with correct props', () => {
-    // Mocking useEffect
-    jest.mock('react', () => ({
-      ...jest.requireActual('react'),
-      useEffect: jest.fn(),
-    }))
     process.env.NEXT_PUBLIC_BUILD_TYPE = 'local'
 
     render(<MedalliaAssets />)

--- a/src/templates/common/medallia/index.test.tsx
+++ b/src/templates/common/medallia/index.test.tsx
@@ -1,11 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { MedalliaAssets } from './'
-
-// Mocking useEffect
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useEffect: jest.fn(),
-}))
+import { recordEvent } from '@/lib/analytics/recordEvent'
 
 // Mock Script
 jest.mock('next/script', () => ({ id, src }) => (
@@ -20,8 +15,78 @@ jest.mock('@/lib/utils/medallia', () => ({
   setWindowVaSurvey: jest.fn(),
 }))
 
+// Mock recordEvent
+jest.mock('@/lib/analytics/recordEvent', () => ({
+  recordEvent: jest.fn(),
+}))
+
+interface MedalliaEvent extends CustomEvent {
+  detail: {
+    Form_Type?: string
+    Form_ID?: string
+    Feedback_UUID?: string
+    Content?: string
+  }
+}
+
+const mockEventDetail: MedalliaEvent = {
+  detail: {},
+  initCustomEvent: function (
+    type: string,
+    bubbles?: boolean,
+    cancelable?: boolean,
+    detail?: unknown
+  ): void {
+    throw new Error('Function not implemented.')
+  },
+  bubbles: false,
+  cancelBubble: false,
+  cancelable: false,
+  composed: false,
+  currentTarget: undefined,
+  defaultPrevented: false,
+  eventPhase: 0,
+  isTrusted: false,
+  returnValue: false,
+  srcElement: undefined,
+  target: undefined,
+  timeStamp: 0,
+  type: '',
+  composedPath: function (): EventTarget[] {
+    throw new Error('Function not implemented.')
+  },
+  initEvent: function (
+    type: string,
+    bubbles?: boolean,
+    cancelable?: boolean
+  ): void {
+    throw new Error('Function not implemented.')
+  },
+  preventDefault: function (): void {
+    throw new Error('Function not implemented.')
+  },
+  stopImmediatePropagation: function (): void {
+    throw new Error('Function not implemented.')
+  },
+  stopPropagation: function (): void {
+    throw new Error('Function not implemented.')
+  },
+  NONE: 0,
+  CAPTURING_PHASE: 1,
+  AT_TARGET: 2,
+  BUBBLING_PHASE: 3,
+}
+
 describe('MedalliaAssets Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
   test('renders Script component with correct props', () => {
+    // Mocking useEffect
+    jest.mock('react', () => ({
+      ...jest.requireActual('react'),
+      useEffect: jest.fn(),
+    }))
     process.env.NEXT_PUBLIC_BUILD_TYPE = 'local'
 
     render(<MedalliaAssets />)
@@ -32,5 +97,82 @@ describe('MedalliaAssets Component', () => {
     const expectedSrc =
       'https://resource.digital.voice.va.gov/wdcvoice/5/onsite/embed.js'
     expect(scriptElement.getAttribute('data-src')).toEqual(expectedSrc)
+  })
+  test('adds listener and calls recordEvent when triggered for Medallia event with UUID and Content', () => {
+    const eventDetail = {
+      ...mockEventDetail,
+      detail: {
+        Form_Type: 'Test Form',
+        Form_ID: '12345',
+        Feedback_UUID: 'abc-123',
+        Content: 'Test Content',
+      },
+    }
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+
+    render(<MedalliaAssets />)
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'MDigital_Feedback_Submit',
+      expect.any(Function),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+
+    // Simulate the event listener being triggered
+    const eventHandler = addEventListenerSpy.mock.calls.find(
+      (call): call is [string, (event: CustomEvent) => void] =>
+        call[0] === 'MDigital_Feedback_Submit'
+    )?.[1]
+    if (eventHandler) {
+      eventHandler(eventDetail)
+    }
+
+    // Assert that recordEvent is called with the correct data
+    expect(recordEvent).toHaveBeenCalledWith({
+      event: 'survey-submit',
+      'survey-tool': 'Medallia',
+      'survey-form-id': '12345',
+      'survey-status': 'Test Form',
+      'survey-details': { feedbackUUID: 'abc-123', content: 'Test Content' },
+    })
+
+    addEventListenerSpy.mockRestore()
+  })
+  test('adds listener and calls recordEvent when triggered for Medallia event with label', () => {
+    const eventDetail = {
+      ...mockEventDetail,
+      detail: {
+        Form_Type: 'Test Form',
+        Form_ID: '12345',
+      },
+    }
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener')
+
+    render(<MedalliaAssets />)
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      'MDigital_Invite_Displayed',
+      expect.any(Function),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+    // Simulate the event listener being triggered
+    const eventHandler = addEventListenerSpy.mock.calls.find(
+      (call): call is [string, (event: CustomEvent) => void] =>
+        call[0] === 'MDigital_Invite_Displayed'
+    )?.[1]
+    if (eventHandler) {
+      eventHandler(eventDetail)
+    }
+
+    // Assert that recordEvent is called with the correct data
+    expect(recordEvent).toHaveBeenCalledWith({
+      event: 'survey-invitation-display',
+      'survey-tool': 'Medallia',
+      'survey-form-id': '12345',
+      'survey-status': 'Invite',
+      'survey-details': {},
+    })
+
+    addEventListenerSpy.mockRestore()
   })
 })

--- a/src/templates/common/medallia/index.test.tsx
+++ b/src/templates/common/medallia/index.test.tsx
@@ -29,7 +29,7 @@ interface MedalliaEvent extends CustomEvent {
   }
 }
 
-const mockEventDetail: MedalliaEvent = {
+const mockEvent: MedalliaEvent = {
   detail: {},
   initCustomEvent: function (
     type: string,
@@ -99,8 +99,8 @@ describe('MedalliaAssets Component', () => {
     expect(scriptElement.getAttribute('data-src')).toEqual(expectedSrc)
   })
   test('adds listener and calls recordEvent when triggered for Medallia event with UUID and Content', () => {
-    const eventDetail = {
-      ...mockEventDetail,
+    const mockEventDetail = {
+      ...mockEvent,
       detail: {
         Form_Type: 'Test Form',
         Form_ID: '12345',
@@ -124,7 +124,7 @@ describe('MedalliaAssets Component', () => {
         call[0] === 'MDigital_Feedback_Submit'
     )?.[1]
     if (eventHandler) {
-      eventHandler(eventDetail)
+      eventHandler(mockEventDetail)
     }
 
     // Assert that recordEvent is called with the correct data
@@ -139,8 +139,8 @@ describe('MedalliaAssets Component', () => {
     addEventListenerSpy.mockRestore()
   })
   test('adds listener and calls recordEvent when triggered for Medallia event with label', () => {
-    const eventDetail = {
-      ...mockEventDetail,
+    const mockEventDetail = {
+      ...mockEvent,
       detail: {
         Form_Type: 'Test Form',
         Form_ID: '12345',
@@ -161,7 +161,7 @@ describe('MedalliaAssets Component', () => {
         call[0] === 'MDigital_Invite_Displayed'
     )?.[1]
     if (eventHandler) {
-      eventHandler(eventDetail)
+      eventHandler(mockEventDetail)
     }
 
     // Assert that recordEvent is called with the correct data

--- a/src/templates/common/medallia/index.tsx
+++ b/src/templates/common/medallia/index.tsx
@@ -56,7 +56,6 @@ export function MedalliaAssets() {
         if (formContent) {
           eData.myParams.content = mData.Content
         }
-        const end = +new Date()
         recordEvent({
           event: eData.action,
           'survey-tool': eData.category,

--- a/src/templates/common/medallia/index.tsx
+++ b/src/templates/common/medallia/index.tsx
@@ -41,8 +41,6 @@ export function MedalliaAssets() {
       formContent = false,
       label = '',
     }) => {
-      // Ignore because these events are unreachable
-      /* istanbul ignore next */
       const handle = (event) => {
         const mData = event.detail
         const eData = {

--- a/src/templates/common/medallia/index.tsx
+++ b/src/templates/common/medallia/index.tsx
@@ -116,6 +116,10 @@ export function MedalliaAssets() {
       label: 'Invite',
     })
     return () => {
+      /**
+       * Cleanup function to remove the event listeners. controller.abort() is called to abort any ongoing requests and prevent memory leaks.
+       * https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal#events
+       */
       controller.abort()
     }
   }, [])

--- a/src/templates/common/medallia/index.tsx
+++ b/src/templates/common/medallia/index.tsx
@@ -7,6 +7,7 @@ import {
   setWindowVaSurvey,
 } from '@/lib/utils/medallia'
 import { BUILD_TYPES } from '@/lib/constants/environment'
+import { recordEvent } from '@/lib/analytics/recordEvent'
 
 export function MedalliaAssets() {
   const scriptId =
@@ -27,6 +28,81 @@ export function MedalliaAssets() {
     const isVamcPage = window.location.pathname.includes('health-care')
     if (isVamcPage) {
       setWindowVaSurvey('mcenter')
+    }
+  }, [])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const { signal } = controller
+    const withFormContent = (acc, data) => {
+      //console.log("acc.content data",data.Content);
+      acc.content = data.Content
+    }
+
+    const withFeedbackUUID = (acc, data) => {
+      acc.feedbackUUID = data.Feedback_UUID
+    }
+
+    const mEvent = (name, action, opts) => {
+      const custom = opts.custom
+      const label = opts.label
+
+      const handle = (event) => {
+        const mData = event.detail
+        const eData = {
+          category: 'Medallia',
+          action: action,
+          label: label || mData.Form_Type,
+          value: mData.Form_ID,
+          myParams: {},
+        }
+        if (custom) {
+          let i
+          for (i = 0; i < custom.length; i++) custom[i](eData.myParams, mData)
+        }
+        const end = +new Date()
+        recordEvent({
+          event: eData.action,
+          'survey-tool': eData.category,
+          'survey-form-id': eData.value,
+          'survey-status': eData.label,
+          'survey-details': eData.myParams,
+        })
+      }
+      window.addEventListener('MDigital_' + name, handle, { signal })
+    }
+    mEvent('ShowForm_Called', 'survey-show-form-call', {})
+    mEvent('Form_Displayed', 'survey-start-form', {})
+    mEvent('Form_Next_Page', 'survey-next-click', {})
+    mEvent('Form_Back_Page', 'survey-back-click', {})
+    mEvent('Form_Close_Submitted', 'survey-submit-close', {})
+    mEvent('Form_Close_No_Submit', 'survey-no-submit-close', {})
+    mEvent('Feedback_Submit', 'survey-submit', {
+      custom: [withFeedbackUUID, withFormContent],
+    })
+    mEvent('Submit_Feedback', 'survey--submission', {
+      custom: [withFeedbackUUID, withFormContent],
+    })
+    mEvent('Feedback_Button_Clicked', 'survey-button-click', {
+      custom: [withFeedbackUUID],
+    })
+    mEvent('ThankYou_Displayed', 'survey--submission-successful', {
+      custom: [withFeedbackUUID, withFormContent],
+    })
+    mEvent('Invite_Displayed', 'survey-invitation-display', {
+      label: 'Invite',
+    })
+    mEvent('Invite_Accepted', 'survey-invitation-accept', {
+      label: 'Invite',
+    })
+    mEvent('Invite_Declined', 'survey-invitation-decline', {
+      label: 'Invite',
+    })
+    mEvent('Invite_Skipped', 'survey-invitation-skip', {
+      label: 'Invite',
+    })
+    return () => {
+      controller.abort()
     }
   }, [])
 

--- a/src/templates/common/medallia/index.tsx
+++ b/src/templates/common/medallia/index.tsx
@@ -41,6 +41,8 @@ export function MedalliaAssets() {
       formContent = false,
       label = '',
     }) => {
+      // Ignore because these events are unreachable
+      /* istanbul ignore next */
       const handle = (event) => {
         const mData = event.detail
         const eData = {

--- a/src/templates/common/medallia/index.tsx
+++ b/src/templates/common/medallia/index.tsx
@@ -34,19 +34,13 @@ export function MedalliaAssets() {
   useEffect(() => {
     const controller = new AbortController()
     const { signal } = controller
-    const withFormContent = (acc, data) => {
-      //console.log("acc.content data",data.Content);
-      acc.content = data.Content
-    }
-
-    const withFeedbackUUID = (acc, data) => {
-      acc.feedbackUUID = data.Feedback_UUID
-    }
-
-    const mEvent = (name, action, opts) => {
-      const custom = opts.custom
-      const label = opts.label
-
+    const mEvent = ({
+      name,
+      action,
+      feedbackUUID = false,
+      formContent = false,
+      label = '',
+    }) => {
       const handle = (event) => {
         const mData = event.detail
         const eData = {
@@ -54,11 +48,13 @@ export function MedalliaAssets() {
           action: action,
           label: label || mData.Form_Type,
           value: mData.Form_ID,
-          myParams: {},
+          myParams: {} as { feedbackUUID?: string; content?: string },
         }
-        if (custom) {
-          let i
-          for (i = 0; i < custom.length; i++) custom[i](eData.myParams, mData)
+        if (feedbackUUID) {
+          eData.myParams.feedbackUUID = mData.Feedback_UUID
+        }
+        if (formContent) {
+          eData.myParams.content = mData.Content
         }
         const end = +new Date()
         recordEvent({
@@ -71,34 +67,53 @@ export function MedalliaAssets() {
       }
       window.addEventListener('MDigital_' + name, handle, { signal })
     }
-    mEvent('ShowForm_Called', 'survey-show-form-call', {})
-    mEvent('Form_Displayed', 'survey-start-form', {})
-    mEvent('Form_Next_Page', 'survey-next-click', {})
-    mEvent('Form_Back_Page', 'survey-back-click', {})
-    mEvent('Form_Close_Submitted', 'survey-submit-close', {})
-    mEvent('Form_Close_No_Submit', 'survey-no-submit-close', {})
-    mEvent('Feedback_Submit', 'survey-submit', {
-      custom: [withFeedbackUUID, withFormContent],
+    mEvent({ name: 'ShowForm_Called', action: 'survey-show-form-call' })
+    mEvent({ name: 'Form_Displayed', action: 'survey-start-form' })
+    mEvent({ name: 'Form_Next_Page', action: 'survey-next-click' })
+    mEvent({ name: 'Form_Back_Page', action: 'survey-back-click' })
+    mEvent({ name: 'Form_Close_Submitted', action: 'survey-submit-close' })
+    mEvent({ name: 'Form_Close_No_Submit', action: 'survey-no-submit-close' })
+    mEvent({
+      name: 'Feedback_Submit',
+      action: 'survey-submit',
+      feedbackUUID: true,
+      formContent: true,
     })
-    mEvent('Submit_Feedback', 'survey--submission', {
-      custom: [withFeedbackUUID, withFormContent],
+    mEvent({
+      name: 'Submit_Feedback',
+      action: 'survey--submission',
+      feedbackUUID: true,
+      formContent: true,
     })
-    mEvent('Feedback_Button_Clicked', 'survey-button-click', {
-      custom: [withFeedbackUUID],
+    mEvent({
+      name: 'Feedback_Button_Clicked',
+      action: 'survey-button-click',
+      feedbackUUID: true,
     })
-    mEvent('ThankYou_Displayed', 'survey--submission-successful', {
-      custom: [withFeedbackUUID, withFormContent],
+    mEvent({
+      name: 'ThankYou_Displayed',
+      action: 'survey--submission-successful',
+      feedbackUUID: true,
+      formContent: true,
     })
-    mEvent('Invite_Displayed', 'survey-invitation-display', {
+    mEvent({
+      name: 'Invite_Displayed',
+      action: 'survey-invitation-display',
       label: 'Invite',
     })
-    mEvent('Invite_Accepted', 'survey-invitation-accept', {
+    mEvent({
+      name: 'Invite_Accepted',
+      action: 'survey-invitation-accept',
       label: 'Invite',
     })
-    mEvent('Invite_Declined', 'survey-invitation-decline', {
+    mEvent({
+      name: 'Invite_Declined',
+      action: 'survey-invitation-decline',
       label: 'Invite',
     })
-    mEvent('Invite_Skipped', 'survey-invitation-skip', {
+    mEvent({
+      name: 'Invite_Skipped',
+      action: 'survey-invitation-skip',
       label: 'Invite',
     })
     return () => {


### PR DESCRIPTION
# Description

A bit of a lift and shift of the medallia event listeners from content-build

## Generated description


This pull request includes several updates to the `MedalliaAssets` component and its associated tests to improve event handling and analytics recording. The most important changes include adding the `recordEvent` function, implementing event listeners for various Medallia events, and updating the test cases to mock and verify these events.

### Improvements to Event Handling and Analytics:

* [`src/templates/common/medallia/index.tsx`](diffhunk://#diff-5cdda7136985d4843bf8f9b7f45b1ea45c1e29d17657c729f9fae7a9ad47266cR10): Added the `recordEvent` function and implemented event listeners for various Medallia events, such as `ShowForm_Called`, `Form_Displayed`, `Feedback_Submit`, and others, to record analytics data. [[1]](diffhunk://#diff-5cdda7136985d4843bf8f9b7f45b1ea45c1e29d17657c729f9fae7a9ad47266cR10) [[2]](diffhunk://#diff-5cdda7136985d4843bf8f9b7f45b1ea45c1e29d17657c729f9fae7a9ad47266cR34-R122)

### Test Updates:

* [`src/templates/common/medallia/index.test.tsx`](diffhunk://#diff-3b60010f20560fdedac940fdb7a82f612412c7f0eaf08631f1477367e64641bdL3-R3): Removed unnecessary `useEffect` mock, added a mock for `recordEvent`, and implemented new test cases to verify that event listeners are correctly added and that `recordEvent` is called with the appropriate data when Medallia events are triggered. [[1]](diffhunk://#diff-3b60010f20560fdedac940fdb7a82f612412c7f0eaf08631f1477367e64641bdL3-R3) [[2]](diffhunk://#diff-3b60010f20560fdedac940fdb7a82f612412c7f0eaf08631f1477367e64641bdR18-R89) [[3]](diffhunk://#diff-3b60010f20560fdedac940fdb7a82f612412c7f0eaf08631f1477367e64641bdR101-R177)

### Minor Changes:

* [`src/templates/common/contentFooter/index.tsx`](diffhunk://#diff-0a6e6061c4cd09c4c1592fcbd3f5ca9047711609e4f1b19e5398aac4116ddb4fR80): Added the `disable-analytics` attribute to the "Give feedback" button.
## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes [19771](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19771)

## Developer Task

- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)

## Testing Steps

 - download an extension that can observe GA4 events like [this one for chrome](https://chromewebstore.google.com/detail/debugger-for-google-analy/nomnoimacbncclfbnfaingniikblfbji?hl=en-US)
 - visit https://www.va.gov/boston-health-care/news-releases/
 - interact with the Feedback button at the bottom of the page (open, close, submit) and note the GA events
 - visit https://pr959-mlloqgh2pg7kaxzayeythni2ydhhqgyp.tugboat.vfs.va.gov/boston-health-care/news-releases/
 - interact with the Feedback button in the same way you did on the live page, and observe that the GA events match

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM


