### PR TITLE
Fail the build on empty resource types

### DIFF
--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -206,7 +206,9 @@ export async function getStaticPaths(
       fallback: 'blocking',
     }
   }
-
+  if (!RESOURCE_TYPES_TO_BUILD.length) {
+    throw new Error('No resource types returned')
+  }
   /* eslint-disable no-console */
   console.log(
     `\n\nBuilding ${RESOURCE_TYPES_TO_BUILD.length} resource types:`,

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -73,20 +73,20 @@ import { VamcSystemVaPolice } from '@/templates/layouts/vamcSystemVaPolice'
 // eslint-disable-next-line prefer-const
 let RESOURCE_TYPES_TO_BUILD = []
 // FEATURE_NEXT_BUILD_CONTENT_ALL is checked to allow local developers to bypass flag checks.
-if (process.env.FEATURE_NEXT_BUILD_CONTENT_ALL === 'true') {
-  RESOURCE_TYPES_TO_BUILD = PAGE_RESOURCE_TYPES
-} else {
-  // Check the env variables loaded from the CMS feature flags and env files to determine what
-  // content types to build.
-  for (let x = 0; x < PAGE_RESOURCE_TYPES.length; x++) {
-    const typeName = PAGE_RESOURCE_TYPES[x].replace(/^node--/, '').toUpperCase()
-    const flagName = `FEATURE_NEXT_BUILD_CONTENT_${typeName}`
-    // Note 'true' as a string is correct here. Env variables are always strings.
-    if (process.env[flagName] === 'true') {
-      RESOURCE_TYPES_TO_BUILD.push(PAGE_RESOURCE_TYPES[x])
-    }
-  }
-}
+// if (process.env.FEATURE_NEXT_BUILD_CONTENT_ALL === 'true') {
+//   RESOURCE_TYPES_TO_BUILD = PAGE_RESOURCE_TYPES
+// } else {
+//   // Check the env variables loaded from the CMS feature flags and env files to determine what
+//   // content types to build.
+//   for (let x = 0; x < PAGE_RESOURCE_TYPES.length; x++) {
+//     const typeName = PAGE_RESOURCE_TYPES[x].replace(/^node--/, '').toUpperCase()
+//     const flagName = `FEATURE_NEXT_BUILD_CONTENT_${typeName}`
+//     // Note 'true' as a string is correct here. Env variables are always strings.
+//     if (process.env[flagName] === 'true') {
+//       RESOURCE_TYPES_TO_BUILD.push(PAGE_RESOURCE_TYPES[x])
+//     }
+//   }
+// }
 
 export const DynamicBreadcrumbs = dynamic(
   () => import('@/templates/common/breadcrumbs'),
@@ -212,7 +212,6 @@ export async function getStaticPaths(
     console.error('No resource types returned')
     process.exit(1)
   }
-  /* eslint-disable no-console */
   console.log(
     `\n\nBuilding ${RESOURCE_TYPES_TO_BUILD.length} resource types:`,
     RESOURCE_TYPES_TO_BUILD,

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -206,8 +206,11 @@ export async function getStaticPaths(
       fallback: 'blocking',
     }
   }
+  /* eslint-disable no-console */
+
   if (!RESOURCE_TYPES_TO_BUILD.length) {
-    throw new Error('No resource types returned')
+    console.error('No resource types returned')
+    process.exit(1)
   }
   /* eslint-disable no-console */
   console.log(

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -73,20 +73,20 @@ import { VamcSystemVaPolice } from '@/templates/layouts/vamcSystemVaPolice'
 // eslint-disable-next-line prefer-const
 let RESOURCE_TYPES_TO_BUILD = []
 // FEATURE_NEXT_BUILD_CONTENT_ALL is checked to allow local developers to bypass flag checks.
-// if (process.env.FEATURE_NEXT_BUILD_CONTENT_ALL === 'true') {
-//   RESOURCE_TYPES_TO_BUILD = PAGE_RESOURCE_TYPES
-// } else {
-//   // Check the env variables loaded from the CMS feature flags and env files to determine what
-//   // content types to build.
-//   for (let x = 0; x < PAGE_RESOURCE_TYPES.length; x++) {
-//     const typeName = PAGE_RESOURCE_TYPES[x].replace(/^node--/, '').toUpperCase()
-//     const flagName = `FEATURE_NEXT_BUILD_CONTENT_${typeName}`
-//     // Note 'true' as a string is correct here. Env variables are always strings.
-//     if (process.env[flagName] === 'true') {
-//       RESOURCE_TYPES_TO_BUILD.push(PAGE_RESOURCE_TYPES[x])
-//     }
-//   }
-// }
+if (process.env.FEATURE_NEXT_BUILD_CONTENT_ALL === 'true') {
+  RESOURCE_TYPES_TO_BUILD = PAGE_RESOURCE_TYPES
+} else {
+  // Check the env variables loaded from the CMS feature flags and env files to determine what
+  // content types to build.
+  for (let x = 0; x < PAGE_RESOURCE_TYPES.length; x++) {
+    const typeName = PAGE_RESOURCE_TYPES[x].replace(/^node--/, '').toUpperCase()
+    const flagName = `FEATURE_NEXT_BUILD_CONTENT_${typeName}`
+    // Note 'true' as a string is correct here. Env variables are always strings.
+    if (process.env[flagName] === 'true') {
+      RESOURCE_TYPES_TO_BUILD.push(PAGE_RESOURCE_TYPES[x])
+    }
+  }
+}
 
 export const DynamicBreadcrumbs = dynamic(
   () => import('@/templates/common/breadcrumbs'),

--- a/src/test/slug.test.tsx
+++ b/src/test/slug.test.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/lib/drupal/staticProps'
 import { DoNotPublishError } from '@/lib/drupal/query'
 import { drupalClient } from '@/lib/drupal/drupalClient'
-import type { GetStaticPathsContext } from 'next'
 
 jest.mock('@/lib/drupal/staticProps', () => ({
   getExpandedStaticPropsContext: jest.fn(),
@@ -51,33 +50,5 @@ describe('[[...slug]].tsx', () => {
       // Assert that getStaticPropsResource was called
       expect(getStaticPropsResource).toHaveBeenCalled()
     })
-  })
-})
-
-describe('getStaticPaths', () => {
-  const originalEnv = process.env
-
-  beforeEach(() => {
-    jest.resetModules()
-    process.env = { ...originalEnv, SSG: 'true' }
-  })
-
-  afterEach(() => {
-    process.env = originalEnv
-  })
-
-  it('throws an error when RESOURCE_TYPES_TO_BUILD is empty', async () => {
-    // remove all feature flags to ensure RESOURCE_TYPES_TO_BUILD is empty
-    const { PAGE_RESOURCE_TYPES } = await import(
-      '@/lib/constants/resourceTypes'
-    )
-    PAGE_RESOURCE_TYPES.forEach((type) => {
-      const flag = `FEATURE_NEXT_BUILD_CONTENT_${type.replace(/^node--/, '').toUpperCase()}`
-      delete process.env[flag]
-    })
-    const { getStaticPaths } = await import('@/pages/[[...slug]]')
-    await expect(getStaticPaths({} as GetStaticPathsContext)).rejects.toThrow(
-      'No resource types returned'
-    )
   })
 })

--- a/src/test/slug.test.tsx
+++ b/src/test/slug.test.tsx
@@ -26,24 +26,24 @@ describe('[[...slug]].tsx', () => {
   describe('getStaticProps', () => {
     const mockContext = { params: { slug: ['test-path'] }, preview: false }
     it('returns notFound when DoNotPublishError is thrown', async () => {
-      // // Mock the expanded context
-      // const mockExpandedContext = { drupalPath: '/test-path', preview: false }
-      // const mockPathInfo = { jsonapi: { resourceName: 'node--event' } }
-      // // Mock the functions
-      // ;(getExpandedStaticPropsContext as jest.Mock).mockReturnValue(
-      //   mockExpandedContext
-      // )
-      // ;(drupalClient.translatePath as jest.Mock).mockResolvedValue(mockPathInfo)
-      // // Mock getStaticPropsResource to throw DoNotPublishError
-      // ;(getStaticPropsResource as jest.Mock).mockImplementation(() => {
-      //   throw new DoNotPublishError('Do not publish error')
-      // })
-      // // Call getStaticProps
-      // const result = await getStaticProps(mockContext)
-      // // Assert that notFound is returned
-      // expect(result).toEqual({ notFound: true })
-      // // Assert that getStaticPropsResource was called
-      // expect(getStaticPropsResource).toHaveBeenCalled()
+      // Mock the expanded context
+      const mockExpandedContext = { drupalPath: '/test-path', preview: false }
+      const mockPathInfo = { jsonapi: { resourceName: 'node--event' } }
+      // Mock the functions
+      ;(getExpandedStaticPropsContext as jest.Mock).mockReturnValue(
+        mockExpandedContext
+      )
+      ;(drupalClient.translatePath as jest.Mock).mockResolvedValue(mockPathInfo)
+      // Mock getStaticPropsResource to throw DoNotPublishError
+      ;(getStaticPropsResource as jest.Mock).mockImplementation(() => {
+        throw new DoNotPublishError('Do not publish error')
+      })
+      // Call getStaticProps
+      const result = await getStaticProps(mockContext)
+      // Assert that notFound is returned
+      expect(result).toEqual({ notFound: true })
+      // Assert that getStaticPropsResource was called
+      expect(getStaticPropsResource).toHaveBeenCalled()
     })
   })
 })

--- a/src/test/slug.test.tsx
+++ b/src/test/slug.test.tsx
@@ -29,19 +29,24 @@ describe('[[...slug]].tsx', () => {
       // Mock the expanded context
       const mockExpandedContext = { drupalPath: '/test-path', preview: false }
       const mockPathInfo = { jsonapi: { resourceName: 'node--event' } }
+
       // Mock the functions
       ;(getExpandedStaticPropsContext as jest.Mock).mockReturnValue(
         mockExpandedContext
       )
       ;(drupalClient.translatePath as jest.Mock).mockResolvedValue(mockPathInfo)
+
       // Mock getStaticPropsResource to throw DoNotPublishError
       ;(getStaticPropsResource as jest.Mock).mockImplementation(() => {
         throw new DoNotPublishError('Do not publish error')
       })
+
       // Call getStaticProps
       const result = await getStaticProps(mockContext)
+
       // Assert that notFound is returned
       expect(result).toEqual({ notFound: true })
+
       // Assert that getStaticPropsResource was called
       expect(getStaticPropsResource).toHaveBeenCalled()
     })

--- a/src/test/slug.test.tsx
+++ b/src/test/slug.test.tsx
@@ -26,29 +26,24 @@ describe('[[...slug]].tsx', () => {
   describe('getStaticProps', () => {
     const mockContext = { params: { slug: ['test-path'] }, preview: false }
     it('returns notFound when DoNotPublishError is thrown', async () => {
-      // Mock the expanded context
-      const mockExpandedContext = { drupalPath: '/test-path', preview: false }
-      const mockPathInfo = { jsonapi: { resourceName: 'node--event' } }
-
-      // Mock the functions
-      ;(getExpandedStaticPropsContext as jest.Mock).mockReturnValue(
-        mockExpandedContext
-      )
-      ;(drupalClient.translatePath as jest.Mock).mockResolvedValue(mockPathInfo)
-
-      // Mock getStaticPropsResource to throw DoNotPublishError
-      ;(getStaticPropsResource as jest.Mock).mockImplementation(() => {
-        throw new DoNotPublishError('Do not publish error')
-      })
-
-      // Call getStaticProps
-      const result = await getStaticProps(mockContext)
-
-      // Assert that notFound is returned
-      expect(result).toEqual({ notFound: true })
-
-      // Assert that getStaticPropsResource was called
-      expect(getStaticPropsResource).toHaveBeenCalled()
+      // // Mock the expanded context
+      // const mockExpandedContext = { drupalPath: '/test-path', preview: false }
+      // const mockPathInfo = { jsonapi: { resourceName: 'node--event' } }
+      // // Mock the functions
+      // ;(getExpandedStaticPropsContext as jest.Mock).mockReturnValue(
+      //   mockExpandedContext
+      // )
+      // ;(drupalClient.translatePath as jest.Mock).mockResolvedValue(mockPathInfo)
+      // // Mock getStaticPropsResource to throw DoNotPublishError
+      // ;(getStaticPropsResource as jest.Mock).mockImplementation(() => {
+      //   throw new DoNotPublishError('Do not publish error')
+      // })
+      // // Call getStaticProps
+      // const result = await getStaticProps(mockContext)
+      // // Assert that notFound is returned
+      // expect(result).toEqual({ notFound: true })
+      // // Assert that getStaticPropsResource was called
+      // expect(getStaticPropsResource).toHaveBeenCalled()
     })
   })
 })

--- a/src/test/slug.test.tsx
+++ b/src/test/slug.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/lib/drupal/staticProps'
 import { DoNotPublishError } from '@/lib/drupal/query'
 import { drupalClient } from '@/lib/drupal/drupalClient'
+import type { GetStaticPathsContext } from 'next'
 
 jest.mock('@/lib/drupal/staticProps', () => ({
   getExpandedStaticPropsContext: jest.fn(),
@@ -50,5 +51,33 @@ describe('[[...slug]].tsx', () => {
       // Assert that getStaticPropsResource was called
       expect(getStaticPropsResource).toHaveBeenCalled()
     })
+  })
+})
+
+describe('getStaticPaths', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...originalEnv, SSG: 'true' }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('throws an error when RESOURCE_TYPES_TO_BUILD is empty', async () => {
+    // remove all feature flags to ensure RESOURCE_TYPES_TO_BUILD is empty
+    const { PAGE_RESOURCE_TYPES } = await import(
+      '@/lib/constants/resourceTypes'
+    )
+    PAGE_RESOURCE_TYPES.forEach((type) => {
+      const flag = `FEATURE_NEXT_BUILD_CONTENT_${type.replace(/^node--/, '').toUpperCase()}`
+      delete process.env[flag]
+    })
+    const { getStaticPaths } = await import('@/pages/[[...slug]]')
+    await expect(getStaticPaths({} as GetStaticPathsContext)).rejects.toThrow(
+      'No resource types returned'
+    )
   })
 })


### PR DESCRIPTION
# Description

This PR fails the build when the `RESOURCE_TYPES_TO_BUILD` array is empty. It adds a guard to exit before the resource types are built so that we can exit if there are none. This came out as a weird blip when the build failed when drupal was unavailable but somehow was still waking up when it tried to build an empty array and failed silently. 

## Generated description

This pull request includes a small but important change to the `src/pages/[[...slug]].tsx` file. It adds a check to ensure that `RESOURCE_TYPES_TO_BUILD` is not empty before proceeding, logging an error and exiting the process if no resource types are returned.

* `src/pages/[[...slug]].tsx`: Added a validation step to log an error and terminate the process if `RESOURCE_TYPES_TO_BUILD` is empty, ensuring proper handling of missing resource types. ([src/pages/[[...slug]].tsxR209-R214](diffhunk://#diff-5f218029560343be88582c198bb3b04e4c18259a5e716a88250afabe4466f957R209-R214))
## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes _link to [21328](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21328)

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

This is probably not the best way but I tried to force the array `RESOURCE_TYPES_TO_BUILD` to be empty programmatically by commenting this if block 
![image](https://github.com/user-attachments/assets/895ae0d2-8ad8-4828-a555-326c5b380c92)


## QA steps+ Screenshots

🤷‍♀️ 
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/8185bc5f-6318-44b0-8b87-4eda33112ce8" />


---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```