### PR TITLE
VACMS-20864: Lovell switcher healthCareLocalFacility

### DIFF
--- a/src/data/queries/healthCareLocalFacility.ts
+++ b/src/data/queries/healthCareLocalFacility.ts
@@ -11,7 +11,11 @@ import {
 } from '@/lib/drupal/query'
 import { Menu } from '@/types/drupal/menu'
 import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
-import { getLovellVariantOfMenu } from '@/lib/drupal/lovell/utils'
+import {
+  getLovellVariantOfMenu,
+  getLovellVariantOfUrl,
+  getOppositeChildVariant,
+} from '@/lib/drupal/lovell/utils'
 import { formatter as formatImage } from '@/data/queries/mediaImage'
 import { ParagraphLinkTeaser } from '@/types/drupal/paragraph'
 import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
@@ -134,5 +138,13 @@ export const formatter: QueryFormatter<
       fieldInstagram: entity.field_region_page.field_instagram ?? null,
       fieldYoutube: entity.field_region_page.field_youtube ?? null,
     },
+    lovellVariant: lovell?.variant,
+    lovellSwitchPath:
+      entity.field_main_location && lovell?.variant
+        ? getLovellVariantOfUrl(
+            entity.path.alias,
+            getOppositeChildVariant(lovell?.variant)
+          )
+        : null,
   }
 }

--- a/src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap
@@ -283,6 +283,8 @@ exports[`HealthCareLocalFacility query should handle the Lovell variant page men
 <p dir="ltr"><a href="http://www.va.gov/health-care/file-travel-pay-reimbursement/">Find out if you qualify for beneficiary travel benefits</a>.</p>",
     },
   ],
+  "lovellSwitchPath": null,
+  "lovellVariant": "tricare",
   "menu": {
     "data": {
       "description": "bar",
@@ -817,6 +819,8 @@ exports[`HealthCareLocalFacility query should output formatted data 1`] = `
 <p dir="ltr"><a href="http://www.va.gov/health-care/file-travel-pay-reimbursement/">Find out if you qualify for beneficiary travel benefits</a>.</p>",
     },
   ],
+  "lovellSwitchPath": null,
+  "lovellVariant": undefined,
   "menu": {
     "data": {
       "description": "bar",

--- a/src/data/queries/tests/healthCareLocalFacility.test.tsx
+++ b/src/data/queries/tests/healthCareLocalFacility.test.tsx
@@ -156,5 +156,53 @@ describe('formatter', () => {
         }).relatedLinks.sectionTitle
       ).toEqual('In the spotlight at VA Boston health care')
     })
+    it('should set the lovellSwitchPath if this is the main Lovell facility', () => {
+      expect(
+        formatter({
+          ...formatterParams,
+          // @ts-expect-error Same as above; next-drupal has the wrong static
+          // type here
+          entity: {
+            ...mockFacilityData,
+            field_main_location: true,
+            path: {
+              alias:
+                '/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center',
+              pid: 1999,
+              langcode: 'en',
+            },
+          },
+          lovell: {
+            isLovellVariantPage: true,
+            variant: 'va',
+          },
+        }).lovellSwitchPath
+      ).toEqual(
+        '/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center'
+      )
+    })
+    it('should not set the lovellSwitchPath if this is the not the main Lovell facility', () => {
+      expect(
+        formatter({
+          ...formatterParams,
+          // @ts-expect-error Same as above; next-drupal has the wrong static
+          // type here
+          entity: {
+            ...mockFacilityData,
+            field_main_location: false,
+            path: {
+              alias:
+                '/lovell-federal-health-care-va/locations/evanston-va-clinic',
+              pid: 1999,
+              langcode: 'en',
+            },
+          },
+          lovell: {
+            isLovellVariantPage: true,
+            variant: 'va',
+          },
+        }).lovellSwitchPath
+      ).toBeNull()
+    })
   })
 })

--- a/src/templates/layouts/healthCareLocalFacility/index.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.tsx
@@ -17,6 +17,7 @@ import { ImageAndStaticMap } from '@/templates/components/imageAndStaticMap'
 import { RelatedLinks } from '@/templates/common/relatedLinks'
 import { ContentFooter } from '@/templates/common/contentFooter'
 import FacilitySocialLinks from './FacilitySocialLinks'
+import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
 
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
@@ -44,6 +45,8 @@ export function HealthCareLocalFacility({
   relatedLinks,
   locationServices,
   socialLinks,
+  lovellVariant,
+  lovellSwitchPath,
 }: FormattedHealthCareLocalFacility) {
   // Populate the side nav data for the side nav widget to fill in
   // Note: The side nav widget is in a separate app in the static-pages bundle
@@ -97,7 +100,10 @@ export function HealthCareLocalFacility({
         <nav aria-label="secondary" data-widget-type="side-nav" />
         <div className="usa-width-three-fourths">
           <article className="usa-content va-l-facility-detail">
-            <div>TODO: Lovell switch link</div>
+            <LovellSwitcher
+              currentVariant={lovellVariant}
+              switchPath={lovellSwitchPath}
+            />
 
             {title && <h1>{title}</h1>}
 

--- a/src/types/formatted/healthCareLocalFacility.ts
+++ b/src/types/formatted/healthCareLocalFacility.ts
@@ -11,6 +11,7 @@ import { FormattedRelatedLinks } from './relatedLinks'
 import { SideNavMenu } from './sideNav'
 import { MediaImage } from '@/types/formatted/media'
 import { FacilitySocialLinksProps } from '@/templates/layouts/healthCareLocalFacility/FacilitySocialLinks'
+import { LovellChildVariant } from '@/lib/drupal/lovell/types'
 
 export type HealthCareLocalFacility = PublishedEntity & {
   introText: string | null
@@ -36,4 +37,6 @@ export type HealthCareLocalFacility = PublishedEntity & {
     wysiwigContents: string
   }>
   socialLinks: FacilitySocialLinksProps
+  lovellVariant?: LovellChildVariant
+  lovellSwitchPath?: string
 }


### PR DESCRIPTION
# Description

Adds the LovellSwitcher component to HealthCareLocalFacility. This switch should only display for one local facility `captain-james-a-lovell-federal-health-care-center` all other local Lovell facilities are either specifically `tricare` for `va` and do not have a variant. 

The LovellSwitcher component already does not render if a switchPath is missing. To insure the switchPath is only set for `captain-james-a-lovell-federal-health-care-center`, the formatter has been updated to look at the `field_main_location` field from Drupal to determine if it is processing the main facility. All other Lovell attributes are still present for non-main facilities.

Closes [20864](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20864)

## Generated description

This pull request introduces functionality to handle Lovell facility variants in the `HealthCareLocalFacility` query and its associated components. The changes include updates to the query formatter, type definitions, and UI components to support switching between Lovell variants (`VA` and `TRICARE`) and displaying the appropriate switch link.

### Query Enhancements:
* Updated the `formatter` in `src/data/queries/healthCareLocalFacility.ts` to include `lovellVariant` and `lovellSwitchPath` properties. These determine the current Lovell variant and the URL for switching to the opposite variant if applicable.

### Unit Tests:
* Added test cases to `src/data/queries/tests/healthCareLocalFacility.test.tsx` to verify the correct behavior of `lovellSwitchPath` for both main and non-main Lovell facilities.
* Updated snapshot tests to include `lovellVariant` and `lovellSwitchPath` in the output. [[1]](diffhunk://#diff-209da7eaba46ff4f3c51597305f96e3c943c67839359c0e0533a1e1b099d5376R286-R287) [[2]](diffhunk://#diff-209da7eaba46ff4f3c51597305f96e3c943c67839359c0e0533a1e1b099d5376R822-R823)

### UI Updates:
* Integrated a new `LovellSwitcher` component into the `HealthCareLocalFacility` layout to display the switch link. This component receives `lovellVariant` and `lovellSwitchPath` as props. [[1]](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefR20) [[2]](diffhunk://#diff-dfb29969d1983625591fe3e87de074afa2660839bba7565b48c78b1d25b3aeefL100-R106)
* Extended the `HealthCareLocalFacility` layout to accept `lovellVariant` and `lovellSwitchPath` properties.

### Type Definitions:
* Added `lovellVariant` and `lovellSwitchPath` to the `HealthCareLocalFacility` type in `src/types/formatted/healthCareLocalFacility.ts` to ensure type safety for the new properties. [[1]](diffhunk://#diff-f1c2e1972ee32d794f599ac7233134a307e92da47943ff8019fbe3442c585589R14) [[2]](diffhunk://#diff-f1c2e1972ee32d794f599ac7233134a307e92da47943ff8019fbe3442c585589R40-R41)

### Utility Imports:
* Extended imports in `src/data/queries/healthCareLocalFacility.ts` to include new Lovell-related utility functions for determining variants and paths.

## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes _link to ticket_

## Developer Task

- [x] PR submitted against the `main` branch of `next-build`.
- [x] Link to the issue that this PR addresses (if applicable).
- [x] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [x] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [x] Provided before and after screenshots of your changes (if applicable).
- [x] Alerted the #next-build Slack channel to request a PR review.
- [x] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)

## Testing Steps
 - [ ] visit https://pr1020-umjgkaptlscvr6de3aup2jw8vr8yqlhh.tugboat.vfs.va.gov/lovell-federal-health-care-tricare/locations/captain-james-a-lovell-federal-health-care-center/
 - [ ] verify that the Lovell Switcher is present
 - [ ] click in the sidenav to go to Naval Great Lakes Burkey Mall Pharmacy
 - [ ] verify the Lovell Switcher is not shown but other Lovell links are correct*
 - [ ] click in the sidenav to go to USS Osborne Dental Clinic
 - [ ] verify the Lovell Switcher is not shown but other Lovell links are correct*
 - [ ] click in the sidenav to go to USS Red Rover
 - [ ] verify the Lovell Switcher is not shown but other Lovell links are correct*
 - [ ] click in the sidenav to go to USS Tranquillity
 - [ ] verify the Lovell Switcher is not shown but other Lovell links are correct*
 - [ ] click in the sidenav to go to Zachary and Elizabeth Fisher Medical and Dental Clinic
 - [ ] verify the Lovell Switcher is not shown but other Lovell links are correct*
 - [ ] visit https://pr1020-umjgkaptlscvr6de3aup2jw8vr8yqlhh.tugboat.vfs.va.gov/lovell-federal-health-care-va/locations/captain-james-a-lovell-federal-health-care-center/
 - [ ] verify that the Lovell Switcher is present
 - [ ] click in the sidenav to go to Evanston VA Clinic
 - [ ] verify the Lovell Switcher is not shown but other Lovell links are correct*
 - [ ] click in the sidenav to go to Kenosha VA Clinic
 - [ ] verify the Lovell Switcher is not shown but other Lovell links are correct*
 - [ ] click in the sidenav to go to McHenry VA Clinic
 - [ ] verify the Lovell Switcher is not shown but other Lovell links are correct*
 - [ ] verify that non-Lovell facilities main or otherwise do not show the Lovell Switcher
 
* Unrelated to this work, one breadcrumb is incorrect, and About us, Programs, & Work with us in the sidebar are incorrect

## Screenshots

<img width="1024" alt="Screenshot 2025-05-08 at 4 59 14 PM" src="https://github.com/user-attachments/assets/2433293a-f851-46f7-b97d-e9a61ee35e0a" />
<img width="1048" alt="Screenshot 2025-05-08 at 4 58 54 PM" src="https://github.com/user-attachments/assets/963a12b8-fa57-4fc9-b9c2-1648e074d904" />

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
