### PR TITLE
Fix author by line logic

### DIFF
--- a/src/lib/drupal/lovell/tests/mockData.ts
+++ b/src/lib/drupal/lovell/tests/mockData.ts
@@ -70,7 +70,8 @@ export const newsStoryPartialResource = {
   },
   caption: 'caption',
   author: {
-    title: 'Author Name',
+    field_name_first: 'Author',
+    field_last_name: 'Name',
   },
   introText: 'intro-text',
   bodyContent: 'story-body',

--- a/src/templates/components/staffNewsProfile/index.test.tsx
+++ b/src/templates/components/staffNewsProfile/index.test.tsx
@@ -2,10 +2,11 @@ import { render, screen } from 'test-utils'
 import { StaffNewsProfile } from '@/templates/components/staffNewsProfile/index'
 
 describe('StaffNewsProfile', () => {
-  test('renders byline with title and description', () => {
+  test('renders byline with full name and description', () => {
     const props = {
-      title: 'John Smith',
-      description: 'Staff Writer',
+      field_name_first: 'John',
+      field_last_name: 'Smith',
+      field_description: 'Staff Writer',
     }
     render(<StaffNewsProfile {...props} />)
     expect(screen.getByText('By John Smith, Staff Writer')).toBeInTheDocument()
@@ -14,10 +15,16 @@ describe('StaffNewsProfile', () => {
 
   test('renders byline with title only when description is missing', () => {
     const props = {
-      title: 'John Smith',
+      field_name_first: 'John',
+      field_last_name: 'Smith',
     }
     render(<StaffNewsProfile {...props} />)
     expect(screen.getByText('By John Smith')).toBeInTheDocument()
     expect(screen.getByText('By John Smith').tagName).toBe('P')
+  })
+
+  test('returns null when no name is provided', () => {
+    const { container } = render(<StaffNewsProfile />)
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/src/templates/components/staffNewsProfile/index.tsx
+++ b/src/templates/components/staffNewsProfile/index.tsx
@@ -1,16 +1,21 @@
 export type PersonProfileTeaserProps = {
-  title: string
-  description?: string
+  field_name_first?: string
+  field_last_name?: string
+  field_description?: string
 }
 
 export const StaffNewsProfile = ({
-  title,
-  description,
-}: PersonProfileTeaserProps): JSX.Element => {
+  field_name_first,
+  field_last_name,
+  field_description,
+}: PersonProfileTeaserProps): JSX.Element | null => {
+  const name = `${field_name_first || ''} ${field_last_name || ''}`.trim()
+  if (!name) return null
+
   return (
     <p className="vads-u-margin-bottom--0p5 vads-u-font-weight--bold">
-      By {title}
-      {description ? `, ${description}` : null}
+      By {name}
+      {field_description ? `, ${field_description}` : ''}
     </p>
   )
 }

--- a/src/templates/layouts/newsStory/index.test.tsx
+++ b/src/templates/layouts/newsStory/index.test.tsx
@@ -36,7 +36,8 @@ const data = {
   caption:
     '"Caring for a single patient and solving that one patient\'s illness is our honor and privilege as health care providers." - Dr. Brooke Decker',
   author: {
-    title: 'Keith Gottschalk',
+    field_name_first: 'Keith',
+    field_last_name: 'Gottschalk',
   },
   introText:
     'When a hospital has a host of great doctors, honoring just two every year is challenging.',

--- a/src/templates/layouts/newsStory/index.tsx
+++ b/src/templates/layouts/newsStory/index.tsx
@@ -51,7 +51,13 @@ export const NewsStory = ({
                   {caption}
                 </div>
               )}
-              {author && <StaffNewsProfile {...author} />}
+              {author && (
+                <StaffNewsProfile
+                  field_name_first={author.field_name_first}
+                  field_last_name={author.field_last_name}
+                  field_description={author.field_description}
+                />
+              )}
               <p className="vads-u-margin-bottom--2p5">
                 <time dateTime={formatDate(date)}>{formatDate(date)}</time>
               </p>

--- a/src/templates/layouts/newsStory/newsStory.stories.ts
+++ b/src/templates/layouts/newsStory/newsStory.stories.ts
@@ -36,7 +36,8 @@ export const Full: Story = {
     caption:
       '"Caring for a single patient and solving that one patient\'s illness is our honor and privilege as health care providers." - Dr. Brooke Decker',
     author: {
-      title: 'Keith Gottschalk',
+      field_name_first: 'Keith',
+      field_last_name: 'Gottschalk',
     },
     introText:
       'When a hospital has a host of great doctors, honoring just two every year is challenging.',


### PR DESCRIPTION
# Description

This PR fixes the author byline, adding a guard to ensure By appears only when certain fields for author exists, and to display full name and title if present, and adds tests.

## Generated description

This pull request refactors the handling of author data across components and tests, transitioning from a single `title` field to separate `field_name_first` and `field_last_name` fields, with an optional `field_description`. It also introduces a null return for cases where no name is provided. The changes ensure consistency and improve flexibility in managing author-related information.

### Refactoring of author data:

* [`src/lib/drupal/lovell/tests/mockData.ts`](diffhunk://#diff-4b318176fc5bab9cab860ecad27a0a1524485b20fa5211f9cef76cb293e2ddd1L73-R74): Updated mock data to replace the `title` field with `field_name_first` and `field_last_name` for author information.
* `src/templates/layouts/newsStory/index.test.tsx` and `src/templates/layouts/newsStory/newsStory.stories.ts`: Replaced `title` with `field_name_first` and `field_last_name` in test data for the `author` object. [[1]](diffhunk://#diff-1620ae9453fcfad5678994d536122e0117c86461afe86d5f0d158ec513888761L39-R40) [[2]](diffhunk://#diff-1db494c84bcca840c71010f0bd70f25484e15693d3f53d5929e6df6cb097d47dL39-R40)

### Updates to `StaffNewsProfile` component:

* [`src/templates/components/staffNewsProfile/index.tsx`](diffhunk://#diff-c0c8ae2403b2741cbebfb8974c3c857ed8abef3b36964259c0404dd1c55cc363L2-R18): Modified `StaffNewsProfile` to accept `field_name_first`, `field_last_name`, and `field_description` instead of `title` and `description`. Added logic to return `null` if no name is provided.
* [`src/templates/layouts/newsStory/index.tsx`](diffhunk://#diff-16d8e739d5a51a8ab3dfdbdea3d9a7f9eda7c2386699aa52720b85d487f32ebfL54-R60): Updated the usage of `StaffNewsProfile` to pass the new fields (`field_name_first`, `field_last_name`, and `field_description`) explicitly.

### Test updates:

* [`src/templates/components/staffNewsProfile/index.test.tsx`](diffhunk://#diff-a1c03e676d54ce26057ebfb8bf562ad53cd15aaeb4aac1ecb1e78e82d08834afL5-R9): Refactored tests to align with the new `StaffNewsProfile` props. Added a new test case to verify that the component returns `null` when no name is provided. [[1]](diffhunk://#diff-a1c03e676d54ce26057ebfb8bf562ad53cd15aaeb4aac1ecb1e78e82d08834afL5-R9) [[2]](diffhunk://#diff-a1c03e676d54ce26057ebfb8bf562ad53cd15aaeb4aac1ecb1e78e82d08834afL17-R29)
## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes _link to [20185](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20185)

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

- [x] Load up local server/tugboat
- [x] https://pr1009-oxfr6rx5zmmaxofbpbpunoxwtjhvkwox.tugboat.vfs.va.gov/washington-dc-health-care/stories/vision-impairment-service-outpatient-rehabilitation-an-intensive-program/
- [x] Ensure the job title exists
- [x] Go to https://pr1009-oxfr6rx5zmmaxofbpbpunoxwtjhvkwox.tugboat.vfs.va.gov/salisbury-health-care/stories/charlotte-area-veteran-grateful-for-vas-whole-health-offerings/
- [x] ensure By is not there

## QA steps

What needs to be checked to prove this works?
What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

## Screenshots

Before:
<img width="1078" alt="image" src="https://github.com/user-attachments/assets/9403bb92-3f62-4146-99fc-b1916b750fe4" />

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/68d4b234-22ab-4b85-b2ed-a499161b930d" />


After:
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/c790d3ee-5b0c-4c21-bd80-3836979c14e1" />

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/30b0a60a-0c9b-4b3a-a3ea-4bb448573787" />
## Is this PR blocked by another PR?

- Add the `DO NOT MERGE` label
- Add links to additional PRs here:

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.