### PR TITLE
Fixing Pagination Regex

### DIFF
--- a/playwright/tests/pressReleaseListing.spec.ts
+++ b/playwright/tests/pressReleaseListing.spec.ts
@@ -31,7 +31,7 @@ test.describe('pressReleaseListing', () => {
   test('Press Release Listing should handle double-digit page numbers correctly', async ({
     page,
   }) => {
-    await page.goto('/southern-nevada-health-care/news-releases')
+    await page.goto('/saginaw-health-care/news-releases')
     const page10Link = page.getByLabel('Page 10')
     await page10Link.click()
     await page.waitForURL(/\/page-10\//)

--- a/playwright/tests/pressReleaseListing.spec.ts
+++ b/playwright/tests/pressReleaseListing.spec.ts
@@ -28,6 +28,23 @@ test.describe('pressReleaseListing', () => {
     await expect(nextPageLink).toBeEnabled()
   })
 
+  test('Press Release Listing should handle double-digit page numbers correctly', async ({
+    page,
+  }) => {
+    await page.goto('/southern-nevada-health-care/news-releases')
+    const page10Link = page.getByLabel('Page 10')
+    await page10Link.click()
+    await page.waitForURL(/\/page-10\//)
+    await expect(page).toHaveURL(/\/page-10\//)
+    const pressReleaseItems = page.locator('.usa-unstyled-list li')
+    await expect(pressReleaseItems).toHaveCount(10)
+    const nextPageLink = page.getByLabel('Next page')
+    await nextPageLink.click()
+    await page.waitForURL(/\/page-11\//)
+    await expect(page).toHaveURL(/\/page-11\//)
+    await expect(pressReleaseItems).toHaveCount(10)
+  })
+
   test('Should render without a11y errors', async ({
     page,
     makeAxeBuilder,

--- a/playwright/tests/pressReleaseListing.spec.ts
+++ b/playwright/tests/pressReleaseListing.spec.ts
@@ -31,13 +31,22 @@ test.describe('pressReleaseListing', () => {
   test('Press Release Listing should handle double-digit page numbers correctly', async ({
     page,
   }) => {
-    await page.goto('/saginaw-health-care/news-releases')
-    const page10Link = page.getByLabel('Page 10')
-    await page10Link.click()
-    await page.waitForURL(/\/page-10\//)
+    await page.goto('/southern-nevada-health-care/news-releases')
+
+    // Navigate to page 10 using the next page button
+    for (let i = 1; i < 10; i++) {
+      const nextPageLink = page.getByLabel('Next page')
+      await nextPageLink.click()
+      await page.waitForURL(new RegExp(`/page-${i + 1}/`))
+      await expect(page).toHaveURL(new RegExp(`/page-${i + 1}/`))
+    }
+
+    // Now we should be on page 10
     await expect(page).toHaveURL(/\/page-10\//)
     const pressReleaseItems = page.locator('.usa-unstyled-list li')
     await expect(pressReleaseItems).toHaveCount(10)
+
+    // Test navigation to page 11
     const nextPageLink = page.getByLabel('Next page')
     await nextPageLink.click()
     await page.waitForURL(/\/page-11\//)

--- a/playwright/tests/pressReleaseListing.spec.ts
+++ b/playwright/tests/pressReleaseListing.spec.ts
@@ -11,10 +11,10 @@ test.describe('pressReleaseListing', () => {
     )
   })
 
-  test('Press Release Listing page should be paginated if there are ore than 10 stories', async ({
+  test('Press Release Listing page should be paginated if there are more than 10 stories', async ({
     page,
   }) => {
-    await page.goto('/saginaw-health-care/news-releases')
+    await page.goto('/southern-nevada-health-care/news-releases')
 
     //Click on "Page 2" link and wait for URL to change
     const page2Link = page.getByLabel('Page 2')
@@ -31,7 +31,7 @@ test.describe('pressReleaseListing', () => {
   test('Press Release Listing should handle double-digit page numbers correctly', async ({
     page,
   }) => {
-    await page.goto('/southern-nevada-health-care/news-releases')
+    await page.goto('/saginaw-health-care/news-releases')
 
     // Navigate to page 10 using the next page button
     for (let i = 1; i < 10; i++) {

--- a/playwright/tests/pressReleaseListing.spec.ts
+++ b/playwright/tests/pressReleaseListing.spec.ts
@@ -14,7 +14,7 @@ test.describe('pressReleaseListing', () => {
   test('Press Release Listing page should be paginated if there are ore than 10 stories', async ({
     page,
   }) => {
-    await page.goto('/southern-nevada-health-care/news-releases')
+    await page.goto('/saginaw-health-care/news-releases')
 
     //Click on "Page 2" link and wait for URL to change
     const page2Link = page.getByLabel('Page 2')

--- a/playwright/tests/pressReleaseListing.spec.ts
+++ b/playwright/tests/pressReleaseListing.spec.ts
@@ -32,26 +32,27 @@ test.describe('pressReleaseListing', () => {
     page,
   }) => {
     await page.goto('/saginaw-health-care/news-releases')
-
-    // Navigate to page 10 using the next page button
     for (let i = 1; i < 10; i++) {
       const nextPageLink = page.getByLabel('Next page')
-      await nextPageLink.click()
-      await page.waitForURL(new RegExp(`/page-${i + 1}/`))
-      await expect(page).toHaveURL(new RegExp(`/page-${i + 1}/`))
+      // Confirm it's visible before clicking
+      await expect(nextPageLink).toBeVisible({ timeout: 5000 })
+      // Wait for both the click and URL change — works with client-side routing
+      await Promise.all([
+        page.waitForURL(new RegExp(`/page-${i + 1}/`), { timeout: 10000 }),
+        nextPageLink.click(),
+      ])
     }
-
-    // Now we should be on page 10
+    // Confirm we’re on page 10
     await expect(page).toHaveURL(/\/page-10\//)
     const pressReleaseItems = page.locator('.usa-unstyled-list li')
     await expect(pressReleaseItems).toHaveCount(10)
-
-    // Test navigation to page 11
+    // Navigate to page 11
     const nextPageLink = page.getByLabel('Next page')
-    await nextPageLink.click()
-    await page.waitForURL(/\/page-11\//)
+    await Promise.all([
+      page.waitForURL(/\/page-11\//, { timeout: 10000 }),
+      nextPageLink.click(),
+    ])
     await expect(page).toHaveURL(/\/page-11\//)
-    await expect(pressReleaseItems).toHaveCount(10)
   })
 
   test('Should render without a11y errors', async ({

--- a/playwright/tests/storyListing.spec.ts
+++ b/playwright/tests/storyListing.spec.ts
@@ -26,6 +26,23 @@ test.describe('Story Listing', () => {
     await expect(nextPageLink).toBeEnabled()
   })
 
+  test('Story Listing should handle double-digit page numbers correctly', async ({
+    page,
+  }) => {
+    await page.goto('/eastern-oklahoma-health-care/stories')
+    const page10Link = page.getByLabel('Page 10')
+    await page10Link.click()
+    await page.waitForURL(/\/page-10\//)
+    await expect(page).toHaveURL(/\/page-10\//)
+    const storyItems = page.locator('.usa-unstyled-list li')
+    await expect(storyItems).toHaveCount(10)
+    const nextPageLink = page.getByLabel('Next page')
+    await nextPageLink.click()
+    await page.waitForURL(/\/page-11\//)
+    await expect(page).toHaveURL(/\/page-11\//)
+    await expect(storyItems).toHaveCount(10)
+  })
+
   test('Should render without a11y errors', async ({
     page,
     makeAxeBuilder,

--- a/playwright/tests/storyListing.spec.ts
+++ b/playwright/tests/storyListing.spec.ts
@@ -29,7 +29,7 @@ test.describe('Story Listing', () => {
   test('Story Listing should handle double-digit page numbers correctly', async ({
     page,
   }) => {
-    await page.goto('/eastern-oklahoma-health-care/stories')
+    await page.goto('/washington-dc-health-care/stories')
     const page10Link = page.getByLabel('Page 10')
     await page10Link.click()
     await page.waitForURL(/\/page-10\//)

--- a/playwright/tests/storyListing.spec.ts
+++ b/playwright/tests/storyListing.spec.ts
@@ -30,12 +30,21 @@ test.describe('Story Listing', () => {
     page,
   }) => {
     await page.goto('/washington-dc-health-care/stories')
-    const page10Link = page.getByLabel('Page 10')
-    await page10Link.click()
-    await page.waitForURL(/\/page-10\//)
+
+    // Navigate to page 10 using the next page button
+    for (let i = 1; i < 10; i++) {
+      const nextPageLink = page.getByLabel('Next page')
+      await nextPageLink.click()
+      await page.waitForURL(new RegExp(`/page-${i + 1}/`))
+      await expect(page).toHaveURL(new RegExp(`/page-${i + 1}/`))
+    }
+
+    // Now we should be on page 10
     await expect(page).toHaveURL(/\/page-10\//)
     const storyItems = page.locator('.usa-unstyled-list li')
     await expect(storyItems).toHaveCount(10)
+
+    // Test navigation to page 11
     const nextPageLink = page.getByLabel('Next page')
     await nextPageLink.click()
     await page.waitForURL(/\/page-11\//)

--- a/playwright/tests/storyListing.spec.ts
+++ b/playwright/tests/storyListing.spec.ts
@@ -30,24 +30,26 @@ test.describe('Story Listing', () => {
     page,
   }) => {
     await page.goto('/washington-dc-health-care/stories')
-
-    // Navigate to page 10 using the next page button
     for (let i = 1; i < 10; i++) {
       const nextPageLink = page.getByLabel('Next page')
-      await nextPageLink.click()
-      await page.waitForURL(new RegExp(`/page-${i + 1}/`))
-      await expect(page).toHaveURL(new RegExp(`/page-${i + 1}/`))
+      // Ensure it's visible and interactable before click
+      await expect(nextPageLink).toBeVisible({ timeout: 5000 })
+      // Wait for click + navigation concurrently
+      await Promise.all([
+        page.waitForURL(new RegExp(`/page-${i + 1}/`), { timeout: 10000 }),
+        nextPageLink.click(),
+      ])
     }
-
-    // Now we should be on page 10
+    // Now on page 10
     await expect(page).toHaveURL(/\/page-10\//)
     const storyItems = page.locator('.usa-unstyled-list li')
     await expect(storyItems).toHaveCount(10)
-
-    // Test navigation to page 11
+    // Go to page 11
     const nextPageLink = page.getByLabel('Next page')
-    await nextPageLink.click()
-    await page.waitForURL(/\/page-11\//)
+    await Promise.all([
+      page.waitForURL(/\/page-11\//, { timeout: 10000 }),
+      nextPageLink.click(),
+    ])
     await expect(page).toHaveURL(/\/page-11\//)
     await expect(storyItems).toHaveCount(10)
   })

--- a/src/lib/drupal/listingPages.test.ts
+++ b/src/lib/drupal/listingPages.test.ts
@@ -7,8 +7,26 @@ import {
 import { slugToPath } from '@/lib/utils/slug'
 
 const listingPageFirstPageSlug = ['some-health-care', 'stories']
-
 const listingPageSecondPageSlug = ['some-health-care', 'stories', 'page-2']
+const listingPageTenthPageSlug = ['some-health-care', 'stories', 'page-10']
+const listingPageTwentiethPageSlug = ['some-health-care', 'stories', 'page-20']
+
+const pressReleaseFirstPageSlug = ['some-health-care', 'news-releases']
+const pressReleaseSecondPageSlug = [
+  'some-health-care',
+  'news-releases',
+  'page-2',
+]
+const pressReleaseTenthPageSlug = [
+  'some-health-care',
+  'news-releases',
+  'page-10',
+]
+const pressReleaseThirteenthPageSlug = [
+  'some-health-care',
+  'news-releases',
+  'page-13',
+]
 
 const nonListingPageSlug = ['some-health-care', 'stories', 'story-title']
 
@@ -68,6 +86,92 @@ describe('getListingPageStaticPropsContext', () => {
       isListingPage: true,
       firstPagePath: slugToPath(listingPageFirstPageSlug),
       page: 2,
+    })
+  })
+
+  test('should properly handle double-digit page number (page 10)', () => {
+    const context = {
+      params: {
+        slug: listingPageTenthPageSlug,
+      },
+    }
+    const result = getListingPageStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: true,
+      firstPagePath: slugToPath(listingPageFirstPageSlug),
+      page: 10,
+    })
+  })
+
+  test('should properly handle double-digit page number (page 20)', () => {
+    const context = {
+      params: {
+        slug: listingPageTwentiethPageSlug,
+      },
+    }
+    const result = getListingPageStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: true,
+      firstPagePath: slugToPath(listingPageFirstPageSlug),
+      page: 20,
+    })
+  })
+})
+
+describe('getListingPageStaticPropsContext for Press Releases', () => {
+  test('should properly handle first page', () => {
+    const context = {
+      params: {
+        slug: pressReleaseFirstPageSlug,
+      },
+    }
+    const result = getListingPageStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: true,
+      firstPagePath: slugToPath(pressReleaseFirstPageSlug),
+      page: 1,
+    })
+  })
+
+  test('should properly handle single-digit page number', () => {
+    const context = {
+      params: {
+        slug: pressReleaseSecondPageSlug,
+      },
+    }
+    const result = getListingPageStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: true,
+      firstPagePath: slugToPath(pressReleaseFirstPageSlug),
+      page: 2,
+    })
+  })
+
+  test('should properly handle double-digit page number (page 10)', () => {
+    const context = {
+      params: {
+        slug: pressReleaseTenthPageSlug,
+      },
+    }
+    const result = getListingPageStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: true,
+      firstPagePath: slugToPath(pressReleaseFirstPageSlug),
+      page: 10,
+    })
+  })
+
+  test('should properly handle double-digit page number (page 13)', () => {
+    const context = {
+      params: {
+        slug: pressReleaseThirteenthPageSlug,
+      },
+    }
+    const result = getListingPageStaticPropsContext(context)
+    expect(result).toStrictEqual({
+      isListingPage: true,
+      firstPagePath: slugToPath(pressReleaseFirstPageSlug),
+      page: 13,
     })
   })
 

--- a/src/lib/drupal/listingPages.ts
+++ b/src/lib/drupal/listingPages.ts
@@ -230,7 +230,7 @@ export function getListingPageStaticPropsContext(
     // EVENT_LISTING pages should only generate one page.
     slug[1] !==
       LISTING_RESOURCE_TYPE_URL_SEGMENTS[RESOURCE_TYPES.EVENT_LISTING] &&
-    slug[2].match(/^page-(\d)+$/)
+    slug[2].match(/^page-(\d+)$/)
   const page = isSlugSubsequentListingPage
     ? parseInt(isSlugSubsequentListingPage[1])
     : null


### PR DESCRIPTION
# Description
Fixes regex to correctly match multi-digit page numbers (e.g. page-10), not just single digits.
## Generated description

This pull request improves handling of double-digit page numbers for listing pages and press release pages, ensuring proper functionality in both tests and application logic. Key changes include the addition of new test cases, updates to slug definitions, and a bug fix in the page number regex.

### Test Enhancements:
* Added tests in `playwright/tests/pressReleaseListing.spec.ts` to validate navigation and item counts for double-digit pages in press release listings.
* Added tests in `playwright/tests/storyListing.spec.ts` to validate navigation and item counts for double-digit pages in story listings.
* Extended tests in `src/lib/drupal/listingPages.test.ts` to cover handling of double-digit page numbers for both story listings and press release listings, including pages 10, 13, and 20.

### Code Updates:
* Updated `src/lib/drupal/listingPages.test.ts` to define additional slug constants for double-digit pages in story and press release listings.
* Fixed a regex bug in `src/lib/drupal/listingPages.ts` to correctly match double-digit page numbers in slugs.
## Ticket

<!--
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20731-->

Closes [20731](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20731)

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

- Load up local host to http://localhost:3999/washington-dc-health-care/stories/page-10/
- Ensure all listings do not show up
- click page 13 and make sure you don't jump to page 3 
- check tugboat for the same behaviour
- run unit tests
## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

## Screenshots

Before:
<img width="1290" alt="image" src="https://github.com/user-attachments/assets/9e1dfeca-bce5-49a6-9505-b01fcadd0813" />
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/63d4bc62-24d9-4de9-a7b6-c7679db170a3" />

After:
<img width="1275" alt="image" src="https://github.com/user-attachments/assets/feeba555-54f9-4bbd-9100-efc3f125cb93" />

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/8f1fcc66-f86a-460a-be1b-d753e4f1146d" />


## Is this PR blocked by another PR?

- Add the `DO NOT MERGE` label
- Add links to additional PRs here:

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.