### PR TITLE
Simplify `field_administration` usage across content types

### DIFF
--- a/src/data/queries/administration.ts
+++ b/src/data/queries/administration.ts
@@ -1,0 +1,15 @@
+import { FieldAdministration } from '@/types/drupal/field_type'
+
+/**
+ * Returns an id used to identify the administration, which we will sometimes use to
+ * identify a specific administrative area, like Lovell.
+ *
+ * In our Drupal content, the `field_administration` field points to a taxonomy Term
+ * that is currently called "Section", but "Section" is only a human label added to
+ * it in the Drupal interface, and that name has evolved over time. It was originally,
+ * "administration" (and thus the name of the field). Since the only machine name of
+ * it is `field_administration`, we'll continue to call it "administration" in our code.
+ */
+export const getAdministrationId = (
+  administration: FieldAdministration | null | undefined
+): number => administration?.drupal_internal__tid // "t" is for taxonomy term

--- a/src/data/queries/healthCareLocalFacility.ts
+++ b/src/data/queries/healthCareLocalFacility.ts
@@ -20,6 +20,7 @@ import {
 import { formatter as formatImage } from '@/data/queries/mediaImage'
 import { ParagraphLinkTeaser } from '@/types/drupal/paragraph'
 import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
+import { getAdministrationId } from './administration'
 
 // Define the query params for fetching node--health_care_local_facility.
 export const params: QueryParams<null> = () => {
@@ -100,9 +101,7 @@ export const formatter: QueryFormatter<
     operatingStatusFacility: entity.field_operating_status_facility,
     menu: formattedMenu,
     path: entity.path.alias,
-    administration: {
-      entityId: entity.field_administration.drupal_internal__tid,
-    },
+    administrationId: getAdministrationId(entity.field_administration),
     vamcEhrSystem: entity.field_region_page.field_vamc_ehr_system,
     officeHours: entity.field_office_hours,
     image: formatImage(entity.field_media),

--- a/src/data/queries/newsStory.ts
+++ b/src/data/queries/newsStory.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/drupal/query'
 import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 import { getNestedIncludes } from '@/lib/utils/queries'
+import { getAdministrationId } from './administration'
 
 // Define the query params for fetching node--news_story.
 export const params: QueryParams<null> = () => {
@@ -56,9 +57,6 @@ export const formatter: QueryFormatter<NodeNewsStory, NewsStory> = (
       title: entity.title,
     },
     listing: entity.field_listing.path.alias,
-    administration: {
-      id: entity.field_administration?.drupal_internal__tid || null,
-      name: entity.field_administration?.name || null,
-    },
+    administrationId: getAdministrationId(entity.field_administration),
   }
 }

--- a/src/data/queries/personProfile.ts
+++ b/src/data/queries/personProfile.ts
@@ -11,6 +11,7 @@ import {
   fetchSingleEntityOrPreview,
 } from '@/lib/drupal/query'
 import { buildStaffProfileSidebarData } from '@/lib/drupal/staffProfileSideNav'
+import { getAdministrationId } from './administration'
 
 // Define the query params for fetching node--person_profile.
 export const params: QueryParams<null> = () => {
@@ -79,9 +80,6 @@ export const formatter: QueryFormatter<PersonProfileData, StaffProfile> = ({
     vamcTitle: entity?.field_office?.title || null,
     office: entity.field_office,
     menu: formattedMenu,
-    administration: {
-      id: entity.field_administration?.drupal_internal__tid || null,
-      name: entity.field_administration?.name || null,
-    },
+    administrationId: getAdministrationId(entity.field_administration),
   }
 }

--- a/src/data/queries/pressRelease.ts
+++ b/src/data/queries/pressRelease.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/drupal/query'
 import { get } from 'lodash'
 import { getNestedIncludes } from '@/lib/utils/queries'
+import { getAdministrationId } from './administration'
 
 // Define the query params for fetching node--press_release.
 export const params: QueryParams<null> = () => {
@@ -105,9 +106,6 @@ export const formatter: QueryFormatter<NodePressRelease, PressRelease> = (
     contacts: formattedContacts,
     downloads: downloads,
     listing: entity.field_listing?.path?.alias,
-    administration: {
-      id: entity.field_administration?.drupal_internal__tid || null,
-      name: entity.field_administration?.name || null,
-    },
+    administrationId: getAdministrationId(entity.field_administration),
   }
 }

--- a/src/data/queries/staticPathResources.ts
+++ b/src/data/queries/staticPathResources.ts
@@ -11,6 +11,7 @@ import { FieldAdministration } from '@/types/drupal/field_type'
 import { PAGE_SIZES } from '@/lib/constants/pageSizes'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { fetchAndConcatAllResourceCollectionPages } from '@/lib/drupal/query'
+import { getAdministrationId } from './administration'
 
 const PAGE_SIZE = PAGE_SIZES.MAX
 
@@ -66,9 +67,8 @@ export const formatter: QueryFormatter<
   )
   return filteredResources.map((filteredResource) => ({
     path: filteredResource.path.alias,
-    administration: {
-      id: filteredResource.field_administration?.drupal_internal__tid || null,
-      name: filteredResource.field_administration?.name || null,
-    },
+    administrationId: getAdministrationId(
+      filteredResource.field_administration
+    ),
   }))
 }

--- a/src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/healthCareLocalFacility.test.tsx.snap
@@ -12,9 +12,7 @@ exports[`HealthCareLocalFacility query should handle the Lovell variant page men
     "locality": "Boston",
     "postal_code": "02114-2104",
   },
-  "administration": {
-    "entityId": 205,
-  },
+  "administrationId": 205,
   "breadcrumbs": [
     {
       "options": [],
@@ -548,9 +546,7 @@ exports[`HealthCareLocalFacility query should output formatted data 1`] = `
     "locality": "Boston",
     "postal_code": "02114-2104",
   },
-  "administration": {
-    "entityId": 205,
-  },
+  "administrationId": 205,
   "breadcrumbs": [
     {
       "options": [],

--- a/src/data/queries/tests/__snapshots__/newsStory.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/newsStory.test.tsx.snap
@@ -2,10 +2,7 @@
 
 exports[`node--news_story formatData outputs formatted data 1`] = `
 {
-  "administration": {
-    "id": 12,
-    "name": "VA Pittsburgh health care",
-  },
+  "administrationId": 12,
   "author": {
     "changed": "2019-08-27T17:50:21+00:00",
     "created": "2019-05-14T16:10:51+00:00",

--- a/src/data/queries/tests/__snapshots__/personProfile.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/personProfile.test.tsx.snap
@@ -2,10 +2,7 @@
 
 exports[`Person profile returns formatted data outputs formatted data 1`] = `
 {
-  "administration": {
-    "id": null,
-    "name": null,
-  },
+  "administrationId": undefined,
   "body": null,
   "breadcrumbs": undefined,
   "completeBiography": null,

--- a/src/data/queries/tests/__snapshots__/pressRelease.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/pressRelease.test.tsx.snap
@@ -8,10 +8,7 @@ exports[`node--press_release formatData output formatted data 1`] = `
     "langcode": null,
     "locality": "Wilmington",
   },
-  "administration": {
-    "id": 188,
-    "name": "VA Wilmington health care",
-  },
+  "administrationId": 188,
   "breadcrumbs": [
     {
       "options": [],

--- a/src/data/queries/tests/__snapshots__/vamcSystem.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/vamcSystem.test.tsx.snap
@@ -4,10 +4,7 @@ exports[`DrupalJsonApiParams configuration params function sets the correct incl
 
 exports[`VamcSystem formatData outputs formatted data 1`] = `
 {
-  "administration": {
-    "id": 254,
-    "name": "VA New York Harbor health care",
-  },
+  "administrationId": 254,
   "breadcrumbs": [
     {
       "options": [],

--- a/src/data/queries/tests/newsStory.test.tsx
+++ b/src/data/queries/tests/newsStory.test.tsx
@@ -25,8 +25,7 @@ describe(`${RESOURCE_TYPES.STORY} formatData`, () => {
 
     const formattedData = queries.formatData(RESOURCE_TYPES.STORY, modifiedMock)
     expect(formattedData.author).toBeNull()
-    expect(formattedData.administration.id).toBeNull()
-    expect(formattedData.administration.name).toBeNull()
+    expect(formattedData.administrationId).toBeUndefined()
   })
 })
 

--- a/src/data/queries/tests/pressRelease.test.tsx
+++ b/src/data/queries/tests/pressRelease.test.tsx
@@ -39,8 +39,7 @@ describe(`${RESOURCE_TYPES.PRESS_RELEASE} formatData`, () => {
     )
     expect(formattedData.listing).toBeUndefined()
     expect(formattedData.contacts).toEqual([])
-    expect(formattedData.administration.id).toBeNull()
-    expect(formattedData.administration.name).toBeNull()
+    expect(formattedData.administrationId).toBeUndefined()
     expect(formattedData.pdfVersion).toBeNull()
   })
   test('handles missing or null contact fields correctly', () => {

--- a/src/data/queries/tests/staticPathResources.test.tsx
+++ b/src/data/queries/tests/staticPathResources.test.tsx
@@ -84,12 +84,10 @@ describe('Static paths formatter', () => {
     const formattedData = formatter(mockResourcesWithAdmin)
 
     expect(formattedData[0].path).toBe('/test-path-1')
-    expect(formattedData[0].administration.id).toBe(10)
-    expect(formattedData[0].administration.name).toBe('Administration 1')
+    expect(formattedData[0].administrationId).toBe(10)
 
     expect(formattedData[1].path).toBe('/test-path-2')
-    expect(formattedData[1].administration.id).toBeNull()
-    expect(formattedData[1].administration.name).toBeNull()
+    expect(formattedData[1].administrationId).toBeUndefined()
   })
   test('filters out resources without a path', () => {
     const formattedData = formatter(mockResourcesWithAdmin)

--- a/src/data/queries/vamcSystem.ts
+++ b/src/data/queries/vamcSystem.ts
@@ -19,6 +19,7 @@ import { Menu } from '@/types/drupal/menu'
 import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
 import { PAGE_SIZES } from '@/lib/constants/pageSizes'
 import { queries } from '.'
+import { getAdministrationId } from './administration'
 
 // Define the query params for fetching node--vamc_system.
 export const params: QueryParams<null> = () => {
@@ -95,10 +96,7 @@ export const formatter: QueryFormatter<VamcSystemData, VamcSystem> = ({
     title: entity.title,
     introText: entity.field_intro_text,
     image: formatImage(entity.field_media),
-    administration: {
-      id: entity.field_administration?.drupal_internal__tid || null,
-      name: entity.field_administration?.name || null,
-    },
+    administrationId: getAdministrationId(entity.field_administration),
     path: entity.path.alias,
     menu: formattedMenu,
     mainFacilities: mainFacilities.map((facility) => ({

--- a/src/lib/drupal/lovell/constants.ts
+++ b/src/lib/drupal/lovell/constants.ts
@@ -3,28 +3,19 @@ import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 export const LOVELL = {
   federal: {
     title: 'Lovell Federal health care',
-    administration: {
-      id: 347,
-      name: 'Lovell Federal health care',
-    },
+    administrationId: 347,
     pathSegment: 'lovell-federal-health-care',
     variant: 'federal',
   },
   tricare: {
     title: 'Lovell Federal health care - TRICARE',
-    administration: {
-      id: 1039,
-      name: 'Lovell - TRICARE',
-    },
+    administrationId: 1039,
     pathSegment: 'lovell-federal-health-care-tricare',
     variant: 'tricare',
   },
   va: {
     title: 'Lovell Federal health care - VA',
-    administration: {
-      id: 1040,
-      name: 'Lovell - VA',
-    },
+    administrationId: 1040,
     pathSegment: 'lovell-federal-health-care-va',
     variant: 'va',
   },

--- a/src/lib/drupal/lovell/staticPaths.ts
+++ b/src/lib/drupal/lovell/staticPaths.ts
@@ -12,7 +12,7 @@ export function getLovellVariantOfStaticPathResource(
 ): StaticPathResource {
   return {
     path: getLovellVariantOfUrl(resource.path, LOVELL[variant].variant),
-    administration: LOVELL[variant].administration,
+    administrationId: LOVELL[variant].administrationId,
   }
 }
 

--- a/src/lib/drupal/lovell/staticProps.ts
+++ b/src/lib/drupal/lovell/staticProps.ts
@@ -85,7 +85,7 @@ export function getLovellChildVariantOfResource(
             path: variantPaths[variant],
           }
         : { path: '', title: '' },
-    administration: LOVELL[variant].administration,
+    administrationId: LOVELL[variant].administrationId,
     listing:
       'listing' in resource && resource.listing
         ? getLovellVariantOfUrl(resource.listing, variant)

--- a/src/lib/drupal/lovell/tests/mockData.ts
+++ b/src/lib/drupal/lovell/tests/mockData.ts
@@ -20,25 +20,22 @@ export const otherSlug = ['some-other-health-care', 'stories', 'story-1']
 
 export const lovellFederalResource = {
   path: slugToPath(lovellFederalSlug),
-  administration: LOVELL.federal.administration,
+  administrationId: LOVELL.federal.administrationId,
 }
 
 export const lovellTricareResource = {
   path: slugToPath(lovellTricareSlug),
-  administration: LOVELL.tricare.administration,
+  administrationId: LOVELL.tricare.administrationId,
 }
 
 export const lovellVaResource = {
   path: slugToPath(lovellVaSlug),
-  administration: LOVELL.va.administration,
+  administrationId: LOVELL.va.administrationId,
 }
 
 export const otherResource = {
   path: slugToPath(otherSlug),
-  administration: {
-    id: 123,
-    name: 'Some Other health care',
-  },
+  administrationId: 123,
 }
 
 export const newsStoryPartialResource = {

--- a/src/lib/drupal/lovell/tests/staticPaths.test.ts
+++ b/src/lib/drupal/lovell/tests/staticPaths.test.ts
@@ -19,7 +19,7 @@ import {
 describe('getLovellVariantOfStaticPathResource', () => {
   const resource = {
     path: `/${LOVELL.va.pathSegment}/stories`,
-    administration: LOVELL.va.administration,
+    administrationId: LOVELL.va.administrationId,
   }
 
   test('should return resource adjusted for federal variant', () => {
@@ -29,7 +29,7 @@ describe('getLovellVariantOfStaticPathResource', () => {
     )
     expect(result).toStrictEqual({
       path: `/${LOVELL.federal.pathSegment}/stories`,
-      administration: LOVELL.federal.administration,
+      administrationId: LOVELL.federal.administrationId,
     })
   })
 
@@ -40,7 +40,7 @@ describe('getLovellVariantOfStaticPathResource', () => {
     )
     expect(result).toStrictEqual({
       path: `/${LOVELL.tricare.pathSegment}/stories`,
-      administration: LOVELL.tricare.administration,
+      administrationId: LOVELL.tricare.administrationId,
     })
   })
 

--- a/src/lib/drupal/lovell/tests/utils.test.ts
+++ b/src/lib/drupal/lovell/tests/utils.test.ts
@@ -384,7 +384,7 @@ describe('isLovellBifurcatedResource', () => {
     const bifurcatedResource = {
       ...newsStoryPartialResource,
       entityPath: lovellVaResource.path,
-      administration: LOVELL.federal.administration,
+      administrationId: LOVELL.federal.administrationId,
     }
     const result = isLovellBifurcatedResource(bifurcatedResource)
     expect(result).toBe(true)
@@ -394,7 +394,7 @@ describe('isLovellBifurcatedResource', () => {
     const tricareResource = {
       ...newsStoryPartialResource,
       entityPath: lovellTricareResource.path,
-      administration: lovellTricareResource.administration,
+      administrationId: lovellTricareResource.administrationId,
     }
     const result = isLovellBifurcatedResource(tricareResource)
     expect(result).toBe(false)
@@ -404,7 +404,7 @@ describe('isLovellBifurcatedResource', () => {
     const vaResource = {
       ...newsStoryPartialResource,
       entityPath: lovellVaResource.path,
-      administration: lovellVaResource.administration,
+      administrationId: lovellVaResource.administrationId,
     }
     const result = isLovellBifurcatedResource(vaResource)
     expect(result).toBe(false)
@@ -414,7 +414,7 @@ describe('isLovellBifurcatedResource', () => {
     const someOtherResource = {
       ...newsStoryPartialResource,
       entityPath: otherResource.path,
-      administration: otherResource.administration,
+      administrationId: otherResource.administrationId,
     }
     const result = isLovellBifurcatedResource(someOtherResource)
     expect(result).toBe(false)

--- a/src/lib/drupal/lovell/utils.ts
+++ b/src/lib/drupal/lovell/utils.ts
@@ -32,24 +32,24 @@ export function isLovellFederalResource(
   resource: LovellFormattedResource | StaticPathResource
 ): boolean {
   return (
-    'administration' in resource &&
-    resource?.administration?.id === LOVELL.federal.administration.id
+    'administrationId' in resource &&
+    resource?.administrationId === LOVELL.federal.administrationId
   )
 }
 export function isLovellTricareResource(
   resource: LovellFormattedResource | StaticPathResource
 ): boolean {
   return (
-    'administration' in resource &&
-    resource?.administration?.id === LOVELL.tricare.administration.id
+    'administrationId' in resource &&
+    resource?.administrationId === LOVELL.tricare.administrationId
   )
 }
 export function isLovellVaResource(
   resource: LovellFormattedResource | StaticPathResource
 ): boolean {
   return (
-    'administration' in resource &&
-    resource?.administration?.id === LOVELL.va.administration.id
+    'administrationId' in resource &&
+    resource?.administrationId === LOVELL.va.administrationId
   )
 }
 export function isLovellResource(

--- a/src/products/event/__snapshots__/query.test.ts.snap
+++ b/src/products/event/__snapshots__/query.test.ts.snap
@@ -11,10 +11,8 @@ exports[`node--event formatData outputs formatted data 1`] = `
     "langcode": "en",
     "locality": "Urbandale",
   },
-  "administration": {
-    "id": null,
-    "name": null,
-  },
+  "administrationId": undefined,
+  "administrationName": undefined,
   "body": {
     "format": "rich_text",
     "processed": "<p>Pickleball Club</p>

--- a/src/products/event/formatted-type.ts
+++ b/src/products/event/formatted-type.ts
@@ -10,7 +10,6 @@ import {
   SocialLinksProps,
   FieldLink,
 } from '@/types/drupal/field_type'
-import { Administration } from '@/types/formatted/administration'
 
 interface DateTimeRangeItem {
   value: string
@@ -50,7 +49,8 @@ export type Event = PublishedEntity & {
   description: string
   link: Link | null
   urlOfOnlineEvent: FieldLink
-  administration: Administration
+  administrationId: number | null
+  administrationName: string | null
 }
 
 // export type EventTeaser = PublishedEntity & {

--- a/src/products/event/query.ts
+++ b/src/products/event/query.ts
@@ -15,6 +15,7 @@ import {
 } from '@/lib/drupal/query'
 import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 import { getNestedIncludes } from '@/lib/utils/queries'
+import { getAdministrationId } from '@/data/queries/administration'
 
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
@@ -72,9 +73,7 @@ export const formatter: QueryFormatter<NodeEvent, Event> = (
     description: entity.field_description,
     link: entity.field_link,
     urlOfOnlineEvent: entity.field_url_of_an_online_event,
-    administration: {
-      id: entity.field_administration?.drupal_internal__tid || null,
-      name: entity.field_administration?.name || null,
-    },
+    administrationId: getAdministrationId(entity.field_administration),
+    administrationName: entity.field_administration?.name,
   }
 }

--- a/src/products/event/template.test.tsx
+++ b/src/products/event/template.test.tsx
@@ -114,10 +114,8 @@ const data = {
       },
     },
   },
-  administration: {
-    id: 0,
-    name: '',
-  },
+  administrationId: 0,
+  administrationName: '',
 }
 
 describe('<Event /> Component', () => {
@@ -174,10 +172,8 @@ describe('<Event /> Component', () => {
       value: '<p>Event Body</p>',
       format: 'text',
     },
-    administration: {
-      id: 0,
-      name: '',
-    },
+    administrationId: 0,
+    administrationName: '',
   }
 
   beforeEach(() => {
@@ -267,10 +263,8 @@ describe('<Event /> Component', () => {
       render(
         <Event
           {...data}
-          administration={{
-            id: 1,
-            name: 'Test Administration',
-          }}
+          administrationId={1}
+          administrationName="Test Administration"
           listing="/test-listing"
           listingOffice="Test Office"
         />

--- a/src/products/event/template.tsx
+++ b/src/products/event/template.tsx
@@ -28,7 +28,8 @@ export const Event = ({
   cost,
   registrationRequired,
   socialLinks,
-  administration,
+  administrationId,
+  administrationName,
   link,
   additionalInfo,
   eventCTA,
@@ -330,9 +331,9 @@ export const Event = ({
         <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--0">
           Other VA events
         </h2>
-        {administration?.id != 7 &&
+        {administrationId != 7 &&
           listingOffice != 'Outreach and events' &&
-          administration?.name && (
+          administrationName && (
             <p>
               <va-link
                 href={listing}
@@ -340,7 +341,7 @@ export const Event = ({
                   recordEvent({ event: 'nav-secondary-button-click' })
                 }
                 id="see-more-events"
-                text={`Browse the ${administration.name} events calendar`}
+                text={`Browse the ${administrationName} events calendar`}
               ></va-link>
             </p>
           )}

--- a/src/templates/components/topTasks/index.test.tsx
+++ b/src/templates/components/topTasks/index.test.tsx
@@ -1,7 +1,6 @@
+import { LOVELL } from '@/lib/drupal/lovell/constants'
 import { TopTasks, _topTaskLovellComp } from './index'
 import { render } from '@testing-library/react'
-
-const lovellAdministration = { entityId: 1039 }
 
 describe('TopTasks', () => {
   it('should render the normal links', () => {
@@ -26,7 +25,7 @@ describe('TopTasks', () => {
       <TopTasks
         path="/test-nav-path"
         vamcEhrSystem="cerner"
-        administration={{ entityId: 1039 }}
+        administrationId={LOVELL.tricare.administrationId}
       />
     )
     expect(
@@ -43,7 +42,7 @@ describe('TopTasks', () => {
         /* @ts-expect-error Shouldn't happen, but just in case... */
         vamcEhrSystem=""
         office={{ vamcEhrSystem: 'cerner' }}
-        administration={{ entityId: 1039 }}
+        administrationId={LOVELL.tricare.administrationId}
       />
     )
     expect(
@@ -62,7 +61,7 @@ describe('TopTasks', () => {
         /* @ts-expect-error Shouldn't happen, but just in case... */
         office={{ vamcEhrSystem: '' }}
         regionPage={{ vamcEhrSystem: 'cerner' }}
-        administration={{ entityId: 1039 }}
+        administrationId={LOVELL.tricare.administrationId}
       />
     )
     expect(
@@ -90,7 +89,7 @@ describe('topTaskLovellComp', () => {
     isProd: true,
     linkType: 'make-an-appointment',
     path: '/test-nav-path',
-    administration: lovellAdministration,
+    administrationId: LOVELL.tricare.administrationId,
     ...cerner,
   }
   const mhsLink = {
@@ -160,7 +159,7 @@ describe('topTaskLovellComp', () => {
     expect(
       _topTaskLovellComp({
         ...mhsLinkData,
-        administration: { entityId: 1040 }, // Lovell is 1039
+        administrationId: LOVELL.va.administrationId,
       })
     ).toEqual(normalLink)
   })

--- a/src/templates/components/topTasks/index.tsx
+++ b/src/templates/components/topTasks/index.tsx
@@ -1,3 +1,4 @@
+import { LOVELL } from '@/lib/drupal/lovell/constants'
 import { VamcEhr } from '@/types/drupal/vamcEhr'
 
 type VamcEhrSystem = VamcEhr['field_region_page']['field_vamc_ehr_system']
@@ -5,7 +6,7 @@ type VamcEhrSystem = VamcEhr['field_region_page']['field_vamc_ehr_system']
 type TopTasksProps = {
   path: string
   vamcEhrSystem: VamcEhrSystem
-  administration?: { entityId: number }
+  administrationId?: number
   regionPage?: { vamcEhrSystem: VamcEhrSystem }
   office?: { vamcEhrSystem: VamcEhrSystem }
 }
@@ -17,7 +18,7 @@ type TopTasksProps = {
  */
 export const TopTasks = ({
   path,
-  administration,
+  administrationId,
   vamcEhrSystem,
   regionPage,
   office,
@@ -29,7 +30,7 @@ export const TopTasks = ({
   const topTask = topTaskLovellComp({
     linkType: 'make-an-appointment',
     path: slashPath,
-    administration,
+    administrationId,
     vamcEhrSystem,
     regionPage,
     office,
@@ -70,7 +71,7 @@ export const TopTasks = ({
 const topTaskLovellComp = ({
   linkType,
   path,
-  administration,
+  administrationId,
   vamcEhrSystem,
   regionPage,
   office,
@@ -85,7 +86,7 @@ const topTaskLovellComp = ({
     isProd,
     linkType,
     path,
-    administration,
+    administrationId,
     vamcEhrSystem,
     regionPage,
     office,
@@ -100,7 +101,7 @@ export const _topTaskLovellComp = ({
   isProd,
   linkType,
   path,
-  administration,
+  administrationId,
   vamcEhrSystem,
   regionPage,
   office,
@@ -111,7 +112,7 @@ export const _topTaskLovellComp = ({
   const flag =
     vamcEhrSystem || office?.vamcEhrSystem || regionPage?.vamcEhrSystem || ''
 
-  const isPageLovell = administration?.entityId === 1039
+  const isPageLovell = administrationId === LOVELL.tricare.administrationId
 
   if (
     (flag === 'cerner' || (flag === 'cerner_staged' && !isProd)) &&

--- a/src/templates/layouts/healthCareLocalFacility/index.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.tsx
@@ -32,7 +32,7 @@ export function HealthCareLocalFacility({
   operatingStatusFacility,
   menu,
   path,
-  administration,
+  administrationId,
   vamcEhrSystem,
   officeHours,
   address,
@@ -115,7 +115,7 @@ export function HealthCareLocalFacility({
 
             <TopTasks
               path={regionBasePath}
-              administration={administration}
+              administrationId={administrationId}
               vamcEhrSystem={vamcEhrSystem}
             />
 

--- a/src/templates/layouts/newsStory/index.test.tsx
+++ b/src/templates/layouts/newsStory/index.test.tsx
@@ -51,10 +51,7 @@ const data = {
     title: 'We honor outstanding doctors',
   },
   listing: '/pittsburgh-health-care/stories',
-  administration: {
-    id: 12,
-    name: 'VA Pittsburgh health care',
-  },
+  administrationId: 12,
   metatags: [
     {
       attributes: {

--- a/src/templates/layouts/pressRelease/index.test.tsx
+++ b/src/templates/layouts/pressRelease/index.test.tsx
@@ -1,8 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { PressRelease } from './index'
-import { getByText } from '@testing-library/react'
 import { fireEvent } from '@testing-library/react'
-import { getByTestId } from '@testing-library/dom'
 
 const contacts = [
   {
@@ -89,10 +87,7 @@ const data = {
   contacts: contacts,
   downloads: downloads,
   listing: '/wilmington-health-care/news-releases',
-  administration: {
-    id: 0,
-    name: '',
-  },
+  administrationId: 0,
   office: undefined,
 }
 

--- a/src/templates/layouts/vamcSystem/index.test.tsx
+++ b/src/templates/layouts/vamcSystem/index.test.tsx
@@ -6,6 +6,7 @@ import { VamcSystem } from './index'
 import { VamcSystem as FormattedVamcSystem } from '@/types/formatted/vamcSystem'
 import { formatter } from '@/data/queries/vamcSystem'
 import { DrupalMenuLinkContent } from 'next-drupal'
+import { LOVELL } from '@/lib/drupal/lovell/constants'
 
 const menuItem: DrupalMenuLinkContent = {
   title: 'Foo',
@@ -75,7 +76,7 @@ describe('VamcSystem with valid data', () => {
     render(
       <VamcSystem
         {...mockData}
-        administration={{ ...mockData.administration, id: 1039 }}
+        administrationId={LOVELL.tricare.administrationId}
       />
     )
     expect(
@@ -85,10 +86,7 @@ describe('VamcSystem with valid data', () => {
 
   test('uses an alternate title for the administration section if the administration is 1040', () => {
     render(
-      <VamcSystem
-        {...mockData}
-        administration={{ ...mockData.administration, id: 1040 }}
-      />
+      <VamcSystem {...mockData} administrationId={LOVELL.va.administrationId} />
     )
     expect(screen.getByText('Manage your VA health online')).toBeInTheDocument()
   })

--- a/src/templates/layouts/vamcSystem/index.tsx
+++ b/src/templates/layouts/vamcSystem/index.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react'
 import { SideNavMenu } from '@/types/formatted/sideNav'
 import { FacilityListing } from '@/templates/components/facilityListing'
 import { RelatedLinks } from '@/templates/common/relatedLinks'
+import { LOVELL } from '@/lib/drupal/lovell/constants'
 // import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
 // import { TopTasks } from '@/templates/components/topTasks'
 // import { FacilityListing } from '@/templates/components/facilityListing'
@@ -14,9 +15,6 @@ import { RelatedLinks } from '@/templates/common/relatedLinks'
 // import { NewsStoryTeaser } from '@/templates/components/newsStoryTeaser'
 // import { EventTeaser } from '@/templates/components/eventTeaser'
 // import { SocialLinks } from '@/templates/common/socialLinks'
-
-const LOVELL_TRICARE_ADMINISTRATION_ID = 1039
-const LOVELL_VA_ADMINISTRATION_ID = 1040
 
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
@@ -28,7 +26,7 @@ export function VamcSystem({
   title,
   introText,
   image,
-  administration,
+  administrationId,
   path,
   menu,
   // vamcEhrSystem,
@@ -95,10 +93,10 @@ export function VamcSystem({
             </section>
 
             {/* Manage your health online section */}
-            {administration?.id !== LOVELL_TRICARE_ADMINISTRATION_ID && (
+            {administrationId !== LOVELL.tricare.administrationId && (
               <section>
                 <h2>
-                  {administration?.id === LOVELL_VA_ADMINISTRATION_ID
+                  {administrationId === LOVELL.va.administrationId
                     ? 'Manage your VA health online'
                     : 'Manage your health online'}
                 </h2>

--- a/src/types/formatted/administration.ts
+++ b/src/types/formatted/administration.ts
@@ -1,4 +1,0 @@
-export type Administration = {
-  id: number
-  name: string
-}

--- a/src/types/formatted/healthCareLocalFacility.ts
+++ b/src/types/formatted/healthCareLocalFacility.ts
@@ -18,7 +18,7 @@ export type HealthCareLocalFacility = PublishedEntity & {
   operatingStatusFacility: FacilityOperatingStatusFlags
   menu: SideNavMenu | null
   path: string
-  administration?: { entityId: number }
+  administrationId?: number
   vamcEhrSystem: VamcEhr['field_region_page']['field_vamc_ehr_system']
   officeHours: FieldOfficeHours[]
   address: FieldAddress

--- a/src/types/formatted/newsStory.ts
+++ b/src/types/formatted/newsStory.ts
@@ -1,7 +1,6 @@
 import { ComponentType } from 'react'
 import { PersonProfileTeaserProps } from '@/templates/components/staffNewsProfile'
 import { SocialLinksProps } from '@/types/drupal/field_type'
-import { Administration } from '@/types/formatted/administration'
 import { PublishedEntity } from './publishedEntity'
 import { MediaImage } from './media'
 
@@ -21,5 +20,5 @@ export type NewsStory = PublishedEntity & {
   date: string
   socialLinks: SocialLinksProps
   listing: string
-  administration: Administration
+  administrationId: number
 }

--- a/src/types/formatted/pressRelease.ts
+++ b/src/types/formatted/pressRelease.ts
@@ -1,7 +1,6 @@
 import { ComponentType } from 'react'
 import { PublishedEntity } from './publishedEntity'
 import { FieldAddress } from '../drupal/field_type'
-import { Administration } from './administration'
 import { PressContact } from './contactInfo'
 
 export type PressReleaseTeaser = PublishedEntity & {
@@ -29,5 +28,5 @@ export type PressRelease = PublishedEntity & {
   contacts: PressContact[]
   downloads: PressReleaseDownload[]
   listing: string
-  administration: Administration
+  administrationId: number
 }

--- a/src/types/formatted/staticPathResource.ts
+++ b/src/types/formatted/staticPathResource.ts
@@ -1,6 +1,4 @@
-import { Administration } from './administration'
-
 export type StaticPathResource = {
   path: string
-  administration: Administration
+  administrationId: number
 }

--- a/src/types/formatted/vamcSystem.ts
+++ b/src/types/formatted/vamcSystem.ts
@@ -1,6 +1,4 @@
-import { ParagraphListOfLinks } from '@/types/drupal/paragraph'
 import { MediaImage } from '@/types/formatted/media'
-import { Administration } from '@/types/formatted/administration'
 import { SideNavMenu } from '@/types/formatted/sideNav'
 import { PublishedEntity } from './publishedEntity'
 import { HealthCareLocalFacility } from './healthCareLocalFacility'
@@ -22,7 +20,7 @@ export type VamcSystem = PublishedEntity & {
   title: string
   introText: string
   image: MediaImage
-  administration: Administration
+  administrationId: number
   menu: SideNavMenu
   path: string
   mainFacilities: MinimalLocalFacility[]


### PR DESCRIPTION
# Description

[Context here](https://github.com/department-of-veterans-affairs/next-build/pull/1040#discussion_r2103388274)

We were inconsistently referencing and using `field_administration` data in our various content types and components, and this aims to make it consistent and simplify it.

## Ticket

Related to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21250