### PR TITLE
Update to readme for scopes in next preview.

### DIFF
--- a/READMEs/preview.md
+++ b/READMEs/preview.md
@@ -53,7 +53,7 @@ Without this configuration, preview functionality will fall back to using the cu
 
 ### Drupal scope
 
-When a new role is added to Drupal, we should also create a corresponding [scope](httpe://va.gov/admin/config/people/simple_oauth/oauth2_scope/dynamic) if the holders of this role need to be able to see Next previews. After the scope is created, exported in config, and deployed onto prod, it will need to be added to the [consumer](https://va.gov/admin/config/services/consumer/2/edit) directly on prod since consumers are entities in the DB and not part of config.
+When a new role is added to Drupal, we should also create a corresponding [scope](httpe://va.gov/admin/config/people/simple_oauth/oauth2_scope/dynamic) if the holders of this role need to be able to see Next Build previews. After the scope is created, exported in config, and deployed onto prod, it will need to be added to the [consumer](https://va.gov/admin/config/services/consumer/2/edit) directly on prod since consumers are entities in the DB and not part of config.
 
 ## CMS Tugboat Preview
 

--- a/READMEs/preview.md
+++ b/READMEs/preview.md
@@ -51,6 +51,10 @@ Additionally, the `PreviewEventSubscriber` in the `va_gov_preview` module will n
 
 Without this configuration, preview functionality will fall back to using the current content-build provided preview server.
 
+### Drupal scope
+
+When a new role is added to Drupal, we should also create a corresponding [scope](httpe://va.gov/admin/config/people/simple_oauth/oauth2_scope/dynamic) if the holders of this role need to be able to see Next previews. After the scope is created, exported in config, and deployed onto prod, it will need to be added to the [consumer](https://va.gov/admin/config/services/consumer/2/edit) directly on prod since consumers are entities in the DB and not part of config.
+
 ## CMS Tugboat Preview
 
 Each CMS Tugboat environment installs next-build, runs `yarn build:preview` and then starts a running preview server. This allows Preview functionality to be tested on each CMS PR with all the wiring hooked up for you.


### PR DESCRIPTION
# Description

Quick readme update related to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21229

## Generated description


This pull request updates the `preview.md` documentation to include instructions for managing Drupal roles and scopes for Next.js previews.

Documentation updates:

* [`READMEs/preview.md`](diffhunk://#diff-937f10d9a3a8d824f7bbfd068c9e5e98cb5bcd5f1511b23c92db81ba41862533R54-R57): Added a new section titled "Drupal scope" that explains the process of creating and managing scopes in Drupal for roles requiring access to Next.js previews. This includes creating a scope, exporting it in configuration, deploying it to production, and manually adding it to the consumer on production since consumers are database entities.

## Ticket

relates to [21229](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21229)


---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.