### PR TITLE
Staff profile defects

### DIFF
--- a/src/data/queries/personProfile.ts
+++ b/src/data/queries/personProfile.ts
@@ -76,8 +76,7 @@ export const formatter: QueryFormatter<PersonProfileData, StaffProfile> = ({
     completeBiography: entity?.field_complete_biography?.uri || null,
     completeBiographyCreate: entity.field_complete_biography_create,
     photoAllowHiresDownload: entity.field_photo_allow_hires_download,
-    vamcOfficalName:
-      entity?.field_office?.field_vamc_system_official_name || null,
+    vamcTitle: entity?.field_office?.title || null,
     office: entity.field_office,
     menu: formattedMenu,
     administration: {

--- a/src/data/queries/personProfile.ts
+++ b/src/data/queries/personProfile.ts
@@ -83,5 +83,7 @@ export const formatter: QueryFormatter<PersonProfileData, StaffProfile> = ({
       id: entity.field_administration?.drupal_internal__tid || null,
       name: entity.field_administration?.name || null,
     },
+    lastUpdated:
+      entity.changed || entity.field_last_saved_by_an_editor || entity.created,
   }
 }

--- a/src/data/queries/tests/__snapshots__/personProfile.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/personProfile.test.tsx.snap
@@ -716,6 +716,6 @@ exports[`Person profile returns formatted data outputs formatted data 1`] = `
   "suffix": "Ph.D.",
   "title": "Patrick J. Doyle",
   "type": "node--person_profile",
-  "vamcOfficalName": "VA Pittsburgh Healthcare System",
+  "vamcTitle": "VA Pittsburgh health care",
 }
 `;

--- a/src/templates/layouts/staffProfile/index.test.tsx
+++ b/src/templates/layouts/staffProfile/index.test.tsx
@@ -79,8 +79,27 @@ describe('StaffProfile Component', () => {
     expect(screen.getByText('Phone:')).toBeInTheDocument()
     expect(screen.getByTestId('phone')).toBeInTheDocument()
     expect(screen.getByText(mockProfile.introText)).toBeInTheDocument()
-    expect(screen.getByText(/Download full size photo/)).toBeInTheDocument()
-    expect(screen.getByText(/Download full bio/)).toBeInTheDocument()
+
+    expect(screen.getByTestId('head-shot-download')).toBeInTheDocument()
+    expect(screen.getByTestId('head-shot-download')).toHaveAttribute(
+      'href',
+      'https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/styles/2_3_medium_thumbnail/public/2021-04/Zachary_Sage.jpg'
+    )
+    expect(screen.getByTestId('head-shot-download')).toHaveAttribute(
+      'filetype',
+      'JPG'
+    )
+    expect(
+      screen.getByTestId('complete-biography-download')
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('complete-biography-download')).toHaveAttribute(
+      'href',
+      'https://dsva-vagov-staging-cms-files.s3.us-gov-west-1.amazonaws.com/2023-07/RCS%20Bio%20%20Headshot.pdf'
+    )
+    expect(screen.getByTestId('complete-biography-download')).toHaveAttribute(
+      'filetype',
+      'PDF'
+    )
   })
 
   test('does not render email when it is null', () => {
@@ -110,9 +129,7 @@ describe('StaffProfile Component', () => {
     }
     render(<StaffProfile {...modifiedProfile} />)
 
-    expect(
-      screen.queryByText(/Download full size photo/)
-    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId('head-shot-download')).not.toBeInTheDocument()
   })
 
   test('does not render bio download option when completeBiography is null', () => {
@@ -122,7 +139,9 @@ describe('StaffProfile Component', () => {
     }
     render(<StaffProfile {...modifiedProfile} />)
 
-    expect(screen.queryByText(/Download full bio/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('complete-biography-download')
+    ).not.toBeInTheDocument()
   })
 
   describe('Lovell variants - tricare', () => {

--- a/src/templates/layouts/staffProfile/index.test.tsx
+++ b/src/templates/layouts/staffProfile/index.test.tsx
@@ -50,7 +50,7 @@ describe('StaffProfile Component', () => {
     completeBiographyCreate: true,
     completeBiography: completeBiography,
     photoAllowHiresDownload: true,
-    vamcOfficalName: 'VA Pittsburgh Healthcare System',
+    vamcTitle: 'VA Pittsburgh Healthcare System',
     media: mediaImage,
     menu: {
       depth: 5,
@@ -137,7 +137,7 @@ describe('StaffProfile Component', () => {
           url: { path: '/leadership' },
         },
       },
-      vamcOfficalName: 'Lovell Federal health care',
+      vamcTitle: 'Lovell Federal health care',
       lovellVariant: 'tricare',
       lovellSwitchPath: '/lovell-federal-health-care-va/leadership',
     }
@@ -168,7 +168,7 @@ describe('StaffProfile Component', () => {
           url: { path: '/leadership' },
         },
       },
-      vamcOfficalName: 'Lovell Federal health care',
+      vamcTitle: 'Lovell Federal health care',
       lovellVariant: 'va',
       lovellSwitchPath: '/lovell-federal-health-care-tricare/leadership',
     }

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -78,7 +78,7 @@ export const StaffProfile = ({
               ) : null}
 
               {emailAddress && (
-                <p className="vads-u-font-size--lg vads-u-margin-bottom--0p5">
+                <p className="vads-u-margin-bottom--0p5 vads-u-margin-top--0">
                   <span className="vads-u-font-weight--bold">Email: </span>
                   <va-link
                     data-testid="profile-email"
@@ -90,7 +90,7 @@ export const StaffProfile = ({
               {phoneNumber?.number && (
                 <PhoneNumber
                   {...phoneNumber}
-                  className="vads-u-font-weight--regular vads-u-margin--0 vads-u-margin-bottom--0p5"
+                  className="vads-u-margin-bottom--0p5 vads-u-margin-top--0"
                 />
               )}
             </div>

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -99,9 +99,9 @@ export const StaffProfile = ({
           </div>
           {completeBiographyCreate && (
             <div className="vads-u-margin-bottom--2">
-              <p className="vads-u-margin-bottom--0 va-introtext">
-                {introText}
-              </p>
+              <div className="va-introtext">
+                <p className="vads-u-margin-bottom--0">{introText}</p>
+              </div>
               <div
                 className="vads-u-margin-bottom--2"
                 dangerouslySetInnerHTML={{ __html: body }}

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -107,29 +107,30 @@ export const StaffProfile = ({
             </div>
           )}
           {media && photoAllowHiresDownload && (
-            <div
-              className="vads-u-align-content--flex-end va-c-margin-top--auto vads-u-margin-bottom--2"
-              id="download-full-size-photo-link"
-            >
-              <i
-                className="va-c-social-icon fas fa-download"
-                aria-hidden="true"
-              ></i>
+            <p>
               {/* TODO this is not the full size photo path. We need to send the original path down from Drupal */}
-              <a href={media.links['2_3_medium_thumbnail'].href} download>
-                {' '}
-                Download full size photo
-              </a>
-            </div>
+              <va-link
+                data-testid="head-shot-download"
+                href={media.links['2_3_medium_thumbnail'].href}
+                download
+                text="Download full size photo"
+                filetype={media.links['2_3_medium_thumbnail'].href
+                  .split('.')
+                  .pop()
+                  .toUpperCase()}
+              />
+            </p>
           )}
           {completeBiography && (
-            <div className="vads-u-align-content--flex-end va-c-margin-top--auto vads-u-margin-bottom--2">
-              <i className="va-c-social-icon fas fa-download"></i>
-              <a href={completeBiography?.url} download>
-                {' '}
-                Download full bio (PDF)
-              </a>
-            </div>
+            <p>
+              <va-link
+                data-testid="complete-biography-download"
+                href={completeBiography?.url}
+                download
+                text="Download full bio"
+                filetype={completeBiography?.url.split('.').pop().toUpperCase()}
+              />
+            </p>
           )}
         </article>
       </div>

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -59,7 +59,7 @@ export const StaffProfile = ({
             </div>
             <div className="vads-u-display--flex vads-u-flex-direction--column">
               <h1 className="vads-u-font-size--xl vads-u-margin-bottom--0p5">
-                {firstName} {lastName} {suffix}
+                {`${firstName} ${lastName} ${suffix ? suffix : ''}`}
               </h1>
               {description ? (
                 <p className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-font-family--serif vads-u-margin-bottom--0p5">

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -50,7 +50,7 @@ export const StaffProfile = ({
               {media && (
                 <MediaImage
                   {...media}
-                  className="person-profile-detail-page-image"
+                  className="person-profile-detail-page-image vads-u-width--full"
                   imageStyle="2_3_medium_thumbnail"
                 />
               )}

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -4,6 +4,7 @@ import { LovellStaticPropsResource } from '@/lib/drupal/lovell/types'
 import { PhoneNumber } from '@/templates/common/phoneNumber'
 import { MediaImage } from '@/templates/common/mediaImage'
 import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
+import { ContentFooter } from '@/templates/common/contentFooter'
 
 export type PersonProfileTeaserProps = {
   title: string
@@ -27,6 +28,7 @@ export const StaffProfile = ({
   menu,
   lovellVariant,
   lovellSwitchPath,
+  lastUpdated,
 }: LovellStaticPropsResource<FormattedStaffProfile>) => {
   return (
     <div className="usa-grid usa-grid-full">
@@ -133,6 +135,7 @@ export const StaffProfile = ({
             </p>
           )}
         </article>
+        <ContentFooter lastUpdated={lastUpdated} />
       </div>
     </div>
   )

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -22,7 +22,7 @@ export const StaffProfile = ({
   completeBiography,
   completeBiographyCreate,
   photoAllowHiresDownload,
-  vamcOfficalName,
+  vamcTitle,
   media,
   menu,
   lovellVariant,
@@ -64,16 +64,15 @@ export const StaffProfile = ({
                   {description}
                 </p>
               ) : null}
-              {vamcOfficalName ? (
+              {vamcTitle ? (
                 <p
                   className="
-                      vads-u-font-weight--normal
                       vads-u-margin--0
                       vads-u-margin-bottom--0p5
                       vads-u-font-family--serif
                       vads-u-font-size--lg"
                 >
-                  {vamcOfficalName}
+                  {vamcTitle}
                   {lovellVariant ? ` - ${lovellVariant.toUpperCase()}` : ''}
                 </p>
               ) : null}

--- a/src/templates/layouts/staffProfile/staffProfile.stories.ts
+++ b/src/templates/layouts/staffProfile/staffProfile.stories.ts
@@ -53,6 +53,6 @@ export const Full: Story = {
         url: { path: `pittsburgh-health-care/about-us/leadership` },
       },
     },
-    vamcOfficalName: 'VA Pittsburgh health care',
+    vamcTitle: 'VA Pittsburgh health care',
   },
 }

--- a/src/types/formatted/staffProfile.ts
+++ b/src/types/formatted/staffProfile.ts
@@ -29,7 +29,7 @@ export type StaffProfile = PublishedEntity & {
   completeBiography?: { url: string }
   completeBiographyCreate?: boolean
   photoAllowHiresDownload?: boolean
-  vamcOfficalName: string
+  vamcTitle: string
   lovellVariant?: LovellChildVariant
   lovellSwitchPath?: string
 }


### PR DESCRIPTION
# Description

Address defects found in the staff profile page.

## Generated description

This pull request refactors the `StaffProfile` component and related files to improve naming consistency, enhance functionality, and update tests. The key changes include renaming a property for clarity, adding new functionality for file downloads, and updating tests to reflect these changes.

### Property Renaming for Clarity:
* Renamed `vamcOfficalName` to `vamcTitle` across multiple files to improve naming consistency and clarity. (`src/data/queries/personProfile.ts` [[1]](diffhunk://#diff-fb3c28fd960889f40581d6766daac0d2e97708113468b12a0492394c71361c39L79-R87) `src/templates/layouts/staffProfile/index.tsx` [[2]](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L25-R31) [[3]](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L53-R83) [[4]](diffhunk://#diff-566b16d575ba28e9547d64f6195798bb736242741aa6c77bdfa2084a5f6bbe8bL56-R56) `src/types/formatted/staffProfile.ts` [[5]](diffhunk://#diff-f51a75a7fc7138380ff9b6a560b9efb09cd3a13072d7599eac6a6f28e9cd4fd3L32-R32)

### Enhanced File Download Functionality:
* Updated the `StaffProfile` component to use `va-link` elements for downloading headshots and biographies, including attributes like `filetype` for better metadata handling. (`src/templates/layouts/staffProfile/index.tsx` [[1]](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L94-R138) [[2]](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L53-R83)

### Test Updates:
* Adjusted test cases to align with the property renaming (`vamcTitle`) and new file download functionality, ensuring proper test coverage. (`src/templates/layouts/staffProfile/index.test.tsx` [[1]](diffhunk://#diff-fb16fac2680525555b561e6ed08f94072649a6cc97cfe45bb61287ceedf2a9a0L53-R53) [[2]](diffhunk://#diff-fb16fac2680525555b561e6ed08f94072649a6cc97cfe45bb61287ceedf2a9a0L82-R102) [[3]](diffhunk://#diff-fb16fac2680525555b561e6ed08f94072649a6cc97cfe45bb61287ceedf2a9a0L113-R132) [[4]](diffhunk://#diff-fb16fac2680525555b561e6ed08f94072649a6cc97cfe45bb61287ceedf2a9a0L125-R144) [[5]](diffhunk://#diff-fb16fac2680525555b561e6ed08f94072649a6cc97cfe45bb61287ceedf2a9a0L140-R159) [[6]](diffhunk://#diff-fb16fac2680525555b561e6ed08f94072649a6cc97cfe45bb61287ceedf2a9a0L171-R190)
* Updated snapshot tests to reflect the renamed property and updated output. (`src/data/queries/tests/__snapshots__/personProfile.test.tsx.snap` [src/data/queries/tests/__snapshots__/personProfile.test.tsx.snapL719-R719](diffhunk://#diff-e86290e3029182d879f7556fe1371bdbdabfaebd989dbc9a800dae78435c0849L719-R719))

### Additional Enhancements:
* Introduced a `lastUpdated` field to the `StaffProfile` component to display the most recent update timestamp. (`src/data/queries/personProfile.ts` [[1]](diffhunk://#diff-fb3c28fd960889f40581d6766daac0d2e97708113468b12a0492394c71361c39L79-R87) `src/templates/layouts/staffProfile/index.tsx` [[2]](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L25-R31)
* Added a `ContentFooter` component to display the `lastUpdated` information. (`src/templates/layouts/staffProfile/index.tsx` [[1]](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998R7) [[2]](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L94-R138)

## Ticket
Closes [21150](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21150)
Closes [21151](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21151)
Closes [21152](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21152)
Closes [21154](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21154)
Closes [21155](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21155)
Closes [21160](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21160)
Closes [21163](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21163)

## Developer Task
- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #next-build Slack channel to request a PR review.
- [x] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)

## Testing Steps
 - [ ] see defects [here](https://github.com/orgs/department-of-veterans-affairs/projects/1464/views/10?filterQuery=status%3ADefects%2C+Staff)
 - [ ] validate that each is resolved with the exception of 21193 on https://pr985-4xycw2ufki5qlxyd6kxc7u13ztx2p19q.tugboat.vfs.va.gov/
 
## Screenshots

Before:
![localhost_3999_lovell-federal-health-care-va_staff-profiles_chad-roe_ (1)](https://github.com/user-attachments/assets/fde6beec-e774-4a2d-b95a-9566d24ddfe8)
After:
![localhost_3999_lovell-federal-health-care-va_staff-profiles_chad-roe_](https://github.com/user-attachments/assets/57734a86-97cd-47b2-b70a-98c149f2931f)

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.