### PR TITLE
Add fetch-entity CLI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -70,7 +70,8 @@
           "./tsconfig.json",
           "./packages/env-loader/tsconfig.json",
           "./packages/proxy-fetcher/tsconfig.json",
-          "./scripts/dependency-tree-visualizer/tsconfig.json"
+          "./scripts/dependency-tree-visualizer/tsconfig.json",
+          "./scripts/fetch-entity/tsconfig.json"
         ]
       }
     }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "test:playwright:a11y:local": "USE_PROXY=false PW_WIDTH_VALUE=768 PW_HEIGHT_VALUE=720 PW_BROWSER_VALUE=chromium yarn playwright test --project=a11y",
     "test:types": "yarn build:env-loader && APP_ENV=test tsc --noEmit",
     "storybook": "storybook dev -p 6006",
-    "storybook:build": "storybook build -o out/storybook-static --quiet"
+    "storybook:build": "storybook build -o out/storybook-static --quiet",
+    "fetch-entity": "NODE_OPTIONS='--disable-warning=ExperimentalWarning' node scripts/fetch-entity/src/index.ts"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",

--- a/scripts/fetch-entity/src/drupalClient.ts
+++ b/scripts/fetch-entity/src/drupalClient.ts
@@ -1,0 +1,44 @@
+/**
+ * This is essentially a copy of what's in the drupalClient.ts module, but
+ * copying it over here for use in the script because importing it from
+ * next-build/src/lib/drupal/drupalClient.ts is a pain.
+ */
+
+import { DrupalClient } from 'next-drupal'
+
+/* eslint-disable import/no-extraneous-dependencies */
+import { SocksProxyAgent } from 'socks-proxy-agent'
+import fetch from 'node-fetch'
+
+const syswideCas = await import('syswide-cas')
+syswideCas.addCAs('certs/VA-Internal-S2-RCA-combined.pem')
+syswideCas.addCAs('certs/rootCA.pem')
+
+const baseUrl =
+  process.env.NEXT_PUBLIC_DRUPAL_BASE_URL || 'https://va-gov-cms.ddev.site'
+
+const debug = process.env.DEBUG === 'true'
+
+const proxyFetch = (input: RequestInfo, init: RequestInit = {}) => {
+  const agent = new SocksProxyAgent('socks5h://127.0.0.1:2001')
+  return fetch(input, { ...init, agent })
+}
+
+export const drupalClient = new DrupalClient(baseUrl, {
+  fetcher: proxyFetch,
+  useDefaultResourceTypeEntry: true,
+  throwJsonApiErrors: false,
+  auth: {
+    // @ts-expect-error It's possible for the env vars to not be set properly
+    clientId: process.env.DRUPAL_CLIENT_ID,
+    // @ts-expect-error It's possible for the env vars to not be set properly
+    clientSecret: process.env.DRUPAL_CLIENT_SECRET,
+  },
+  previewSecret: process.env.DRUPAL_PREVIEW_SECRET,
+  // Add request header to tell the CMS to return public-facing URLs for files.
+  headers: {
+    'Content-Type': 'application/vnd.api+json',
+    Accept: 'application/vnd.api+json',
+    'File-Public-Base-Url-Check': 'true',
+  },
+})

--- a/scripts/fetch-entity/src/getEnvVars.ts
+++ b/scripts/fetch-entity/src/getEnvVars.ts
@@ -1,0 +1,35 @@
+/**
+ * This is essentially a copy of what's in the env-loader package, but we need
+ * to copy it over here because getting the silly thing to run as a script is a
+ * pain otherwise.
+ */
+
+/* eslint-disable import/no-extraneous-dependencies */
+import dotenv from 'dotenv'
+import dotenvExpand from 'dotenv-expand'
+
+export type EnvVars = {
+  [key: string]: string
+}
+
+const loadEnvVarsFromPath = (path: string, verbose: boolean): EnvVars => {
+  const envVars = {}
+  dotenvExpand.expand(
+    dotenv.config({
+      path,
+      override: true,
+      processEnv: envVars,
+    })
+  )
+
+  if (verbose) {
+    // eslint-disable-next-line no-console
+    console.log(`Using environment variables from: ${path}`)
+  }
+
+  return envVars
+}
+
+export const getEnvFileVars = (appEnv?: string, verbose = true): EnvVars => {
+  return loadEnvVarsFromPath(`envs/.env.local`, verbose)
+}

--- a/scripts/fetch-entity/src/index.ts
+++ b/scripts/fetch-entity/src/index.ts
@@ -1,0 +1,80 @@
+/* eslint-disable no-console */
+
+/**
+ * Note: This script only works with Node or ts-node, not Bun or Deno.
+ */
+
+import { program } from 'commander'
+// import { DrupalClientAuth } from 'next-drupal'
+import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+import util from 'util'
+
+import { getEnvFileVars } from './getEnvVars.ts'
+
+const envFileVars = getEnvFileVars('local', false)
+
+process.env = {
+  ...process.env,
+  ...envFileVars,
+}
+
+const { drupalClient } = await import('./drupalClient.ts')
+
+// The username & password will let us apply filters, so prefer that
+// Fall back to the client ID and secret otherwise
+//
+// @ts-expect-error It's possible for the env vars to not be set properly
+const withAuth: DrupalClientAuth = process.env.DRUPAL_USERNAME
+  ? {
+      username: process.env.DRUPAL_USERNAME,
+      password: process.env.DRUPAL_PASSWORD,
+    }
+  : {
+      clientId: process.env.DRUPAL_CLIENT_ID,
+      clientSecret: process.env.DRUPAL_CLIENT_SECRET,
+    }
+
+program
+  .description(
+    'Fetch a resource from the Drupal JSON:API. Useful for grabbing mock data.'
+  )
+  .argument('<resource-type>', 'The resource type to fetch')
+  .argument('<uuid>', 'The ID of the resource to fetch')
+  .option(
+    '--include <includes...>',
+    'Dot-notated, space-separated includes (e.g. field_telephone field_region_page.field_related_links.field_va_paragraphs)'
+  )
+  .option('--json', 'Output as JSON. Beware of circular references!')
+  .action(
+    async (
+      resourceType: string,
+      uuid: string,
+      options: { include?: string[]; json?: boolean }
+    ) => {
+      const params = new DrupalJsonApiParams()
+      if (options.include?.length) {
+        params.addInclude(options.include)
+      }
+
+      const data = await drupalClient.getResource(resourceType, uuid, {
+        params: params.getQueryObject(),
+        withAuth,
+      })
+
+      if (options.json) {
+        // If we're piping or redirecting, print as JSON.
+        // E.g. `node ... | pbcopy` or `node ... > data.json`
+        console.log(JSON.stringify(data, null, 2))
+        // console.log(util.format('%j', data)) will output just "[Circular]" if
+        // there are circular references
+      } else {
+        // If we're printing to the terminal, pretty print with colors.
+        // NOTE: This is not proper JSON. (No quotes around property names.)
+        console.log(
+          util.inspect(data, { depth: null, colors: process.stdout.isTTY })
+        )
+      }
+    }
+  )
+
+program.parse()

--- a/scripts/fetch-entity/tsconfig.json
+++ b/scripts/fetch-entity/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src"],
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": "src/",
+    "target": "esnext",
+    "module": "esnext",
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "paths": {
+      "@/lib/*": ["../../src/lib/*"]
+    }
+  }
+}


### PR DESCRIPTION
# Description

Adds a utility script to fetch and hydrate entities from Drupal's JSON:API from the command line.

The goal here is to use this for grabbing mock data more easily. I built this because the mock data I was trying to grab had circular references, and every other way I tried to plug that into a mock data file kept failing during serialization. I used this to output Mostly JavaScript™ by the power of `util.inspect()`. From there, I copy-pasta'd that into a `.mock.ts` file, removed the `[Circular *1]` and `<Ref *1>` pointers, and plugged that new variable into the `mockData.field_local_health_care_service_` property.

It's not the most elegant solution, but it works. 😬 

## Screenshots

**Help**
![image](https://github.com/user-attachments/assets/fb5e5e1a-fcf7-406d-9a63-3f8edb5f2f99)

**Colored output**
![image](https://github.com/user-attachments/assets/0017826a-1135-4bbb-a47e-cf89c1f7377b)

**JSON output**
![image](https://github.com/user-attachments/assets/668842a6-b8b7-4d41-a725-f4ad8dc9b05f)

## Ticket

Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20793