### PR TITLE
Fix press release listing for Lovell 😭

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,14 @@ const nextConfig = {
     // this could be anything, use latest git hash if it exists
     return process.env.GIT_HASH ?? 'vagovprod'
   },
+  webpack(webpackConfig) {
+    return {
+      ...webpackConfig,
+      optimization: {
+        minimize: isProd,
+      },
+    }
+  },
 }
 
 export default nextConfig

--- a/packages/env-loader/src/index.ts
+++ b/packages/env-loader/src/index.ts
@@ -128,8 +128,6 @@ async function cleanup(verbose = false) {
 
   const log = verbose ? console.log : () => {}
 
-  console.log('verbose:', verbose)
-
   log(chalk.blue('\nCleaning up...'))
   try {
     if (fs.existsSync(buildIDFile)) {

--- a/src/data/queries/pressReleaseListing.ts
+++ b/src/data/queries/pressReleaseListing.ts
@@ -15,6 +15,8 @@ import {
   fetchSingleEntityOrPreview,
   getMenu,
 } from '@/lib/drupal/query'
+import { ExpandedStaticPropsContext } from '@/lib/drupal/staticProps'
+import { getLovellVariantOfMenu } from '@/lib/drupal/lovell/utils'
 
 const PAGE_SIZE = PAGE_SIZES[RESOURCE_TYPES.PRESS_RELEASE_LISTING]
 
@@ -38,6 +40,7 @@ type PressReleaseListingData = {
   totalItems: number
   totalPages: number
   current: number
+  lovell?: ExpandedStaticPropsContext['lovell']
 }
 
 // Implement the data loader.
@@ -70,13 +73,12 @@ export const data: QueryData<
       )
 
   // Fetch the menu name dynamically off of the field_office reference
-  let menu = null
-  if (entity.field_office.field_system_menu) {
-    menu = await getMenu(
-      entity.field_office.field_system_menu.resourceIdObjMeta
-        ?.drupal_internal__target_id
-    )
-  }
+  const menu = entity.field_office.field_system_menu
+    ? await getMenu(
+        entity.field_office.field_system_menu.resourceIdObjMeta
+          ?.drupal_internal__target_id
+      )
+    : null
 
   return {
     entity,
@@ -85,13 +87,14 @@ export const data: QueryData<
     totalItems,
     totalPages: totalPages,
     current: opts?.page,
+    lovell: opts.context?.lovell,
   }
 }
 
 export const formatter: QueryFormatter<
   PressReleaseListingData,
   PressReleaseListing
-> = ({ entity, releases, menu, totalItems, totalPages, current }) => {
+> = ({ entity, releases, menu, totalItems, totalPages, current, lovell }) => {
   const formattedReleases = releases.map((release) => {
     return queries.formatData(
       `${RESOURCE_TYPES.PRESS_RELEASE}--teaser`,
@@ -99,7 +102,13 @@ export const formatter: QueryFormatter<
     )
   })
 
-  const formattedMenu = buildSideNavDataFromMenu(entity.path.alias, menu)
+  let formattedMenu =
+    menu !== null ? buildSideNavDataFromMenu(entity.path.alias, menu) : null
+
+  if (lovell?.isLovellVariantPage) {
+    formattedMenu = getLovellVariantOfMenu(formattedMenu, lovell?.variant)
+  }
+
   return {
     ...entityBaseFields(entity),
     introText: entity.field_intro_text,

--- a/src/data/queries/pressReleaseListing.ts
+++ b/src/data/queries/pressReleaseListing.ts
@@ -112,7 +112,7 @@ export const formatter: QueryFormatter<
   return {
     ...entityBaseFields(entity),
     introText: entity.field_intro_text,
-    releases: formattedReleases,
+    'news-releases': formattedReleases,
     menu: formattedMenu,
     currentPage: current,
     totalItems,

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -259,11 +259,24 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       }
     }
     try {
-      const resource = await getStaticPropsResource(
-        resourceType,
-        pathInfo,
-        expandedContext
-      )
+      let resource
+      try {
+        resource = await getStaticPropsResource(
+          resourceType,
+          pathInfo,
+          expandedContext
+        )
+      } catch (e) {
+        const util = await import('util')
+        console.error('\n\nFailed to fetch resource:')
+        console.error(
+          util.inspect(
+            { resourceType, pathInfo, expandedContext },
+            { colors: true, depth: null }
+          )
+        )
+        throw e
+      }
       // If we're not in preview mode and the resource is not published,
       // Return page not found.
       if (!expandedContext.preview && !resource?.published) {

--- a/src/templates/layouts/pressReleaseListing/index.test.tsx
+++ b/src/templates/layouts/pressReleaseListing/index.test.tsx
@@ -24,7 +24,7 @@ describe('PressReleaseListing component renders', () => {
         'Get the latest news from the Birmingham VA Health Care System.\\r\\n',
       type: 'node--press_releases_listing',
       published: true,
-      releases: formattedPressReleases,
+      'news-releases': formattedPressReleases,
       menu: {
         rootPath: 'sample/path/url',
         data: { name: '', description: '', links: [] },
@@ -65,7 +65,9 @@ describe('PressReleaseListing component renders', () => {
   })
 
   test('with no press releases', () => {
-    render(<PressReleaseListing {...pressReleaseListingProps} releases={[]} />)
+    render(
+      <PressReleaseListing {...pressReleaseListingProps} news-releases={[]} />
+    )
     expect(screen.queryByText(/News releases/)).toBeInTheDocument()
     const element = screen.getByText('No stories at this time.')
     expect(element).toBeInTheDocument()

--- a/src/templates/layouts/pressReleaseListing/index.tsx
+++ b/src/templates/layouts/pressReleaseListing/index.tsx
@@ -27,17 +27,20 @@ interface customWindow extends Window {
 }
 declare const window: customWindow
 
-export function PressReleaseListing({
-  id,
-  title,
-  introText,
-  releases,
-  menu,
-  currentPage,
-  totalPages,
-  lovellVariant,
-  lovellSwitchPath,
-}: LovellStaticPropsResource<FormattedPressReleaseListing>) {
+export function PressReleaseListing(
+  props: LovellStaticPropsResource<FormattedPressReleaseListing>
+) {
+  const {
+    id,
+    title,
+    introText,
+    menu,
+    currentPage,
+    totalPages,
+    lovellVariant,
+    lovellSwitchPath,
+  } = props
+  const releases = props['news-releases']
   // Add data to the window object for the sidebar widget
   useEffect(() => {
     window.sideNav = menu

--- a/src/templates/layouts/pressReleaseListing/pressReleaseListing.stories.ts
+++ b/src/templates/layouts/pressReleaseListing/pressReleaseListing.stories.ts
@@ -21,6 +21,6 @@ export const NoPressReleases: Story = {
 export const List: Story = {
   args: {
     ...data,
-    releases: formattedPressReleases,
+    'news-releases': formattedPressReleases,
   },
 }

--- a/src/types/formatted/pressReleaseListing.ts
+++ b/src/types/formatted/pressReleaseListing.ts
@@ -8,7 +8,7 @@ export type PressReleaseListingLink = {
 
 export type PressReleaseListing = PublishedEntity & {
   introText: string
-  releases: PressReleaseTeaser[]
+  'news-releases': PressReleaseTeaser[]
   menu: SideNavMenu
   currentPage: number
   totalItems: number


### PR DESCRIPTION
# Description

Gets the Lovell press release listing page working.

## Screenshots

Non-Lovell
![image](https://github.com/user-attachments/assets/f44b194a-84a3-41a3-886b-234257ddbeee)

Lovell - TRICARE
![image](https://github.com/user-attachments/assets/f136f8be-3d60-44b0-ac00-622e4f61f2d1)

Lovell - VA
![image](https://github.com/user-attachments/assets/4e9a8578-b570-4714-ae62-5ad8b5336443)
As you can see, pagination also works.

## Generated description

This pull request introduces multiple changes to enhance functionality, improve error handling, and update naming conventions for consistency. The most significant updates include adding support for Lovell-specific menu variants, improving error logging in static props fetching, and renaming the `releases` property to `news-releases` across the codebase.

### Enhancements to functionality:
* Added support for Lovell-specific menu variants by introducing the `lovell` property in `PressReleaseListingData` and updating the `formatter` function to handle Lovell menu variants dynamically. [[1]](diffhunk://#diff-32f669bc8c8d7816ed403b5c2823741c5ba666e5990ceaec57185aa02239a7eaR43) [[2]](diffhunk://#diff-32f669bc8c8d7816ed403b5c2823741c5ba666e5990ceaec57185aa02239a7eaR90-R115)
* Updated the `PressReleaseListing` component to use the `news-releases` property instead of `releases`, ensuring compatibility with the new naming convention.

### Improved error handling:
* Enhanced error logging in `getStaticProps` by adding detailed inspection of failed resource fetches, making debugging easier. ([src/pages/[[...slug]].tsxL262-R279](diffhunk://#diff-5f218029560343be88582c198bb3b04e4c18259a5e716a88250afabe4466f957L262-R279))

### Naming convention updates:
* Renamed the `releases` property to `news-releases` across multiple files, including type definitions, components, and test cases, to improve clarity and consistency. [[1]](diffhunk://#diff-c2f0ce559d549ddbc6090bce31889ff516e6a1d58ea1b704ea613ea26aa8dfe2L27-R27) [[2]](diffhunk://#diff-c2f0ce559d549ddbc6090bce31889ff516e6a1d58ea1b704ea613ea26aa8dfe2L68-R70) [[3]](diffhunk://#diff-dad0ca23d163b33d7864472420b28323d36646debf0b80d21bab602eca94de31L24-R24) [[4]](diffhunk://#diff-196fe81af14d2ab7504125ede188e08372bd4b182ef675ed4068c1fea25c43ebL11-R11)

### Miscellaneous improvements:
* Simplified the logic for fetching menus in `pressReleaseListing.ts` by using a ternary operator instead of a conditional block.
* Removed an unnecessary `console.log` statement in the `cleanup` function to reduce noise in verbose mode.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20142
