### PR TITLE
Add manage-your-health links section to VAMC System page

### DIFF
--- a/src/templates/layouts/vamcSystem/ManageYourHealthLinks.test.tsx
+++ b/src/templates/layouts/vamcSystem/ManageYourHealthLinks.test.tsx
@@ -1,0 +1,168 @@
+import { render } from '@testing-library/react'
+import { ManageYourHealthLinks } from './ManageYourHealthLinks'
+
+// Mock the environment variable
+const originalEnv = process.env
+
+/**
+ * Helper function to query for va-link elements by their text content. Takes a container
+ * and returns a function that can be used to query for a link by text content.
+ */
+const getVaLinkByTextFn = (container: HTMLElement) => (text: string) => {
+  return container.querySelector(`va-link[text="${text}"]`)
+}
+
+describe('ManageYourHealthLinks', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('renders all health links with correct text', () => {
+    const { container } = render(
+      <ManageYourHealthLinks vamcEhrSystem="vista" />
+    )
+
+    const linkTexts = [
+      'Refill and track your prescriptions',
+      'Send a secure message to your health care team',
+      'Schedule and manage health appointments',
+      'Download VA Health Chat',
+      'Download your VA medical records (Blue Button)',
+      'View your lab and test results',
+      'Order hearing aid batteries and accessories',
+      'Connect to VA care',
+    ]
+
+    const getVaLinkByText = getVaLinkByTextFn(container)
+    linkTexts.forEach((text) => {
+      expect(getVaLinkByText(text)).toBeInTheDocument()
+    })
+  })
+
+  it('renders all icons', () => {
+    render(<ManageYourHealthLinks vamcEhrSystem="vista" />)
+
+    const icons = document.querySelectorAll('va-icon')
+    expect(icons).toHaveLength(9)
+  })
+
+  it('generates correct URLs for Vista system', () => {
+    const { container } = render(
+      <ManageYourHealthLinks vamcEhrSystem="vista" />
+    )
+
+    const getVaLinkByText = getVaLinkByTextFn(container)
+    const refillLink = getVaLinkByText('Refill and track your prescriptions')
+    const messagingLink = getVaLinkByText(
+      'Send a secure message to your health care team'
+    )
+    const appointmentsLink = getVaLinkByText(
+      'Schedule and manage health appointments'
+    )
+
+    expect(refillLink).toHaveAttribute(
+      'href',
+      '/health-care/refill-track-prescriptions/'
+    )
+    expect(messagingLink).toHaveAttribute(
+      'href',
+      '/health-care/secure-messaging/'
+    )
+    expect(appointmentsLink).toHaveAttribute(
+      'href',
+      '/health-care/schedule-view-va-appointments/'
+    )
+  })
+
+  it('generates correct URLs for Cerner system in production', () => {
+    process.env.APP_ENV = 'prod'
+    const { container } = render(
+      <ManageYourHealthLinks vamcEhrSystem="cerner" />
+    )
+
+    const getVaLinkByText = getVaLinkByTextFn(container)
+    const refillLink = getVaLinkByText('Refill and track your prescriptions')
+    const messagingLink = getVaLinkByText(
+      'Send a secure message to your health care team'
+    )
+    const appointmentsLink = getVaLinkByText(
+      'Schedule and manage health appointments'
+    )
+
+    expect(refillLink).toHaveAttribute(
+      'href',
+      'https://patientportal.myhealth.va.gov/pages/medications/current'
+    )
+    expect(messagingLink).toHaveAttribute(
+      'href',
+      'https://patientportal.myhealth.va.gov/pages/messaging/inbox'
+    )
+    expect(appointmentsLink).toHaveAttribute(
+      'href',
+      'https://patientportal.myhealth.va.gov/pages/scheduling/upcoming'
+    )
+  })
+
+  it('generates correct URLs for Cerner staged system in non-production', () => {
+    process.env.APP_ENV = 'dev'
+    const { container } = render(
+      <ManageYourHealthLinks vamcEhrSystem="cerner_staged" />
+    )
+
+    const getVaLinkByText = getVaLinkByTextFn(container)
+    const refillLink = getVaLinkByText('Refill and track your prescriptions')
+    const messagingLink = getVaLinkByText(
+      'Send a secure message to your health care team'
+    )
+    const appointmentsLink = getVaLinkByText(
+      'Schedule and manage health appointments'
+    )
+
+    expect(refillLink).toHaveAttribute(
+      'href',
+      'https://patientportal.myhealth.va.gov/pages/medications/current'
+    )
+    expect(messagingLink).toHaveAttribute(
+      'href',
+      'https://patientportal.myhealth.va.gov/pages/messaging/inbox'
+    )
+    expect(appointmentsLink).toHaveAttribute(
+      'href',
+      'https://patientportal.myhealth.va.gov/pages/scheduling/upcoming'
+    )
+  })
+
+  it('generates default URLs for Cerner staged in production', () => {
+    process.env.APP_ENV = 'prod'
+    const { container } = render(
+      <ManageYourHealthLinks vamcEhrSystem="cerner_staged" />
+    )
+
+    const getVaLinkByText = getVaLinkByTextFn(container)
+    const refillLink = getVaLinkByText('Refill and track your prescriptions')
+    const messagingLink = getVaLinkByText(
+      'Send a secure message to your health care team'
+    )
+    const appointmentsLink = getVaLinkByText(
+      'Schedule and manage health appointments'
+    )
+
+    expect(refillLink).toHaveAttribute(
+      'href',
+      '/health-care/refill-track-prescriptions/'
+    )
+    expect(messagingLink).toHaveAttribute(
+      'href',
+      '/health-care/secure-messaging/'
+    )
+    expect(appointmentsLink).toHaveAttribute(
+      'href',
+      '/health-care/schedule-view-va-appointments/'
+    )
+  })
+})

--- a/src/templates/layouts/vamcSystem/ManageYourHealthLinks.tsx
+++ b/src/templates/layouts/vamcSystem/ManageYourHealthLinks.tsx
@@ -1,0 +1,152 @@
+import { VamcEhrSystem } from '@/types/drupal/vamcEhr'
+
+interface ManageYourHealthLinksProps {
+  vamcEhrSystem: VamcEhrSystem
+}
+
+export function isProd() {
+  return process.env.APP_ENV === 'prod'
+}
+
+export function ManageYourHealthLinks({
+  vamcEhrSystem,
+}: ManageYourHealthLinksProps) {
+  function getTopTaskUrl(path) {
+    // If cerner, or if cerner-staged in a non-prod environment
+    if (
+      vamcEhrSystem === 'cerner' ||
+      (vamcEhrSystem === 'cerner_staged' && !isProd())
+    ) {
+      if (path === 'refill-track-prescriptions/') {
+        return 'https://patientportal.myhealth.va.gov/pages/medications/current'
+      }
+
+      if (path === 'secure-messaging/') {
+        return 'https://patientportal.myhealth.va.gov/pages/messaging/inbox'
+      }
+
+      if (path === 'schedule-view-va-appointments/') {
+        return 'https://patientportal.myhealth.va.gov/pages/scheduling/upcoming'
+      }
+
+      if (path === 'get-medical-records/') {
+        return 'https://patientportal.myhealth.va.gov/pages/health_record/clinical_documents/open_notes?pagelet=https%3A%2F%2Fportal.myhealth.va.gov%2Fperson%2F1056308125V679416%2Fhealth-record%2Fopen-notes'
+      }
+
+      if (path === 'view-test-and-lab-results/') {
+        return 'https://patientportal.myhealth.va.gov/pages/health_record/results'
+      }
+    }
+
+    // Vista equivalent
+    return `/health-care/${path}`
+  }
+
+  return (
+    <div className="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
+      <div className="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
+        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="pill"
+          />
+          <va-link
+            href={getTopTaskUrl('refill-track-prescriptions/')}
+            text="Refill and track your prescriptions"
+          />
+        </div>
+        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="forum"
+          />
+          <va-link
+            href={getTopTaskUrl('secure-messaging/')}
+            text="Send a secure message to your health care team"
+          />
+        </div>
+        <div className="vads-facility-hub-cta vads-u-border-color--primary-alt-light medium-screen:vads-u-border-bottom--1px vads-u-display--flex vads-u-align-items--center">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="event_available"
+          />
+          <va-link
+            href={getTopTaskUrl('schedule-view-va-appointments/')}
+            text="Schedule and manage health appointments"
+          />
+        </div>
+        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center health-online-desktop-link">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="chat"
+          />
+          <va-link
+            href="https://mobile.va.gov/app/va-health-chat"
+            text="Download VA Health Chat"
+          />
+        </div>
+      </div>
+      <div>
+        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="note_add"
+          />
+          <va-link
+            href={getTopTaskUrl('get-medical-records/')}
+            text="Download your VA medical records (Blue Button)"
+          />
+        </div>
+        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="assignment"
+          />
+          <va-link
+            href={getTopTaskUrl('view-test-and-lab-results/')}
+            text="View your lab and test results"
+          />
+        </div>
+        <div className="vads-facility-hub-cta vads-facility-hub-cta-last-line vads-u-border-top--1px vads-u-border-color--primary-alt-light vads-u-display--flex vads-u-align-items--center">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="hearing_disabled"
+          />
+          <va-link
+            href="/health-care/order-hearing-aid-batteries-and-accessories/"
+            text="Order hearing aid batteries and accessories"
+          />
+        </div>
+        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center health-online-mobile-link">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="chat"
+          />
+          <va-link
+            href="https://mobile.va.gov/app/va-health-chat"
+            text="Download VA Health Chat"
+          />
+        </div>
+        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
+          <va-icon
+            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+            size="3"
+            icon="phone"
+          />
+          <va-link
+            href="https://www.va.gov/health/connect-to-va-care/index.asp"
+            text="Connect to VA care"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/templates/layouts/vamcSystem/ManageYourHealthLinks.tsx
+++ b/src/templates/layouts/vamcSystem/ManageYourHealthLinks.tsx
@@ -1,4 +1,5 @@
 import { VamcEhrSystem } from '@/types/drupal/vamcEhr'
+import clsx from 'clsx'
 
 interface ManageYourHealthLinksProps {
   vamcEhrSystem: VamcEhrSystem
@@ -42,110 +43,97 @@ export function ManageYourHealthLinks({
     return `/health-care/${path}`
   }
 
+  const renderIcon = (icon: string) => (
+    <va-icon
+      class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
+      size="3"
+      icon={icon}
+    />
+  )
+
+  const baseItemClasses =
+    'vads-facility-hub-cta vads-u-margin--0 vads-u-align-items--center vads-u-border-top--1px vads-u-border-color--primary-alt-light'
+  const normalItemClasses = clsx(baseItemClasses, 'vads-u-display--flex')
+  const mobileOnlyItemClasses = clsx(
+    baseItemClasses,
+    'vads-u-display--flex medium-screen:vads-u-display--none'
+  )
+  const desktopOnlyItemClasses = clsx(
+    baseItemClasses,
+    'vads-u-display--none medium-screen:vads-u-display--flex'
+  )
+
+  // Let's use border util classes instead
   return (
     <div className="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
       <div className="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
-        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="pill"
-          />
+        <p className={normalItemClasses}>
+          {renderIcon('pill')}
           <va-link
             href={getTopTaskUrl('refill-track-prescriptions/')}
             text="Refill and track your prescriptions"
           />
-        </div>
-        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="forum"
-          />
+        </p>
+        <p className={normalItemClasses}>
+          {renderIcon('forum')}
           <va-link
             href={getTopTaskUrl('secure-messaging/')}
             text="Send a secure message to your health care team"
           />
-        </div>
-        <div className="vads-facility-hub-cta vads-u-border-color--primary-alt-light medium-screen:vads-u-border-bottom--1px vads-u-display--flex vads-u-align-items--center">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="event_available"
-          />
+        </p>
+        <p className={normalItemClasses}>
+          {renderIcon('event_available')}
           <va-link
             href={getTopTaskUrl('schedule-view-va-appointments/')}
             text="Schedule and manage health appointments"
           />
-        </div>
-        <div className="vads-facility-hub-cta vads-u-display--none medium-screen:vads-u-display--flex vads-u-align-items--center">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="chat"
-          />
+        </p>
+        <p
+          className={clsx(desktopOnlyItemClasses, 'vads-u-border-bottom--1px')}
+        >
+          {renderIcon('chat')}
           <va-link
             href="https://mobile.va.gov/app/va-health-chat"
             text="Download VA Health Chat"
           />
-        </div>
+        </p>
       </div>
       <div>
-        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="note_add"
-          />
+        <p className={normalItemClasses}>
+          {renderIcon('note_add')}
           <va-link
             href={getTopTaskUrl('get-medical-records/')}
             text="Download your VA medical records (Blue Button)"
           />
-        </div>
-        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="assignment"
-          />
+        </p>
+        <p className={normalItemClasses}>
+          {renderIcon('assignment')}
           <va-link
             href={getTopTaskUrl('view-test-and-lab-results/')}
             text="View your lab and test results"
           />
-        </div>
-        <div className="vads-facility-hub-cta vads-facility-hub-cta-last-line vads-u-border-top--1px vads-u-border-color--primary-alt-light vads-u-display--flex vads-u-align-items--center">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="hearing_disabled"
-          />
+        </p>
+        <p className={normalItemClasses}>
+          {renderIcon('hearing_disabled')}
           <va-link
             href="/health-care/order-hearing-aid-batteries-and-accessories/"
             text="Order hearing aid batteries and accessories"
           />
-        </div>
-        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center medium-screen:vads-u-display--none">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="chat"
-          />
+        </p>
+        <p className={mobileOnlyItemClasses}>
+          {renderIcon('chat')}
           <va-link
             href="https://mobile.va.gov/app/va-health-chat"
             text="Download VA Health Chat"
           />
-        </div>
-        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center">
-          <va-icon
-            class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
-            size="3"
-            icon="phone"
-          />
+        </p>
+        <p className={clsx(normalItemClasses, 'vads-u-border-bottom--1px')}>
+          {renderIcon('phone')}
           <va-link
             href="https://www.va.gov/health/connect-to-va-care/index.asp"
             text="Connect to VA care"
           />
-        </div>
+        </p>
       </div>
     </div>
   )

--- a/src/templates/layouts/vamcSystem/ManageYourHealthLinks.tsx
+++ b/src/templates/layouts/vamcSystem/ManageYourHealthLinks.tsx
@@ -78,7 +78,7 @@ export function ManageYourHealthLinks({
             text="Schedule and manage health appointments"
           />
         </div>
-        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center health-online-desktop-link">
+        <div className="vads-facility-hub-cta vads-u-display--none medium-screen:vads-u-display--flex vads-u-align-items--center">
           <va-icon
             class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
             size="3"
@@ -124,7 +124,7 @@ export function ManageYourHealthLinks({
             text="Order hearing aid batteries and accessories"
           />
         </div>
-        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center health-online-mobile-link">
+        <div className="vads-facility-hub-cta vads-u-display--flex vads-u-align-items--center medium-screen:vads-u-display--none">
           <va-icon
             class="vads-u-color--link-default vads-facility-hub-cta-circle vads-u-margin-right--1"
             size="3"

--- a/src/templates/layouts/vamcSystem/index.tsx
+++ b/src/templates/layouts/vamcSystem/index.tsx
@@ -8,6 +8,7 @@ import { FacilityListing } from '@/templates/components/facilityListing'
 import { RelatedLinks } from '@/templates/common/relatedLinks'
 import { RegionalTopTasks } from '@/templates/components/topTasks'
 import { LOVELL } from '@/lib/drupal/lovell/constants'
+import { ManageYourHealthLinks } from '@/templates/layouts/vamcSystem/ManageYourHealthLinks'
 // import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
 // import { TopTasks } from '@/templates/components/topTasks'
 // import { FacilityListing } from '@/templates/components/facilityListing'
@@ -106,11 +107,7 @@ export function VamcSystem({
                     ? 'Manage your VA health online'
                     : 'Manage your health online'}
                 </h2>
-                <div className="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
-                  <div className="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
-                    {/* TODO: Add health online links component */}
-                  </div>
-                </div>
+                <ManageYourHealthLinks vamcEhrSystem={vamcEhrSystem} />
               </section>
             )}
 


### PR DESCRIPTION
# Description

- Adds the "Manage your health online" section to VAMC System page
- Fixes the weird border issues that were called out in the ticket
- Uses `<p>` tags instead of `<div>` tags (also callled out in the ticket)

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21252

## Testing Steps

See ticket for testing URLs and a screenshot of the section in question

## Screenshots

### Before (Production with border bug) (Desktop)

<img width="734" alt="Screenshot 2025-05-21 at 3 26 41 PM" src="https://github.com/user-attachments/assets/3b24edd3-e611-432e-a321-46e3c3158971" />

### After (Desktop)

<img width="746" alt="Screenshot 2025-05-21 at 3 27 08 PM" src="https://github.com/user-attachments/assets/e38307e8-251a-466d-b009-822bff3d826a" />

### Before (Production with border bug) (Mobile)

<img width="351" alt="Screenshot 2025-05-21 at 3 27 42 PM" src="https://github.com/user-attachments/assets/9c4b4cfc-0816-420c-b391-c5715472beb4" />

### After (Mobile)

<img width="353" alt="Screenshot 2025-05-21 at 3 27 27 PM" src="https://github.com/user-attachments/assets/5cd0d764-a0a7-40ab-a3d5-f3f59fa51d87" />
