### PR TITLE
Update  Github Action runner ubuntu version for create ECR image & update manifest

### DIFF
--- a/.github/workflows/mirror-images.yml
+++ b/.github/workflows/mirror-images.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   mirror:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       ECR_REPOSITORY: "dsva/next-build-node"
       IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   update-manifest:
     if: ${{ !(github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}
     steps:


### PR DESCRIPTION
# Description

Updates an outdated runner OS. See https://github.com/actions/runner-images/issues/11101

## Generated description

This pull request updates the GitHub Actions workflows to use the latest Ubuntu runner version for improved compatibility and support.

Updates to GitHub Actions workflows:

* [`.github/workflows/mirror-images.yml`](diffhunk://#diff-000c2c5c41de288c4505fa435f4bfaeacff2c85cb83dc045b506e9e9498d2ea1L22-R22): Changed the `runs-on` property from `ubuntu-20.04` to `ubuntu-latest` in the `mirror` job.
* [`.github/workflows/update-manifest.yml`](diffhunk://#diff-8ae4145d74449daf9b315c4870fa71a61a1602f0bebf7478ab2d34514f69e9c2L33-R33): Updated the `runs-on` property from `ubuntu-20.04` to `ubuntu-latest` in the `update-manifest` job.

