### PR TITLE
Update CODEOWNERS to give  Next Build Product visibility over templates.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,7 @@
 
 # General ownership: Next Build Team (ap-team) & Platform FE COP
 *       @department-of-veterans-affairs/ap-team @department-of-veterans-affairs/va-platform-cop-frontend
+
+# Front-end template work should be verified by product owners.
+
+src/templates @department-of-veterans-affairs/next-build-product


### PR DESCRIPTION
# Description
Adds Next Build Product as a code owner of `src/templates`, in order to force visual/business logic review of changes.

## Generated description
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns ownership of the `src/templates` directory to the `next-build-product` team for verification by product owners.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R11-R14): Added `src/templates` to be verified by the `next-build-product` team.

