### PR TITLE
Add logging to getStaticPaths

### DIFF
--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -193,12 +193,35 @@ export async function getStaticPaths(
     }
   }
 
+  /* eslint-disable no-console */
+  console.log(
+    `\n\nBuilding ${RESOURCE_TYPES_TO_BUILD.length} resource types:`,
+    RESOURCE_TYPES_TO_BUILD,
+    '\n\n'
+  )
+
+  console.time('Fetching page paths')
+
+  const resources = await Promise.all(
+    RESOURCE_TYPES_TO_BUILD.map(getStaticPathsByResourceType)
+  )
+
+  console.timeEnd('Fetching page paths')
+
+  console.log('\n')
+  console.table(
+    RESOURCE_TYPES_TO_BUILD.reduce((resourceTable, resourceName, index) => {
+      return {
+        ...resourceTable,
+        [resourceName]: { 'Page Count': resources[index].length },
+      }
+    }, {})
+  )
+  console.log('\n')
+  /* eslint-enable no-console */
+
   return {
-    paths: (
-      await Promise.all(
-        RESOURCE_TYPES_TO_BUILD.map(getStaticPathsByResourceType)
-      )
-    ).flat(),
+    paths: resources.flat(),
     fallback: 'blocking',
   }
 }


### PR DESCRIPTION
It's not the prettiest logging, but I'm throwing this in here so we can see what content types we're building, how many pages each type has, and how long it takes to fetch that path data.

We can clean up the output here some, but we're still gonna run into the "Collecting page data..." bit getting in our way. There's probably some way around that with `process.stdout.write()` and some funny terminal escape codes to backspace, but... 🙈 I've done it before, and it was ugly. Makes the logs kinda messy here, but they already are, and they're only meant to be human readable anyhow, so 🤷 . In this case, I'm favoring a little messier logs over a little messier code. I have no strong opinions, though.

## Screenshots

![image](https://github.com/user-attachments/assets/e0ed9e8a-8856-4ea5-a644-926d7c3b441e)


## Generated description

This pull request introduces logging and performance measurement to the `getStaticPaths` function in the `src/pages/[[...slug]].tsx` file. These changes aim to provide better visibility into the static path generation process during the build.

### Enhancements to debugging and performance monitoring:

* Added `console.log` statements to display the number and types of resource types being built (`RESOURCE_TYPES_TO_BUILD`). ([src/pages/[[...slug]].tsxL196-R224](diffhunk://#diff-5f218029560343be88582c198bb3b04e4c18259a5e716a88250afabe4466f957L196-R224))
* Introduced `console.time` and `console.timeEnd` to measure the time taken for fetching page paths. ([src/pages/[[...slug]].tsxL196-R224](diffhunk://#diff-5f218029560343be88582c198bb3b04e4c18259a5e716a88250afabe4466f957L196-R224))
* Added a `console.table` to summarize the page count for each resource type in a structured format. ([src/pages/[[...slug]].tsxL196-R224](diffhunk://#diff-5f218029560343be88582c198bb3b04e4c18259a5e716a88250afabe4466f957L196-R224))
