### PR TITLE
Fix the top task URLs

### DIFF
--- a/src/templates/layouts/healthCareLocalFacility/index.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.tsx
@@ -81,6 +81,11 @@ export function HealthCareLocalFacility({
     },
   }
 
+  // Used to get a base url path of a health care region from `path`
+  // NOTE: Maybe could use entity.field_region_page.path.alias instead?
+  // `content-build` does it this way, though.
+  const regionBasePath = path.split('/')[1]
+
   return (
     <div className="interior" id="content">
       <div className="usa-grid usa-grid-full">
@@ -99,7 +104,7 @@ export function HealthCareLocalFacility({
             )}
 
             <TopTasks
-              path={path}
+              path={regionBasePath}
               administration={administration}
               vamcEhrSystem={vamcEhrSystem}
             />


### PR DESCRIPTION
# Description

Fixes the URLs for the top tasks section using `path.split('/')[1]`. It's...not my favorite, but it's what `content-build` does, so it should be consistent? I'd rather use `entity.field_region_page.path.alias`, but I don't know if that'll be true for every facility.

## Screenshots

![image](https://github.com/user-attachments/assets/52c53d3e-c5d5-429e-a382-2021571304bd)

## Generated description

This pull request introduces a minor update to the `HealthCareLocalFacility` component in `src/templates/layouts/healthCareLocalFacility/index.tsx`. The changes include extracting a region base path from the `path` variable and using it in the `TopTasks` component.

### Changes to `HealthCareLocalFacility` component:

* Added logic to extract the base URL path of a health care region from the `path` variable using `path.split('/')[1]`. A note was included suggesting a potential alternative approach using `entity.field_region_page.path.alias`.
* Updated the `TopTasks` component to use the newly extracted `regionBasePath` instead of the full `path` variable.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21168