### PR TITLE
Fix mobile aspect ration for profile headshot

### DIFF
--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -52,7 +52,7 @@ export const StaffProfile = ({
               {media && (
                 <MediaImage
                   {...media}
-                  className="person-profile-detail-page-image vads-u-width--full"
+                  className="person-profile-detail-page-image vads-u-width--auto"
                   imageStyle="2_3_medium_thumbnail"
                 />
               )}


### PR DESCRIPTION
# Description

Changes `vads-u-width--full` (width: 100%) to `vads-u-width--auto` (width: auto) to maintain the aspect ratio of headshot down to mobile sizes. 

## Generated description

This pull request includes a small update to the `StaffProfile` component to adjust the styling of the media image.

* [`src/templates/layouts/staffProfile/index.tsx`](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L55-R55): Changed the `className` property of the `MediaImage` component from `vads-u-width--full` to `vads-u-width--auto` to modify the image's width behavior.
## Ticket


Closes [21150](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21150#issuecomment-2821245181)

## Developer Task

- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)


## Testing Steps

 - visit https://pr987-2hccpeuw4d1qba9umzxxwqbqtlj2wuac.tugboat.vfs.va.gov/boston-health-care/staff-profiles/vincent-ng/
 - in another tab open https://www.va.gov/boston-health-care/staff-profiles/vincent-ng/
 - compare various screen sizes and verify that the head shot image is the same in both tugboat and prod
 - verify that the image maintains its aspect ratio and doesn't stretch at any screen size

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.