### PR TITLE
VACMS-20166: Making va-links self closing

### DIFF
--- a/src/templates/components/newsStoryTeaser/index.test.tsx
+++ b/src/templates/components/newsStoryTeaser/index.test.tsx
@@ -40,11 +40,12 @@ describe('<NewsStoryTeaser> with valid data', () => {
     const { container } = render(<NewsStoryTeaser {...teaserData} />)
     const imgEl = container.querySelector('img')
     expect(imgEl).toBeTruthy()
+    const link = container.querySelector('va-link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', teaserData.link)
+    expect(link).toHaveAttribute('text', teaserData.title)
     expect(
-      screen.queryByText(/We honor outstanding doctors/)
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText(
+      screen.getByText(
         /When a hospital has a host of great doctors, honoring just two every year is challenging./
       )
     ).toBeInTheDocument()
@@ -55,11 +56,12 @@ describe('<NewsStoryTeaser> with valid data', () => {
     const { container } = render(<NewsStoryTeaser {...dataWithoutImage} />)
     const imgEl = container.querySelector('img')
     expect(imgEl).toBeNull()
+    const link = container.querySelector('va-link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', teaserData.link)
+    expect(link).toHaveAttribute('text', teaserData.title)
     expect(
-      screen.queryByText(/We honor outstanding doctors/)
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText(
+      screen.getByText(
         /When a hospital has a host of great doctors, honoring just two every year is challenging./
       )
     ).toBeInTheDocument()
@@ -73,20 +75,31 @@ describe('<NewsStoryTeaser> with valid data', () => {
     const { container } = render(<NewsStoryTeaser {...dataWithInvalidImage} />)
     const imgEl = container.querySelector('img')
     expect(imgEl).toBeNull()
-    expect(
-      screen.queryByText(/We honor outstanding doctors/)
-    ).toBeInTheDocument()
+    const link = container.querySelector('va-link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', teaserData.link)
+    expect(link).toHaveAttribute('text', teaserData.title)
   })
 
   it('renders correctly with default heading level', () => {
-    render(<NewsStoryTeaser {...teaserData} headingLevel={undefined} />)
+    const { container } = render(
+      <NewsStoryTeaser {...teaserData} headingLevel={undefined} />
+    )
     expect(document.querySelector('h2')).toBeInTheDocument()
-    expect(screen.getByText(teaserData.title)).toBeInTheDocument()
+    const link = container.querySelector('va-link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', teaserData.link)
+    expect(link).toHaveAttribute('text', teaserData.title)
   })
 
   it('renders correctly with specified heading level', () => {
-    render(<NewsStoryTeaser {...teaserData} headingLevel="h3" />)
+    const { container } = render(
+      <NewsStoryTeaser {...teaserData} headingLevel="h3" />
+    )
     expect(document.querySelector('h3')).toBeInTheDocument()
-    expect(screen.getByText(teaserData.title)).toBeInTheDocument()
+    const link = container.querySelector('va-link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', teaserData.link)
+    expect(link).toHaveAttribute('text', teaserData.title)
   })
 })

--- a/src/templates/components/newsStoryTeaser/index.tsx
+++ b/src/templates/components/newsStoryTeaser/index.tsx
@@ -20,9 +20,7 @@ export const NewsStoryTeaser = ({
       <div className="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
         <div className="usa-width-two-thirds">
           <TitleTag className="vads-u-font-size--md medium-screen:vads-u-font-size--lg medium-screen:vads-u-margin-bottom--0p5">
-            <va-link href={link} text={title}>
-              {title}
-            </va-link>
+            <va-link href={link} text={title} />
           </TitleTag>
           <p className="vads-u-margin-y--0">
             {truncateWordsOrChar(introText, 60, true)}

--- a/src/templates/components/pressReleaseTeaser/index.test.tsx
+++ b/src/templates/components/pressReleaseTeaser/index.test.tsx
@@ -21,14 +21,14 @@ describe('<PressReleaseTeaser> with valid data', () => {
   })
   test('renders component', () => {
     const { container } = render(<PressReleaseTeaser {...teaserData} />)
+    const link = container.querySelector('va-link')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', teaserData.link)
+    expect(link).toHaveAttribute('text', teaserData.title)
     expect(
-      screen.queryByText(/Wilmington VAMC 2019 Annual Report/)
+      screen.getByText(/We invite you to come and read our 2019 Annual Report./)
     ).toBeInTheDocument()
-    expect(
-      screen.queryByText(
-        /We invite you to come and read our 2019 Annual Report./
-      )
-    ).toBeInTheDocument()
+    expect(screen.getByText('April 12, 2021')).toBeInTheDocument()
   })
 
   test('renders with default heading level', () => {

--- a/src/templates/components/pressReleaseTeaser/index.tsx
+++ b/src/templates/components/pressReleaseTeaser/index.tsx
@@ -20,9 +20,7 @@ export function PressReleaseTeaser({
     <>
       <section className="vads-u-margin-bottom--4">
         <TitleTag className="vads-u-margin-bottom--1p5 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
-          <va-link href={link} text={title}>
-            {title}
-          </va-link>
+          <va-link href={link} text={title} />
         </TitleTag>
         <strong>{formatDate(releaseDate)}</strong>
         <p className="vads-u-margin-top--0">

--- a/src/templates/layouts/vetCenterOutstation/index.tsx
+++ b/src/templates/layouts/vetCenterOutstation/index.tsx
@@ -288,9 +288,10 @@ export function VetCenterOutstation({
                 Vet Centers are community based to be more accessible in areas
                 where you live. Find a nearby Vet Center location.
               </p>
-              <va-link href={`${path}/locations`}>
-                Find a nearby Vet Center location
-              </va-link>
+              <va-link
+                href={`${path}/locations`}
+                text="Find a nearby Vet Center location"
+              />
             </div>
           </div>
 


### PR DESCRIPTION
# Description

This PR makes the va-link self closing in some files across the codebase.
## Generated description

This pull request updates the usage of the `<va-link>` component across multiple files to simplify its implementation and improve test coverage. The primary changes involve replacing the child-based `<va-link>` structure with a self-closing tag that uses the `text` attribute, and updating corresponding tests to validate the new structure.

### Component Updates:

* [`src/templates/components/newsStoryTeaser/index.tsx`](diffhunk://#diff-a3a22c710561bd7dd66963d62b553b4935257d0a1fa53833f70f58a1cc35d08aL23-R23): Refactored the `<va-link>` component to use a self-closing tag with the `text` attribute instead of wrapping the title as a child.
* [`src/templates/components/pressReleaseTeaser/index.tsx`](diffhunk://#diff-a52f541f81ba799f267e6125ab0cfb73ba4094b78c123021e4a2366dc41e5cc0L23-R23): Updated the `<va-link>` implementation to a self-closing tag with the `text` attribute.
* [`src/templates/layouts/vetCenterOutstation/index.tsx`](diffhunk://#diff-cd0f0c70cc0ccebaec32854856c0a067b3587414f5e03187679fb6221467e53dL291-R294): Modified the `<va-link>` component to use the `text` attribute for the link text instead of having it as a child.

### Test Updates:

* [`src/templates/components/newsStoryTeaser/index.test.tsx`](diffhunk://#diff-721a74c6ae17d4dad4d56dbb1e07ca90bb64b1608915e5e89384ddd46a79b806R43-R48): Updated tests to validate the new `<va-link>` structure, ensuring the `href` and `text` attributes are present and correct. Removed outdated assertions for child text content. [[1]](diffhunk://#diff-721a74c6ae17d4dad4d56dbb1e07ca90bb64b1608915e5e89384ddd46a79b806R43-R48) [[2]](diffhunk://#diff-721a74c6ae17d4dad4d56dbb1e07ca90bb64b1608915e5e89384ddd46a79b806R59-R64) [[3]](diffhunk://#diff-721a74c6ae17d4dad4d56dbb1e07ca90bb64b1608915e5e89384ddd46a79b806L76-R103)
* [`src/templates/components/pressReleaseTeaser/index.test.tsx`](diffhunk://#diff-d252312eb41b4c5dfde9ce8ebaa26a92b619f0b26aa3f2f449eb47779ae0db1aR24-R31): Added assertions to confirm the presence and correctness of the `href` and `text` attributes in the `<va-link>` component. Removed assertions for child text content.
## Ticket

<!--
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20166-->

Closes [20166](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20166)

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
- Load up local server and check  [/minneapolis-health-care/news-releases/](https://main-kqjsor0i3mjdwsy9gojxhhyvdzh0wubb.tugboat.vfs.va.gov/minneapolis-health-care/news-releases/)
- news releases are not on tugboat :( 
- Ensure links are clicking and working as before
- Press release teaser page and vet center outstation

## QA steps
- ensure nothing is breaking

## Screenshots

<img width="1385" alt="image" src="https://github.com/user-attachments/assets/353e82ef-5177-4dea-959d-1d6416721075" />
---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```