### PR TITLE
VAMC Facilities: Top tasks

### DIFF
--- a/src/data/queries/healthCareLocalFacility.ts
+++ b/src/data/queries/healthCareLocalFacility.ts
@@ -81,7 +81,7 @@ export const formatter: QueryFormatter<
     operatingStatusFacility: entity.field_operating_status_facility,
     menu: formattedMenu,
     path: entity.path.alias,
-    adminstration: {
+    administration: {
       entityId: entity.field_administration.drupal_internal__tid,
     },
     vamcEhrSystem: entity.field_region_page.field_vamc_ehr_system,

--- a/src/data/queries/healthCareLocalFacility.ts
+++ b/src/data/queries/healthCareLocalFacility.ts
@@ -19,7 +19,7 @@ export const params: QueryParams<null> = () => {
     'field_region_page',
     // 'field_media',
     // 'field_media.image',
-    // 'field_administration',
+    'field_administration',
   ])
 }
 
@@ -80,5 +80,10 @@ export const formatter: QueryFormatter<
     introText: entity.field_intro_text,
     operatingStatusFacility: entity.field_operating_status_facility,
     menu: formattedMenu,
+    path: entity.path.alias,
+    adminstration: {
+      entityId: entity.field_administration.drupal_internal__tid,
+    },
+    vamcEhrSystem: entity.field_region_page.field_vamc_ehr_system,
   }
 }

--- a/src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`HealthCareLocalFacility formatData outputs formatted data 1`] = `
 {
-  "adminstration": {
+  "administration": {
     "entityId": undefined,
   },
   "breadcrumbs": [

--- a/src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap
@@ -2,6 +2,9 @@
 
 exports[`HealthCareLocalFacility formatData outputs formatted data 1`] = `
 {
+  "adminstration": {
+    "entityId": undefined,
+  },
   "breadcrumbs": [
     {
       "options": [],
@@ -155,8 +158,10 @@ exports[`HealthCareLocalFacility formatData outputs formatted data 1`] = `
   ],
   "moderationState": "archived",
   "operatingStatusFacility": "closed",
+  "path": "/st-cloud-health-care/locations/st-cloud-va-mobile-clinic",
   "published": false,
   "title": "St. Cloud VA Mobile Clinic",
   "type": "node--health_care_local_facility",
+  "vamcEhrSystem": "vista",
 }
 `;

--- a/src/templates/components/topTasks/index.test.tsx
+++ b/src/templates/components/topTasks/index.test.tsx
@@ -1,0 +1,125 @@
+import { ComponentProps } from 'react'
+import { TopTasks, _topTaskLovellComp } from './index'
+import { off } from 'process'
+
+const mockData: ComponentProps<typeof TopTasks> = {
+  path: '/test-nav-path',
+  vamcEhrSystem: 'vista',
+}
+
+const lovellAdministration = { entityId: 1039 }
+
+describe('TopTasks', () => {
+  it('should render', () => {})
+})
+
+describe('topTaskLovellComp', () => {
+  const cerner = { vamcEhrSystem: 'cerner' } as const
+  const mhsLinkData: Parameters<typeof _topTaskLovellComp>[0] = {
+    isProd: true,
+    linkType: 'make-an-appointment',
+    path: '/test-nav-path',
+    administration: lovellAdministration,
+    ...cerner,
+  }
+  const mhsLink = {
+    text: 'MHS Genesis Patient Portal',
+    url: 'https://my.mhsgenesis.health.mil/',
+  }
+  const normalLink = {
+    text: 'Make an appointment',
+    url: `${mhsLinkData.path}/make-an-appointment`,
+  }
+
+  it('should show the MHS link vamcEhrSystem is cerner', () => {
+    expect(_topTaskLovellComp(mhsLinkData)).toEqual(mhsLink)
+  })
+
+  it('should fall back to office.vamcEhrSystem', () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        vamcEhrSystem: null,
+        office: cerner,
+      })
+    ).toEqual(mhsLink)
+  })
+
+  it('should fall back to regionPage.vamcEhrSystem', () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        vamcEhrSystem: null,
+        regionPage: cerner,
+      })
+    ).toEqual(mhsLink)
+  })
+
+  it('should show the MHS link with cerner_staged on dev', () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        vamcEhrSystem: 'cerner_staged',
+        isProd: false,
+      })
+    ).toEqual(mhsLink)
+  })
+
+  it('should show the normal link with cerner_staged on prod', () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        vamcEhrSystem: 'cerner_staged',
+        isProd: true,
+      })
+    ).toEqual(normalLink)
+  })
+
+  it("should show the normal link if the link type isn't 'make-an-appointment'", () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        // @ts-expect-error TypeScript should catch this, but just in case...
+        linkType: 'other-link-type',
+      })
+    ).toEqual(normalLink)
+  })
+
+  it("should show the normal link if the page isn't Lovell", () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        administration: { entityId: 1040 }, // Lovell is 1039
+      })
+    ).toEqual(normalLink)
+  })
+
+  it('should show the normal link if the vamcEhrSystem is vista', () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        vamcEhrSystem: 'vista',
+      })
+    ).toEqual(normalLink)
+  })
+
+  it('should show normal link if all vamcEhrSystem values are null', () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        vamcEhrSystem: null,
+        office: undefined,
+        regionPage: undefined,
+      })
+    ).toEqual(normalLink)
+  })
+
+  it('should show normal link if linkType is undefined', () => {
+    expect(
+      _topTaskLovellComp({
+        ...mhsLinkData,
+        linkType: undefined,
+      })
+    ).toEqual(normalLink)
+  })
+})

--- a/src/templates/components/topTasks/index.test.tsx
+++ b/src/templates/components/topTasks/index.test.tsx
@@ -1,16 +1,87 @@
-import { ComponentProps } from 'react'
 import { TopTasks, _topTaskLovellComp } from './index'
-import { off } from 'process'
-
-const mockData: ComponentProps<typeof TopTasks> = {
-  path: '/test-nav-path',
-  vamcEhrSystem: 'vista',
-}
+import { render } from '@testing-library/react'
 
 const lovellAdministration = { entityId: 1039 }
 
 describe('TopTasks', () => {
-  it('should render', () => {})
+  it('should render the normal links', () => {
+    const { container } = render(
+      <TopTasks path="/test-nav-path" vamcEhrSystem="vista" />
+    )
+    expect(
+      container.querySelector('va-link-action[text="Make an appointment"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('va-link-action[text="Register for care"]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector(
+        'va-link-action[text="Learn about pharmacy services"]'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should render the MHS link', () => {
+    const { container } = render(
+      <TopTasks
+        path="/test-nav-path"
+        vamcEhrSystem="cerner"
+        administration={{ entityId: 1039 }}
+      />
+    )
+    expect(
+      container.querySelector(
+        'va-link-action[text="MHS Genesis Patient Portal"]'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should render the MHS link from the office', () => {
+    const { container } = render(
+      <TopTasks
+        path="/test-nav-path"
+        /* @ts-expect-error Shouldn't happen, but just in case... */
+        vamcEhrSystem=""
+        office={{ vamcEhrSystem: 'cerner' }}
+        administration={{ entityId: 1039 }}
+      />
+    )
+    expect(
+      container.querySelector(
+        'va-link-action[text="MHS Genesis Patient Portal"]'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should render the MHS link from the regonPage', () => {
+    const { container } = render(
+      <TopTasks
+        path="/test-nav-path"
+        /* @ts-expect-error Shouldn't happen, but just in case... */
+        vamcEhrSystem=""
+        /* @ts-expect-error Shouldn't happen, but just in case... */
+        office={{ vamcEhrSystem: '' }}
+        regionPage={{ vamcEhrSystem: 'cerner' }}
+        administration={{ entityId: 1039 }}
+      />
+    )
+    expect(
+      container.querySelector(
+        'va-link-action[text="MHS Genesis Patient Portal"]'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should handle no slash in the path', () => {
+    const { container } = render(
+      <TopTasks path="test-nav-path" vamcEhrSystem="vista" />
+    )
+    expect(
+      container.querySelector(
+        'va-link-action[href="/test-nav-path/register-for-care"]'
+      )
+    ).toBeInTheDocument()
+  })
 })
 
 describe('topTaskLovellComp', () => {

--- a/src/templates/components/topTasks/index.tsx
+++ b/src/templates/components/topTasks/index.tsx
@@ -22,9 +22,13 @@ export const TopTasks = ({
   regionPage,
   office,
 }: TopTasksProps) => {
+  // Make sure we have exactly one / at the start of the path to avoid malformed
+  // URLs.
+  const slashPath = path.startsWith('/') ? path : `/${path}`
+
   const topTask = topTaskLovellComp({
     linkType: 'make-an-appointment',
-    path,
+    path: slashPath,
     administration,
     vamcEhrSystem,
     regionPage,
@@ -42,13 +46,13 @@ export const TopTasks = ({
         ></va-link-action>
         <va-link-action
           class="vads-u-display--block"
-          href={`/${path}/register-for-care`}
+          href={`${slashPath}/register-for-care`}
           text="Register for care"
           type="secondary"
         ></va-link-action>
         <va-link-action
           class="vads-u-display--block"
-          href={`/${path}/pharmacy`}
+          href={`${slashPath}/pharmacy`}
           text="Learn about pharmacy services"
           type="secondary"
         ></va-link-action>
@@ -74,7 +78,7 @@ const topTaskLovellComp = ({
   text: string
   url: string
 } => {
-  // Can I do this? Is this right?
+  // TODO: Can I do this? Is this right?
   const isNotProd = process.env.NODE_ENV !== 'production'
 
   const flag =
@@ -94,12 +98,12 @@ const topTaskLovellComp = ({
     // keeping this as a placeholder for future other linktypes for the MHS Genesis site (e.g. Pharmacy)
     return {
       text: 'Make an appointment',
-      url: `/${path}/make-an-appointment`,
+      url: `${path}/make-an-appointment`,
     }
   }
   // fallback as default
   return {
     text: 'Make an appointment',
-    url: `/${path}/make-an-appointment`,
+    url: `${path}/make-an-appointment`,
   }
 }

--- a/src/templates/components/topTasks/index.tsx
+++ b/src/templates/components/topTasks/index.tsx
@@ -78,8 +78,8 @@ const topTaskLovellComp = ({
   text: string
   url: string
 } => {
-  // TODO: Can I do this? Is this right?
-  const isNotProd = process.env.NODE_ENV !== 'production'
+  // TODO: Is this right?
+  const isNotProd = process.env.APP_ENV !== 'prod'
 
   const flag =
     vamcEhrSystem || office?.vamcEhrSystem || regionPage?.vamcEhrSystem || ''

--- a/src/templates/components/topTasks/index.tsx
+++ b/src/templates/components/topTasks/index.tsx
@@ -79,26 +79,48 @@ const topTaskLovellComp = ({
   url: string
 } => {
   // TODO: Is this right?
-  const isNotProd = process.env.APP_ENV !== 'prod'
+  const isProd = process.env.APP_ENV === 'prod'
 
+  return _topTaskLovellComp({
+    isProd,
+    linkType,
+    path,
+    administration,
+    vamcEhrSystem,
+    regionPage,
+    office,
+  })
+}
+
+/**
+ * Same as `topTaskLovellComp` but with an additional `isProd` flag to aid
+ * testing.
+ */
+export const _topTaskLovellComp = ({
+  isProd,
+  linkType,
+  path,
+  administration,
+  vamcEhrSystem,
+  regionPage,
+  office,
+}: TopTasksProps & { isProd: boolean; linkType?: 'make-an-appointment' }): {
+  text: string
+  url: string
+} => {
   const flag =
     vamcEhrSystem || office?.vamcEhrSystem || regionPage?.vamcEhrSystem || ''
 
   const isPageLovell = administration?.entityId === 1039
 
-  if (flag === 'cerner' || (flag === 'cerner_staged' && isNotProd)) {
-    if (linkType === 'make-an-appointment' && isPageLovell) {
-      return {
-        text: 'MHS Genesis Patient Portal',
-        url: 'https://my.mhsgenesis.health.mil/',
-      }
-    }
-  } else if (linkType === 'make-an-appointment') {
-    // If we remove this eslint complains of the nested if, so
-    // keeping this as a placeholder for future other linktypes for the MHS Genesis site (e.g. Pharmacy)
+  if (
+    (flag === 'cerner' || (flag === 'cerner_staged' && !isProd)) &&
+    linkType === 'make-an-appointment' &&
+    isPageLovell
+  ) {
     return {
-      text: 'Make an appointment',
-      url: `${path}/make-an-appointment`,
+      text: 'MHS Genesis Patient Portal',
+      url: 'https://my.mhsgenesis.health.mil/',
     }
   }
   // fallback as default

--- a/src/templates/components/topTasks/index.tsx
+++ b/src/templates/components/topTasks/index.tsx
@@ -1,0 +1,105 @@
+import { VamcEhr } from '@/types/drupal/vamcEhr'
+
+type VamcEhrSystem = VamcEhr['field_region_page']['field_vamc_ehr_system']
+
+type TopTasksProps = {
+  path: string
+  vamcEhrSystem: VamcEhrSystem
+  administration?: { entityId: number }
+  regionPage?: { vamcEhrSystem: VamcEhrSystem }
+  office?: { vamcEhrSystem: VamcEhrSystem }
+}
+
+/**
+ * Display a set of actionable links for a facility.
+ *
+ * This is used for Facility details pages and (A-Z) Health Services page.
+ */
+export const TopTasks = ({
+  path,
+  administration,
+  vamcEhrSystem,
+  regionPage,
+  office,
+}: TopTasksProps) => {
+  const topTask = topTaskLovellComp({
+    linkType: 'make-an-appointment',
+    path,
+    administration,
+    vamcEhrSystem,
+    regionPage,
+    office,
+  })
+
+  return (
+    <div className="usa-grid usa-grid-full vads-u-margin-bottom--6">
+      <div data-template="facilities/facilities_health_services_buttons">
+        <va-link-action
+          class="vads-u-display--block"
+          href={`${topTask.url}`}
+          text={`${topTask.text}`}
+          type="secondary"
+        ></va-link-action>
+        <va-link-action
+          class="vads-u-display--block"
+          href={`/${path}/register-for-care`}
+          text="Register for care"
+          type="secondary"
+        ></va-link-action>
+        <va-link-action
+          class="vads-u-display--block"
+          href={`/${path}/pharmacy`}
+          text="Learn about pharmacy services"
+          type="secondary"
+        ></va-link-action>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Generates a text and URL object for the top task component based on the
+ * provided properties.
+ *
+ * NOTE: May need to export this from another module later to be used elsewhere.
+ */
+const topTaskLovellComp = ({
+  linkType,
+  path,
+  administration,
+  vamcEhrSystem,
+  regionPage,
+  office,
+}: TopTasksProps & { linkType?: 'make-an-appointment' }): {
+  text: string
+  url: string
+} => {
+  // Can I do this? Is this right?
+  const isNotProd = process.env.NODE_ENV !== 'production'
+
+  const flag =
+    vamcEhrSystem || office?.vamcEhrSystem || regionPage?.vamcEhrSystem || ''
+
+  const isPageLovell = administration?.entityId === 1039
+
+  if (flag === 'cerner' || (flag === 'cerner_staged' && isNotProd)) {
+    if (linkType === 'make-an-appointment' && isPageLovell) {
+      return {
+        text: 'MHS Genesis Patient Portal',
+        url: 'https://my.mhsgenesis.health.mil/',
+      }
+    }
+  } else if (linkType === 'make-an-appointment') {
+    // If we remove this eslint complains of the nested if, so
+    // keeping this as a placeholder for future other linktypes for the MHS Genesis site (e.g. Pharmacy)
+    return {
+      text: 'Make an appointment',
+      url: `/${path}/make-an-appointment`,
+    }
+  }
+  // fallback as default
+  return {
+    text: 'Make an appointment',
+    url: `/${path}/make-an-appointment`,
+  }
+}

--- a/src/templates/layouts/healthCareLocalFacility/index.test.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.test.tsx
@@ -18,6 +18,9 @@ const mockData: FormattedHealthCareLocalFacility = {
       links: [],
     },
   },
+  path: '/test-nav-path',
+  vamcEhrSystem: 'vista',
+  administration: { entityId: 1234 },
 }
 
 describe('HealthCareLocalFacility with valid data', () => {

--- a/src/templates/layouts/healthCareLocalFacility/index.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.tsx
@@ -5,6 +5,7 @@ import { SideNavMenu } from '@/types/formatted/sideNav'
 
 import { LocationServices } from './LocationServices'
 import { HealthServices } from './HealthServices'
+import { TopTasks } from '@/templates/components/topTasks'
 
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
@@ -17,6 +18,9 @@ export function HealthCareLocalFacility({
   introText,
   operatingStatusFacility,
   menu,
+  path,
+  administration,
+  vamcEhrSystem,
 }: FormattedHealthCareLocalFacility) {
   // Populate the side nav data for the side nav widget to fill in
   // Note: The side nav widget is in a separate app in the static-pages bundle
@@ -41,9 +45,11 @@ export function HealthCareLocalFacility({
               </div>
             )}
 
-            <div className="usa-grid usa-grid-full vads-u-margin-bottom--6">
-              <div>TODO: facilities_health_services_buttons</div>
-            </div>
+            <TopTasks
+              path={path}
+              administration={administration}
+              vamcEhrSystem={vamcEhrSystem}
+            />
 
             <va-on-this-page></va-on-this-page>
 

--- a/src/types/formatted/healthCareLocalFacility.ts
+++ b/src/types/formatted/healthCareLocalFacility.ts
@@ -1,10 +1,13 @@
 import { FacilityOperatingStatusFlags } from '../drupal/node'
+import { VamcEhr } from '../drupal/vamcEhr'
 import { PublishedEntity } from './publishedEntity'
 import { SideNavMenu } from './sideNav'
 
 export type HealthCareLocalFacility = PublishedEntity & {
-  // Other attributes here
   introText: string | null
   operatingStatusFacility: FacilityOperatingStatusFlags
   menu: SideNavMenu | null
+  path: string
+  administration?: { entityId: number }
+  vamcEhrSystem: VamcEhr['field_region_page']['field_vamc_ehr_system']
 }


### PR DESCRIPTION
# Description

Adds the top tasks links to the page

## Generated description

This pull request includes several changes to enhance the handling of `TopTasks` for health care local facilities by adding new properties and updating tests accordingly. The most important changes include adding new fields to the data queries, updating the `TopTasks` component, and modifying the corresponding tests.

### Enhancements to data queries:

* [`src/data/queries/healthCareLocalFacility.ts`](diffhunk://#diff-35c09c75baec6b07a198e9d78d40d7db3a47ac9fc1c9a1e68a3566c1faf7303fR83-R87): Added `path`, `administration`, and `vamcEhrSystem` fields to the data formatter.

### Updates to `TopTasks` component:

* [`src/templates/components/topTasks/index.tsx`](diffhunk://#diff-b6ed2ed533f30ca9eb50c03864762acaea39a821a77f65e7336d3757a18ae82aR1-R131): Created the `TopTasks` component to display actionable links for a facility, including logic to handle different `vamcEhrSystem` values.

### Modifications to tests:

* [`src/templates/components/topTasks/index.test.tsx`](diffhunk://#diff-7b4ed1a687735817923db4ce7aed3feec7bedaa7989b43fc4078a20349a98997R1-R196): Added tests for the `TopTasks` component to ensure correct rendering of links based on different `vamcEhrSystem` values and conditions.
* [`src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap`](diffhunk://#diff-209da7eaba46ff4f3c51597305f96e3c943c67839359c0e0533a1e1b099d5376R5-R7): Updated snapshot tests to include new fields `path`, `administration`, and `vamcEhrSystem`. [[1]](diffhunk://#diff-209da7eaba46ff4f3c51597305f96e3c943c67839359c0e0533a1e1b099d5376R5-R7) [[2]](diffhunk://#diff-209da7eaba46ff4f3c51597305f96e3c943c67839359c0e0533a1e1b099d5376R161-R165)

### Integration of `TopTasks` into layout:

* [`src/templates/layouts/healthCareLocalFacility/index.tsx`](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefR8): Integrated the `TopTasks` component into the `HealthCareLocalFacility` layout, passing the new fields as props. [[1]](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefR8) [[2]](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefR21-R23) [[3]](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefL44-R52)

### Type updates:

* [`src/types/formatted/healthCareLocalFacility.ts`](diffhunk://#diff-f1c2e1972ee32d794f599ac7233134a307e92da47943ff8019fbe3442c585589R2-R12): Updated the `HealthCareLocalFacility` type to include `path`, `administration`, and `vamcEhrSystem` fields.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20768

## Screenshots
![image](https://github.com/user-attachments/assets/f297408b-65c1-42f1-89b2-9823a7d56749)

1. The URL of the current page
2. Hovering over this link
3. Shows the URL of the current page + `/make-an-appointment` like it's supposed to