### PR TITLE
VACMS-19211 - update SITE_URL at build

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -72,6 +72,8 @@ services:
         - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt yarn build:sitemap --SITE_URL ${TUGBOAT_DEFAULT_SERVICE_URL}
         # Set the webroot to the output folder.
         - ln -snf "${TUGBOAT_ROOT}/out" "${DOCROOT}"
+        # Update site URL
+        - sed -i "s|replace-with-tugboat-url|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/envs/.env.tugboat"
 
       # Run any commands after the site is built.
       online:

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -53,14 +53,15 @@ services:
         # Clone vets-website
         - ./scripts/install-repos.sh
 
-        # Update site URL
-        - sed -i "s|replace-with-tugboat-url|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/envs/.env.tugboat"
       # Commands that build the site. This is where you would add
       # steps required to set up or configure the site. When a
       # preview is built from a base preview, the build workflow
       # starts here, skipping the init and update steps, because the
       # results of those are inherited from the base preview.
       build:
+        # Update site URL
+        - sed -i "s|replace-with-tugboat-url|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/envs/.env.tugboat"
+
         - yarn --version
         # Install dependencies. These are included in .yarn/cache, shouldn't add significant time or network requests.
         - yarn install

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -60,7 +60,7 @@ services:
       # results of those are inherited from the base preview.
       build:
         # Update site URL
-        - sed -i "s|replace-with-tugboat-url|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/envs/.env.tugboat"
+        - echo "SITE_URL=${TUGBOAT_DEFAULT_SERVICE_URL}" >> "${TUGBOAT_ROOT}/envs/.env.tugboat"
 
         - yarn --version
         # Install dependencies. These are included in .yarn/cache, shouldn't add significant time or network requests.

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -53,6 +53,8 @@ services:
         # Clone vets-website
         - ./scripts/install-repos.sh
 
+        # Update site URL
+        - sed -i "s|replace-with-tugboat-url|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/envs/.env.tugboat"
       # Commands that build the site. This is where you would add
       # steps required to set up or configure the site. When a
       # preview is built from a base preview, the build workflow
@@ -72,8 +74,6 @@ services:
         - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt yarn build:sitemap --SITE_URL ${TUGBOAT_DEFAULT_SERVICE_URL}
         # Set the webroot to the output folder.
         - ln -snf "${TUGBOAT_ROOT}/out" "${DOCROOT}"
-        # Update site URL
-        - sed -i "s|replace-with-tugboat-url|${TUGBOAT_DEFAULT_SERVICE_URL}|g" "${TUGBOAT_ROOT}/envs/.env.tugboat"
 
       # Run any commands after the site is built.
       online:

--- a/envs/.env.tugboat
+++ b/envs/.env.tugboat
@@ -11,7 +11,8 @@ NEXT_PUBLIC_BUILD_TYPE=tugboat
 NEXT_PUBLIC_ASSETS_URL=/generated/
 
 # Domain for the static output.
-SITE_URL=replace-with-tugboat-url
+# This value will be appended to the file during tugboat build
+# SITE_URL=
 
 # Domain for the static output; likely unused.
 NEXT_PUBLIC_SITE_URL=https://www.va.gov

--- a/envs/.env.tugboat
+++ b/envs/.env.tugboat
@@ -11,7 +11,7 @@ NEXT_PUBLIC_BUILD_TYPE=tugboat
 NEXT_PUBLIC_ASSETS_URL=/generated/
 
 # Domain for the static output.
-SITE_URL=${TUGBOAT_DEFAULT_SERVICE_URL}
+SITE_URL=replace-with-tugboat-url
 
 # Domain for the static output; likely unused.
 NEXT_PUBLIC_SITE_URL=https://www.va.gov


### PR DESCRIPTION
# Description

This PR removes the tugboat variable from the SITE_URL in the tugboat env file. The value is now replaced during the tugboat build step before the `yarn export` happens. This makes sure that the var and files all exist but nothing has been built yet.

## Generated description

This pull request updates the configuration for Tugboat previews to properly handle the site URL. The changes ensure that the `SITE_URL` placeholder is replaced dynamically during the build process.

### Configuration updates for Tugboat:

* [`.tugboat/config.yml`](diffhunk://#diff-fbd0812762ff8d2c67fa66a4956c3b55557ad0889505294f524192000b2ce50eR62-R64): Added a `sed` command in the build step to replace the placeholder `replace-with-tugboat-url` with the actual `${TUGBOAT_DEFAULT_SERVICE_URL}` in the `.env.tugboat` file.
* [`envs/.env.tugboat`](diffhunk://#diff-831aaee303b0dc99e20f0f512c2c921d217fd2441d33ee0913caf2d5a88030b7L14-R14): Changed the `SITE_URL` value from `${TUGBOAT_DEFAULT_SERVICE_URL}` to a placeholder `replace-with-tugboat-url`, which will now be updated dynamically during the build process.

## Ticket

Closes [19211](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/19211)

## Developer Task

- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)

## Screenshot
![Screenshot 2025-05-01 at 9 08 11 AM](https://github.com/user-attachments/assets/9a66e4f6-3609-4848-abbb-0fa71dd94abb)

## Testing Steps
 - [ ] Visit https://pr1004-tsv44t4mih35iw5k1daympryw3gyf8aq.tugboat.vfs.va.gov/boston-health-care/stories/va-bostons-virtual-health-resource-center-offers-veterans-help-navigating-new-va-login/
 - [ ] hover over the `Share on Facebook` & `Share on X (formerly Twitter)` links, verify that they reference this page with the full tugboat URL.
 - [ ] go to the [tugboat dashboard](https://tugboat.vfs.va.gov/6812b4fe09d190440b9c034b) for this build
 - [ ] click Terminal on the web service
 - [ ] view the tugboat env file (`vi envs/.env.tugboat`)
 - [ ] verify that the `SITE_URL` value matches that path to this tugboat preview URL (https://pr1004-tsv44t4mih35iw5k1daympryw3gyf8aq.tugboat.vfs.va.gov/)


---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
