### PR TITLE
Remove FE CoP from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,16 @@
 # These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-#  CMS Team or FE COP will be requested for
-# review when someone opens a pull request.
+# the repo.
 #
 # Review the CODEOWNERS guide before editing:
 # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/codeowners.md
 
-# General ownership: Next Build Team (ap-team) & Platform FE COP
-*       @department-of-veterans-affairs/ap-team @department-of-veterans-affairs/va-platform-cop-frontend
+# General ownership: Next Build Team (ap-team)
+*       @department-of-veterans-affairs/ap-team
 
 # Front-end template work should be verified by product owners.
-src/templates @department-of-veterans-affairs/next-build-product @department-of-veterans-affairs/ap-team @department-of-veterans-affairs/va-platform-cop-frontend
-src/products/*/template.tsx @department-of-veterans-affairs/next-build-product @department-of-veterans-affairs/ap-team @department-of-veterans-affairs/va-platform-cop-frontend
+src/templates @department-of-veterans-affairs/next-build-product @department-of-veterans-affairs/ap-team
+src/products/*/template.tsx @department-of-veterans-affairs/next-build-product @department-of-veterans-affairs/ap-team
 
-# Product code ownership
-src/products/event/ @department-of-veterans-affairs/ap-team @department-of-veterans-affairs/va-platform-cop-frontend
-src/products/eventListing/ @department-of-veterans-affairs/ap-team @department-of-veterans-affairs/va-platform-cop-frontend
+# Code ownership of individual products
+src/products/event/ @department-of-veterans-affairs/ap-team
+src/products/eventListing/ @department-of-veterans-affairs/ap-team


### PR DESCRIPTION
# Description

Removes the FE CoP from the `CODEOWNERS` file.

## Generated description

This pull request updates the `.github/CODEOWNERS` file to streamline ownership assignments by removing the Front-End Community of Practice (FE COP) from several areas and clarifying team responsibilities.

### Changes to ownership assignments:

* Removed `@department-of-veterans-affairs/va-platform-cop-frontend` as a code owner for general ownership, front-end templates, and specific product directories, leaving `@department-of-veterans-affairs/ap-team` as the sole owner in these areas.

These changes simplify the ownership structure and reduce overlap in code review responsibilities.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21236