### PR TITLE
Cvalarida/vamc image and map

### DIFF
--- a/src/templates/common/mediaImage/index.test.tsx
+++ b/src/templates/common/mediaImage/index.test.tsx
@@ -96,4 +96,11 @@ describe('MediaImage component returns null', () => {
     )
     expect(container.firstChild).toBeNull()
   })
+
+  test('returns null when alt text is missing or empty', () => {
+    const { container } = render(
+      <MediaImage {...mediaImage} alt="" imageStyle="2_1_large" />
+    )
+    expect(container.firstChild).toBeNull()
+  })
 })

--- a/src/templates/common/mediaImage/index.tsx
+++ b/src/templates/common/mediaImage/index.tsx
@@ -63,6 +63,10 @@ export const MediaImage = (
     return null
   }
 
+  if (!props.alt) {
+    return null
+  }
+
   return (
     <Image
       id={props.id}

--- a/src/templates/components/imageAndStaticMap/index.test.tsx
+++ b/src/templates/components/imageAndStaticMap/index.test.tsx
@@ -7,9 +7,6 @@ jest.mock('@/templates/common/mediaImage', () => ({
   // eslint-disable-next-line @next/next/no-img-element
   MediaImage: ({ alt }) => <img alt={alt} />,
 }))
-jest.mock('@/lib/analytics/recordEvent', () => ({
-  recordEvent: jest.fn(),
-}))
 
 describe('ImageAndStaticMap Component', () => {
   const mockImage = {
@@ -28,16 +25,5 @@ describe('ImageAndStaticMap Component', () => {
   it('renders the image with the correct alt text', () => {
     render(<ImageAndStaticMap image={mockImage} facilityId="facility-1" />)
     expect(screen.getByAltText('Test Image')).toBeInTheDocument()
-  })
-
-  it('triggers recordEvent on image click', () => {
-    const { recordEvent } = require('@/lib/analytics/recordEvent')
-    render(<ImageAndStaticMap image={mockImage} facilityId="facility-1" />)
-
-    fireEvent.click(screen.getByAltText('Test Image'))
-    expect(recordEvent).toHaveBeenCalledWith({
-      event: 'image-click',
-      'facility-name': 'facility-1',
-    })
   })
 })

--- a/src/templates/components/imageAndStaticMap/index.tsx
+++ b/src/templates/components/imageAndStaticMap/index.tsx
@@ -1,5 +1,4 @@
 import { MediaImage } from '@/templates/common/mediaImage'
-import { recordEvent } from '@/lib/analytics/recordEvent'
 
 import { MediaImage as FormattedMediaImage } from '@/types/formatted/media'
 
@@ -14,18 +13,7 @@ export const ImageAndStaticMap: React.FC<ImageAndStaticMapProps> = ({
 }) => {
   return (
     <div className="usa-width-one-third inline-table-helper vads-u-order--first mobile-lg:vads-u-order--initial vads-u-margin-bottom--2 vads-u-margin-left--auto facility">
-      <div
-        onClick={() =>
-          recordEvent({ event: 'image-click', 'facility-name': facilityId })
-        }
-        style={{ cursor: 'pointer' }}
-      >
-        <MediaImage
-          {...image}
-          imageStyle="2_1_large"
-          className="facility-img"
-        />
-      </div>
+      <MediaImage {...image} imageStyle="2_1_large" className="facility-img" />
       <div data-widget-type="facility-map" data-facility={facilityId}>
         {/* TODO: Create Facility Map component for display here */}
       </div>

--- a/src/templates/layouts/healthCareLocalFacility/index.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.tsx
@@ -13,6 +13,7 @@ import { OperatingStatusFlags } from './OperatingStatus'
 import { Address } from './Address'
 import { Phone } from './Phone'
 import { Hours } from '@/templates/components/hours'
+import { ImageAndStaticMap } from '@/templates/components/imageAndStaticMap'
 
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
@@ -109,7 +110,7 @@ export function HealthCareLocalFacility({
             >
               Location and contact information
             </h2>
-            <div className="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--4">
+            <div className="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column mobile-lg:vads-u-flex-direction--row facility vads-u-margin-bottom--2p5 vads-u-margin-bottom--4">
               <div className="usa-width-two-thirds">
                 <div>
                   <OperatingStatusFlags
@@ -148,7 +149,10 @@ export function HealthCareLocalFacility({
                   </section>
                 </div>
               </div>
-              <div>TODO: Image and static map</div>
+              <ImageAndStaticMap
+                image={image}
+                facilityId={facilityLocatorApiId}
+              />
             </div>
             <LocationServices />
             <div>TODO: List of links section</div>


### PR DESCRIPTION
# Description

Adds the image and (presumably) map to the page.

Along the way, I had to fiddle with a few other things to get it to display and behave as expected, but the changes were minimal.

## Screenshots

Locally, it can't access the facility locator API, so it doesn't actually render a map.
![image](https://github.com/user-attachments/assets/539d7007-f81d-476b-8b95-d36fcccc0add)

We can see by the spinner that the widget is loading correctly, though, and when we examine the DOM, we see the attributes are set correctly as well.

![image](https://github.com/user-attachments/assets/03eafec6-494c-4e25-87a9-086618cdbe56)


## Generated description

This pull request introduces several updates to improve the functionality and structure of the `MediaImage` and `ImageAndStaticMap` components, as well as their integration into the `HealthCareLocalFacility` layout. The main changes include adding a validation check for `alt` text in the `MediaImage` component, removing unused analytics functionality from `ImageAndStaticMap`, and integrating the `ImageAndStaticMap` component into the `HealthCareLocalFacility` layout.

### MediaImage Component Enhancements:
* Added a validation in `MediaImage` to return `null` if the `alt` text is missing or empty, ensuring accessibility compliance. (`src/templates/common/mediaImage/index.tsx`, [src/templates/common/mediaImage/index.tsxR66-R69](diffhunk://#diff-bfccd708583b87c70bd90c950ec2db5c6764c99f77ff28876fd328c969c4be23R66-R69))
* Updated the `MediaImage` test suite to include a test case verifying that the component returns `null` when the `alt` text is empty. (`src/templates/common/mediaImage/index.test.tsx`, [src/templates/common/mediaImage/index.test.tsxR99-R105](diffhunk://#diff-baaccf8461bb720a65af31245bb5b30bb4b1aca535701b16a17e5e5fb4e52d50R99-R105))

### ImageAndStaticMap Component Simplifications:
* Removed the `recordEvent` analytics functionality and associated `onClick` handler from `ImageAndStaticMap`, simplifying the component's behavior. (`src/templates/components/imageAndStaticMap/index.tsx`, [[1]](diffhunk://#diff-ead5fe56a6dba7dc893c7621f779f77a25d2461a7682200a9cf30438c319078bL2) [[2]](diffhunk://#diff-ead5fe56a6dba7dc893c7621f779f77a25d2461a7682200a9cf30438c319078bL17-R16)
* Deleted the corresponding test for the removed `recordEvent` functionality. (`src/templates/components/imageAndStaticMap/index.test.tsx`, [[1]](diffhunk://#diff-7c10f45a360345ddbf25ca9464357cc019bc1eda67721869430456571fd49a3fL10-L12) [[2]](diffhunk://#diff-7c10f45a360345ddbf25ca9464357cc019bc1eda67721869430456571fd49a3fL32-L42)

### HealthCareLocalFacility Layout Integration:
* Integrated the `ImageAndStaticMap` component into the `HealthCareLocalFacility` layout to replace a placeholder, enhancing the layout with dynamic content. (`src/templates/layouts/healthCareLocalFacility/index.tsx`, [[1]](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefR16) [[2]](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefL151-R155)
* Adjusted layout styles to improve responsiveness and spacing in the `HealthCareLocalFacility` component. (`src/templates/layouts/healthCareLocalFacility/index.tsx`, [src/templates/layouts/healthCareLocalFacility/index.tsxL112-R113](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefL112-R113))

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20786
