### PR TITLE
Staff profile to v3 grid

### DIFF
--- a/src/templates/common/breadcrumbs/index.tsx
+++ b/src/templates/common/breadcrumbs/index.tsx
@@ -67,7 +67,7 @@ const Breadcrumbs = ({
   const fcString = JSON.stringify(filteredCrumbs)
 
   return (
-    <div className="vads-u-padding-x--1p5">
+    <div className="vads-grid-container">
       <va-breadcrumbs class="row" wrapping breadcrumb-list={fcString} />
     </div>
   )

--- a/src/templates/components/staffProfileSideBarNav/index.tsx
+++ b/src/templates/components/staffProfileSideBarNav/index.tsx
@@ -30,11 +30,11 @@ const StaffProfileSideBarNav: React.FC<SidebarNavProps> = ({
       data-template="navigation/facility_no_drupal_page_sidebar_nav"
       id="va-detailpage-sidebar"
       data-drupal-sidebar
-      className="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav"
+      className="va-c-facility-sidebar"
     >
       <div>
         <div className="left-side-nav-title">
-          <h4>{link.label}</h4>
+          <h4 className="vads-u-margin--0">{link.label}</h4>
         </div>
         <p className="vads-u-margin-y--0">
           <va-link

--- a/src/templates/components/staffProfileSideBarNav/index.tsx
+++ b/src/templates/components/staffProfileSideBarNav/index.tsx
@@ -33,9 +33,9 @@ const StaffProfileSideBarNav: React.FC<SidebarNavProps> = ({
       className="va-c-facility-sidebar"
     >
       <div>
-        <div className="left-side-nav-title">
-          <h4 className="vads-u-margin--0">{link.label}</h4>
-        </div>
+        <h4 className="vads-u-margin-top--0 vads-u-margin-bottom--3">
+          {link.label}
+        </h4>
         <p className="vads-u-margin-y--0">
           <va-link
             data-testid="sidebar-nav-link"

--- a/src/templates/components/staffProfileSideBarNav/index.tsx
+++ b/src/templates/components/staffProfileSideBarNav/index.tsx
@@ -30,7 +30,7 @@ const StaffProfileSideBarNav: React.FC<SidebarNavProps> = ({
       data-template="navigation/facility_no_drupal_page_sidebar_nav"
       id="va-detailpage-sidebar"
       data-drupal-sidebar
-      className="va-c-facility-sidebar vads-u-padding-left--2 desktop:vads-u-padding-x--0"
+      className="va-c-facility-sidebar"
     >
       <div>
         <h4 className="vads-u-margin-top--0 vads-u-margin-bottom--3">

--- a/src/templates/components/staffProfileSideBarNav/index.tsx
+++ b/src/templates/components/staffProfileSideBarNav/index.tsx
@@ -30,7 +30,7 @@ const StaffProfileSideBarNav: React.FC<SidebarNavProps> = ({
       data-template="navigation/facility_no_drupal_page_sidebar_nav"
       id="va-detailpage-sidebar"
       data-drupal-sidebar
-      className="va-c-facility-sidebar"
+      className="va-c-facility-sidebar vads-u-padding-left--2 desktop:vads-u-padding-x--0"
     >
       <div>
         <h4 className="vads-u-margin-top--0 vads-u-margin-bottom--3">

--- a/src/templates/layouts/staffProfile/index.test.tsx
+++ b/src/templates/layouts/staffProfile/index.test.tsx
@@ -24,6 +24,12 @@ describe('StaffProfile Component', () => {
           linkParams: {},
         },
       },
+      original: {
+        href: 'https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/styles/original/public/2021-04/Zachary_Sage.jpg',
+        meta: {
+          linkParams: {},
+        },
+      },
     },
   }
   const completeBiography = {
@@ -83,7 +89,7 @@ describe('StaffProfile Component', () => {
     expect(screen.getByTestId('head-shot-download')).toBeInTheDocument()
     expect(screen.getByTestId('head-shot-download')).toHaveAttribute(
       'href',
-      'https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/styles/2_3_medium_thumbnail/public/2021-04/Zachary_Sage.jpg'
+      'https://s3-us-gov-west-1.amazonaws.com/content.www.va.gov/img/styles/original/public/2021-04/Zachary_Sage.jpg'
     )
     expect(screen.getByTestId('head-shot-download')).toHaveAttribute(
       'filetype',

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -32,110 +32,117 @@ export const StaffProfile = ({
 }: LovellStaticPropsResource<FormattedStaffProfile>) => {
   return (
     <div className="vads-grid-container">
-      {menu && (
-        <StaffProfileSideBarNav
-          sidebarData={menu}
-          lovellVariant={lovellVariant}
-        />
-      )}
-      <div className="usa-width-three-fourths">
-        <article className="usa-content">
-          <LovellSwitcher
-            currentVariant={lovellVariant}
-            switchPath={lovellSwitchPath}
-          />
-          <div className="vads-grid-container vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
-            <div
-              className="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-margin-right--3"
-              style={{ maxWidth: '160px' }}
-            >
-              {media && (
-                <MediaImage
-                  {...media}
-                  className="person-profile-detail-page-image vads-u-width--auto"
-                  imageStyle="2_3_medium_thumbnail"
-                />
-              )}
-            </div>
-            <div className="vads-u-display--flex vads-u-flex-direction--column">
-              <h1 className="vads-u-font-size--xl vads-u-margin-bottom--0p5">
-                {`${firstName} ${lastName} ${suffix ? suffix : ''}`}
-              </h1>
-              {description ? (
-                <p className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-font-family--serif vads-u-margin-bottom--0p5">
-                  {description}
-                </p>
-              ) : null}
-              {vamcTitle ? (
-                <p
-                  className="
-                      vads-u-margin--0
-                      vads-u-margin-bottom--0p5
-                      vads-u-font-family--serif
-                      vads-u-font-size--lg"
-                >
-                  {vamcTitle}
-                  {lovellVariant ? ` - ${lovellVariant.toUpperCase()}` : ''}
-                </p>
-              ) : null}
-
-              {emailAddress && (
-                <p className="vads-u-margin-bottom--0p5 vads-u-margin-top--0">
-                  <span className="vads-u-font-weight--bold">Email: </span>
-                  <va-link
-                    data-testid="profile-email"
-                    href={`mailto:${emailAddress}`}
-                    text={emailAddress}
-                  />
-                </p>
-              )}
-              {phoneNumber?.number && (
-                <PhoneNumber
-                  {...phoneNumber}
-                  className="vads-u-margin-bottom--0p5 vads-u-margin-top--0"
-                />
-              )}
-            </div>
+      <div className="vads-grid-row">
+        {menu && (
+          <div className="vads-u-display--none tablet:vads-u-display--block tablet:vads-grid-col-3">
+            <StaffProfileSideBarNav
+              sidebarData={menu}
+              lovellVariant={lovellVariant}
+            />
           </div>
-          {completeBiographyCreate && (
-            <div className="vads-u-margin-bottom--2">
-              <div className="va-introtext">
-                <p className="vads-u-margin-bottom--0">{introText}</p>
-              </div>
+        )}
+        <div className={menu ? 'tablet:vads-grid-col-9' : 'vads-grid-col-12'}>
+          <article className="usa-content">
+            <LovellSwitcher
+              currentVariant={lovellVariant}
+              switchPath={lovellSwitchPath}
+            />
+            <div className="vads-display--flex vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column tablet:vads-u-flex-direction--row">
               <div
-                className="vads-u-margin-bottom--2"
-                dangerouslySetInnerHTML={{ __html: body }}
-              />
+                className="vads-u-margin-bottom--2 tablet:vads-u-margin-bottom--0 vads-u-margin-right--3"
+                style={{ maxWidth: '160px' }}
+              >
+                {media && (
+                  <MediaImage
+                    {...media}
+                    className="person-profile-detail-page-image vads-u-width--auto"
+                    imageStyle="2_3_medium_thumbnail"
+                  />
+                )}
+              </div>
+              <div className="vads-u-display--flex vads-u-flex-direction--column">
+                <h1 className="vads-u-font-size--xl vads-u-margin-bottom--0p5">
+                  {`${firstName} ${lastName} ${suffix ? suffix : ''}`}
+                </h1>
+                {description ? (
+                  <p className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-font-family--serif vads-u-margin-bottom--0p5">
+                    {description}
+                  </p>
+                ) : null}
+                {vamcTitle ? (
+                  <p
+                    className="
+                        vads-u-margin--0
+                        vads-u-margin-bottom--0p5
+                        vads-u-font-family--serif
+                        vads-u-font-size--lg"
+                  >
+                    {vamcTitle}
+                    {lovellVariant ? ` - ${lovellVariant.toUpperCase()}` : ''}
+                  </p>
+                ) : null}
+
+                {emailAddress && (
+                  <p className="vads-u-margin-bottom--0p5 vads-u-margin-top--0">
+                    <span className="vads-u-font-weight--bold">Email: </span>
+                    <va-link
+                      data-testid="profile-email"
+                      href={`mailto:${emailAddress}`}
+                      text={emailAddress}
+                    />
+                  </p>
+                )}
+                {phoneNumber?.number && (
+                  <PhoneNumber
+                    {...phoneNumber}
+                    className="vads-u-margin-bottom--0p5 vads-u-margin-top--0"
+                  />
+                )}
+              </div>
             </div>
-          )}
-          {media && photoAllowHiresDownload && (
-            <p>
-              {/* TODO this is not the full size photo path. We need to send the original path down from Drupal */}
-              <va-link
-                data-testid="head-shot-download"
-                href={media.links['2_3_medium_thumbnail'].href}
-                download
-                text="Download full size photo"
-                filetype={media.links['2_3_medium_thumbnail'].href
-                  .split('.')
-                  .pop()
-                  .toUpperCase()}
-              />
-            </p>
-          )}
-          {completeBiography && (
-            <p>
-              <va-link
-                data-testid="complete-biography-download"
-                href={completeBiography?.url}
-                download
-                text="Download full bio"
-                filetype={completeBiography?.url.split('.').pop().toUpperCase()}
-              />
-            </p>
-          )}
-        </article>
-        <ContentFooter lastUpdated={lastUpdated} />
+            {completeBiographyCreate && (
+              <div className="vads-u-margin-bottom--2">
+                <div className="va-introtext">
+                  <p className="vads-u-margin-bottom--0">{introText}</p>
+                </div>
+                <div
+                  className="vads-u-margin-bottom--2"
+                  dangerouslySetInnerHTML={{ __html: body }}
+                />
+              </div>
+            )}
+            {media && photoAllowHiresDownload && (
+              <p>
+                {/* TODO this is not the full size photo path. We need to send the original path down from Drupal */}
+                <va-link
+                  data-testid="head-shot-download"
+                  href={media.links['2_3_medium_thumbnail'].href}
+                  download
+                  text="Download full size photo"
+                  filetype={media.links['2_3_medium_thumbnail'].href
+                    .split('.')
+                    .pop()
+                    .toUpperCase()}
+                />
+              </p>
+            )}
+            {completeBiography && (
+              <p>
+                <va-link
+                  data-testid="complete-biography-download"
+                  href={completeBiography?.url}
+                  download
+                  text="Download full bio"
+                  filetype={completeBiography?.url
+                    .split('.')
+                    .pop()
+                    .toUpperCase()}
+                />
+              </p>
+            )}
+          </article>
+          <ContentFooter lastUpdated={lastUpdated} />
+        </div>
       </div>
     </div>
   )

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -31,7 +31,7 @@ export const StaffProfile = ({
   lastUpdated,
 }: LovellStaticPropsResource<FormattedStaffProfile>) => {
   return (
-    <div className="vads-grid-container mobile:vads-u-padding-x--0">
+    <div className="vads-grid-container">
       <div className="vads-grid-row">
         {menu && (
           <div className="vads-u-display--none tablet:vads-u-display--block tablet:vads-grid-col-3">
@@ -113,13 +113,12 @@ export const StaffProfile = ({
             )}
             {media && photoAllowHiresDownload && (
               <p>
-                {/* TODO this is not the full size photo path. We need to send the original path down from Drupal */}
                 <va-link
                   data-testid="head-shot-download"
-                  href={media.links['2_3_medium_thumbnail'].href}
+                  href={media.links['original'].href}
                   download
                   text="Download full size photo"
-                  filetype={media.links['2_3_medium_thumbnail'].href
+                  filetype={media.links['original'].href
                     .split('.')
                     .pop()
                     .toUpperCase()}

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -31,7 +31,7 @@ export const StaffProfile = ({
   lastUpdated,
 }: LovellStaticPropsResource<FormattedStaffProfile>) => {
   return (
-    <div className="vads-grid-container">
+    <div className="vads-grid-container mobile:vads-u-padding-x--0">
       <div className="vads-grid-row">
         {menu && (
           <div className="vads-u-display--none tablet:vads-u-display--block tablet:vads-grid-col-3">

--- a/src/templates/layouts/staffProfile/index.tsx
+++ b/src/templates/layouts/staffProfile/index.tsx
@@ -31,7 +31,7 @@ export const StaffProfile = ({
   lastUpdated,
 }: LovellStaticPropsResource<FormattedStaffProfile>) => {
   return (
-    <div className="usa-grid usa-grid-full">
+    <div className="vads-grid-container">
       {menu && (
         <StaffProfileSideBarNav
           sidebarData={menu}
@@ -44,7 +44,7 @@ export const StaffProfile = ({
             currentVariant={lovellVariant}
             switchPath={lovellSwitchPath}
           />
-          <div className="usa-grid usa-grid-full vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
+          <div className="vads-grid-container vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
             <div
               className="vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--0 vads-u-margin-right--3"
               style={{ maxWidth: '160px' }}


### PR DESCRIPTION
# Description

Updates classnames to utilize v3 grid. 

## Generated description

This pull request refactors the layout and styling of the staff profile page to improve responsiveness and consistency. Key changes include updates to the sidebar navigation, grid layout, and styling adjustments for better alignment with design standards.

### Layout and Responsiveness Improvements:

* Updated the `StaffProfileSideBarNav` component to remove the `usa-width-one-fourth` class and added a new `vads-u-margin--0` class to the `<h4>` element for consistent spacing. (`src/templates/components/staffProfileSideBarNav/index.tsx`, [src/templates/components/staffProfileSideBarNav/index.tsxL33-R37](diffhunk://#diff-534e7f0e3579d6bc8b1785e073cbaf6a6c64c4857701e46cc0c14a1b365bfeabL33-R37))
* Refactored the `StaffProfile` layout to use `vads-grid-container` and `vads-grid-row` for better grid alignment. Adjusted the sidebar visibility and grid column sizes with responsive utility classes like `tablet:vads-grid-col-3` and `tablet:vads-grid-col-9`. (`src/templates/layouts/staffProfile/index.tsx`, [src/templates/layouts/staffProfile/index.tsxL34-R52](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L34-R52))

### Code Formatting and Cleanup:

* Reformatted the `filetype` prop in the `Download full bio` link to improve readability by chaining methods across multiple lines. (`src/templates/layouts/staffProfile/index.tsx`, [src/templates/layouts/staffProfile/index.tsxL133-R147](diffhunk://#diff-d74274c7a72eef4771791e64dc3cd75049dc232c9eeed07c1fef3da1e188f998L133-R147))
## Ticket

Closes [21083](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21083)

## Developer Task

- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)

## Testing Steps

 - [ ] Verify that there are no grid v1 classes in used on a profile page(https://pr993-lh3lmqwmfxqje6oyrnupd6le9dzaudcd.tugboat.vfs.va.gov/boston-health-care/staff-profiles/vincent-ng/)
 - [ ] review page at various breakpoints and compare to prod *note the padding for grid containers in grid v3 is larger than on prod. Also the changes at the medium breakpoint (768px) now take place at tablet(640px):
     - [ ] 1201px+
     - [ ] 1024px
     - [ ] 640px
     - [ ] 481px
     - [ ] 320px
 
## Screenshots
### 320:
![localhost_3999_boston-health-care_staff-profiles_vincent-ng_](https://github.com/user-attachments/assets/b07f4b5b-d2f1-4b0f-80b0-db10e3d5bc83)

### 481:
![localhost_3999_boston-health-care_staff-profiles_vincent-ng_ (1)](https://github.com/user-attachments/assets/6fb01637-f809-4207-b643-29fecc94228b)

### 640:
![localhost_3999_boston-health-care_staff-profiles_vincent-ng_ (2)](https://github.com/user-attachments/assets/72fed95e-5c59-489e-8cc7-7c4791c7ea74)

### 1024:
![localhost_3999_boston-health-care_staff-profiles_vincent-ng_ (3)](https://github.com/user-attachments/assets/ad55c0d6-41bc-47bf-84d7-d174124a9f20)

### 1201+:
![localhost_3999_boston-health-care_staff-profiles_vincent-ng_ (4)](https://github.com/user-attachments/assets/16a07b74-c4cf-4b3c-966f-873672126b19)

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.