### PR TITLE
VACMS-20871: Police menu and markup

### DIFF
--- a/src/data/queries/tests/__snapshots__/vamcSystemVaPolice.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/vamcSystemVaPolice.test.tsx.snap
@@ -28,6 +28,10 @@ exports[`VamcSystemVaPolice formatData outputs formatted data 1`] = `
   "entityPath": "/central-arkansas-health-care/va-police",
   "id": "7833b254-f4e4-4adb-bce1-d72d5e337c1e",
   "lastUpdated": "2023-12-20T21:57:55+00:00",
+  "menu": {
+    "data": null,
+    "rootPath": "/central-arkansas-health-care/va-police/",
+  },
   "metatags": [
     {
       "attributes": {
@@ -108,6 +112,7 @@ exports[`VamcSystemVaPolice formatData outputs formatted data 1`] = `
     },
   ],
   "moderationState": "published",
+  "path": "/central-arkansas-health-care/va-police",
   "published": true,
   "title": "VA police",
   "type": "node--vamc_system_va_police",

--- a/src/data/queries/tests/vamcSystemVaPolice.test.tsx
+++ b/src/data/queries/tests/vamcSystemVaPolice.test.tsx
@@ -1,25 +1,26 @@
-import { NodeVamcSystemVaPolice } from '@/types/drupal/node'
+/**
+ * @jest-environment node
+ */
+
 import { queries } from '@/data/queries'
 import mockData from '@/mocks/vamcSystemVaPolice.mock.json'
+import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes' // Import RESOURCE_TYPES
 
-const VamcSystemVaPoliceMock: NodeVamcSystemVaPolice = mockData
+jest.mock('@/lib/drupal/query', () => ({
+  ...jest.requireActual('@/lib/drupal/query'),
+  fetchSingleEntityOrPreview: () => mockData, // Mock fetchSingleEntityOrPreview
+  getMenu: () => ({
+    items: [],
+    tree: [],
+  }),
+}))
 
 describe('VamcSystemVaPolice formatData', () => {
-  let windowSpy
-
-  beforeEach(() => {
-    windowSpy = jest.spyOn(window, 'window', 'get')
-  })
-
-  afterEach(() => {
-    windowSpy.mockRestore()
-  })
-
-  test('outputs formatted data', () => {
-    windowSpy.mockImplementation(() => undefined)
-
-    expect(
-      queries.formatData('node--vamc_system_va_police', VamcSystemVaPoliceMock)
-    ).toMatchSnapshot()
+  test('outputs formatted data', async () => {
+    const result = await queries.getData(
+      RESOURCE_TYPES.VAMC_SYSTEM_VA_POLICE, // Use the correct resource type
+      { id: mockData.id }
+    )
+    expect(result).toMatchSnapshot()
   })
 })

--- a/src/data/queries/vamcSystemVaPolice.ts
+++ b/src/data/queries/vamcSystemVaPolice.ts
@@ -8,17 +8,20 @@ import { ExpandedStaticPropsContext } from '@/lib/drupal/staticProps'
 import {
   entityBaseFields,
   fetchSingleEntityOrPreview,
+  getMenu,
 } from '@/lib/drupal/query'
+import { Menu } from '@/types/drupal/menu'
+import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
+import util from 'util'
+import fs from 'fs'
+import { en } from '@faker-js/faker/.'
 
 // Define the query params for fetching node--vamc_system_va_police.
 export const params: QueryParams<null> = () => {
-  return new DrupalJsonApiParams()
-  // uncomment to add referenced entity data to the response
-  // .addInclude([
-  //  'field_media',
-  //  'field_media.image',
-  //  'field_administration',
-  // ])
+  return new DrupalJsonApiParams().addInclude([
+    'field_administration',
+    'field_office',
+  ])
 }
 
 // Define the option types for the data loader.
@@ -27,25 +30,50 @@ export type VamcSystemVaPoliceDataOpts = {
   context?: ExpandedStaticPropsContext
 }
 
+type VamcSystemVaPoliceData = {
+  entity: NodeVamcSystemVaPolice
+  menu: Menu | null
+}
+
 // Implement the data loader.
 export const data: QueryData<
   VamcSystemVaPoliceDataOpts,
-  NodeVamcSystemVaPolice
-> = async (opts): Promise<NodeVamcSystemVaPolice> => {
+  VamcSystemVaPoliceData
+> = async (opts): Promise<VamcSystemVaPoliceData> => {
   const entity = (await fetchSingleEntityOrPreview(
     opts,
     RESOURCE_TYPES.VAMC_SYSTEM_VA_POLICE,
     params
   )) as NodeVamcSystemVaPolice
 
-  return entity
+  if (!entity) {
+    throw new Error(`NodeVamcSystemVaPolice entity not found for id: ${opts.id}`)
+  }
+
+  // Fetch the menu name dynamically off of the field_office reference
+  const menu = entity.field_office.field_system_menu
+    ? await getMenu(
+        entity.field_office.field_system_menu.resourceIdObjMeta
+          ?.drupal_internal__target_id
+      )
+    : null
+
+  return { entity, menu }
 }
 
-export const formatter: QueryFormatter<
-  NodeVamcSystemVaPolice,
-  VamcSystemVaPolice
-> = (entity: NodeVamcSystemVaPolice) => {
+export const formatter: QueryFormatter<VamcSystemVaPoliceData, VamcSystemVaPolice> = ({
+  entity,
+  menu,
+}) => {
+  const formattedMenu = buildSideNavDataFromMenu(entity.path.alias, menu)
   return {
     ...entityBaseFields(entity),
+    title: entity.title,
+    // administration: {
+    //   id: entity.field_administration?.drupal_internal__tid || null,
+    //   title: entity.field_administration?.name || null,
+    // },
+    path: entity.path.alias,
+    menu: formattedMenu,
   }
 }

--- a/src/data/queries/vamcSystemVaPolice.ts
+++ b/src/data/queries/vamcSystemVaPolice.ts
@@ -12,8 +12,7 @@ import {
 } from '@/lib/drupal/query'
 import { Menu } from '@/types/drupal/menu'
 import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
-import util from 'util'
-import fs from 'fs'
+
 
 // Define the query params for fetching node--vamc_system_va_police.
 export const params: QueryParams<null> = () => {

--- a/src/data/queries/vamcSystemVaPolice.ts
+++ b/src/data/queries/vamcSystemVaPolice.ts
@@ -14,7 +14,6 @@ import { Menu } from '@/types/drupal/menu'
 import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
 import util from 'util'
 import fs from 'fs'
-import { en } from '@faker-js/faker/.'
 
 // Define the query params for fetching node--vamc_system_va_police.
 export const params: QueryParams<null> = () => {
@@ -47,7 +46,9 @@ export const data: QueryData<
   )) as NodeVamcSystemVaPolice
 
   if (!entity) {
-    throw new Error(`NodeVamcSystemVaPolice entity not found for id: ${opts.id}`)
+    throw new Error(
+      `NodeVamcSystemVaPolice entity not found for id: ${opts.id}`
+    )
   }
 
   // Fetch the menu name dynamically off of the field_office reference
@@ -61,10 +62,10 @@ export const data: QueryData<
   return { entity, menu }
 }
 
-export const formatter: QueryFormatter<VamcSystemVaPoliceData, VamcSystemVaPolice> = ({
-  entity,
-  menu,
-}) => {
+export const formatter: QueryFormatter<
+  VamcSystemVaPoliceData,
+  VamcSystemVaPolice
+> = ({ entity, menu }) => {
   const formattedMenu = buildSideNavDataFromMenu(entity.path.alias, menu)
   return {
     ...entityBaseFields(entity),

--- a/src/data/queries/vamcSystemVaPolice.ts
+++ b/src/data/queries/vamcSystemVaPolice.ts
@@ -13,7 +13,6 @@ import {
 import { Menu } from '@/types/drupal/menu'
 import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
 
-
 // Define the query params for fetching node--vamc_system_va_police.
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([

--- a/src/mocks/vamcSystemVaPolice.mock.json
+++ b/src/mocks/vamcSystemVaPolice.mock.json
@@ -579,12 +579,20 @@
       "field_product"
     ]
   },
+  "field_system_menu": {
+    "type": "menu--menu",
+    "id": "512f53dd-3006-43db-93ab-9257f39869f6",
+    "resourceIdObjMeta": {
+      "drupal_internal__target_id": "va-central-arkansas-health-care"
+    }
+  },
   "relationshipNames": [
     "node_type",
     "revision_uid",
     "uid",
     "field_office",
     "field_phone_numbers_paragraph",
-    "field_administration"
+    "field_administration",
+    "field_system_menu"
   ]
 }

--- a/src/templates/layouts/vamcSystemVaPolice/index.test.tsx
+++ b/src/templates/layouts/vamcSystemVaPolice/index.test.tsx
@@ -35,15 +35,11 @@ const mockData = formatter({
   menu: mockMenu,
 })
 
-
-
 describe('VamcSystemVaPolice with valid data', () => {
   test('renders VamcSystemVaPolice component', () => {
     render(<VamcSystemVaPolice {...mockData} />)
 
-    const basicDataFields: Array<keyof FormattedVamcSystemVaPolice> = [
-      'title',
-    ]
+    const basicDataFields: Array<keyof FormattedVamcSystemVaPolice> = ['title']
     basicDataFields.forEach((key) =>
       expect(screen.getByText(mockData[key])).toBeInTheDocument()
     )
@@ -55,5 +51,4 @@ describe('VamcSystemVaPolice with valid data', () => {
     // we're adding it
     expect(window.sideNav).toEqual(mockData.menu)
   })
-
 })

--- a/src/templates/layouts/vamcSystemVaPolice/index.test.tsx
+++ b/src/templates/layouts/vamcSystemVaPolice/index.test.tsx
@@ -1,11 +1,59 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+import drupalMockData from '@/mocks/vamcSystemVaPolice.mock.json'
 import { VamcSystemVaPolice } from './index'
+import { VamcSystemVaPolice as FormattedVamcSystemVaPolice } from '@/types/formatted/vamcSystemVaPolice'
+import { formatter } from '@/data/queries/vamcSystemVaPolice'
+import { DrupalMenuLinkContent } from 'next-drupal'
+
+const menuItem: DrupalMenuLinkContent = {
+  title: 'Foo',
+  type: 'meh',
+  url: '/nowhere/in-particular',
+  id: 'foo',
+  description: 'bar',
+  enabled: true,
+  expanded: true,
+  menu_name: 'baz',
+  meta: {},
+  options: {},
+  parent: null,
+  provider: null,
+  route: null,
+  weight: '0',
+}
+
+const mockMenu = {
+  items: [menuItem],
+  tree: [menuItem],
+}
+
+const mockData = formatter({
+  // drupalMockData technically has numbers instead of strings
+  // for some of the IDs, but this is a known problem.
+  entity: drupalMockData,
+  menu: mockMenu,
+})
+
+
 
 describe('VamcSystemVaPolice with valid data', () => {
   test('renders VamcSystemVaPolice component', () => {
-    render(<VamcSystemVaPolice title={'Hello world'} />)
+    render(<VamcSystemVaPolice {...mockData} />)
 
-    expect(screen.queryByText(/Hello world/)).toBeInTheDocument()
+    const basicDataFields: Array<keyof FormattedVamcSystemVaPolice> = [
+      'title',
+    ]
+    basicDataFields.forEach((key) =>
+      expect(screen.getByText(mockData[key])).toBeInTheDocument()
+    )
   })
+  test('adds the sideNav to window.sideNav', () => {
+    render(<VamcSystemVaPolice {...mockData} />)
+
+    // @ts-expect-error - window.sideNav is not a default window property, but
+    // we're adding it
+    expect(window.sideNav).toEqual(mockData.menu)
+  })
+
 })

--- a/src/templates/layouts/vamcSystemVaPolice/index.tsx
+++ b/src/templates/layouts/vamcSystemVaPolice/index.tsx
@@ -1,11 +1,40 @@
+import { VamcSystemVaPolice as FormattedVamcSystemVaPolice } from "@/types/formatted/vamcSystemVaPolice"
+import { ContentFooter } from "@/templates/common/contentFooter"
+import { useEffect } from "react"
+import { SideNavMenu } from "@/types/formatted/sideNav"
+
 type VamcSystemVaPoliceProps = {
   title: string
 }
 
-export function VamcSystemVaPolice({ title }: VamcSystemVaPoliceProps) {
+// Allows additions to window object without overwriting global type
+interface customWindow extends Window {
+  sideNav?: SideNavMenu
+}
+declare const window: customWindow
+
+export function VamcSystemVaPolice({
+  title,
+  path,
+  menu,
+ }: FormattedVamcSystemVaPolice) {
+   useEffect(() => {
+      window.sideNav = menu
+    }, [menu])
+
   return (
-    <div>
-      <p>{title}</p>
+    <div className="va-l-detail-page va-facility-page">
+      <div className="usa-grid usa-grid-full">
+         {/* Nav data fille in by a separate script from `window.sideNav` */}
+        <nav aria-label="secondary" data-widget-type="side-nav" />
+        {/* Main page content */}
+        <div className="usa-width-three-fourths">
+          <article className="usa-content">
+            <h1>{title}</h1>
+          </article>
+        </div>
+      </div>
     </div>
+
   )
 }

--- a/src/templates/layouts/vamcSystemVaPolice/index.tsx
+++ b/src/templates/layouts/vamcSystemVaPolice/index.tsx
@@ -35,7 +35,7 @@ export function VamcSystemVaPolice({
               PLACEHOLDER INTRO TEXT
             </div>
             {/* Table of Contents */}
-            <va-on-this-page>PLACEHOLDER TABLE OF CONTENTS</va-on-this-page>
+            <va-on-this-page></va-on-this-page>
             {/* How to contact us (field_phone_numbers_paragraph) */}
             <div className="vads-u-margin-bottom--4" id="field-phone-numbers">
               <h2 id="how-to-contact-us-police">How to contact us</h2>

--- a/src/templates/layouts/vamcSystemVaPolice/index.tsx
+++ b/src/templates/layouts/vamcSystemVaPolice/index.tsx
@@ -30,6 +30,39 @@ export function VamcSystemVaPolice({
         <div className="usa-width-three-fourths">
           <article className="usa-content">
             <h1>{title}</h1>
+            {/* Intro text (field_cc_va_police_overview)}
+            <div className="va-introtext vads-u-font-size--lg vads-u-font-family--serif">
+              PLACEHOLDER INTRO TEXT
+            </div>
+            {/* Table of Contents */}
+            <va-on-this-page>PLACEHOLDER TABLE OF CONTENTS</va-on-this-page>
+            {/* How to contact us (field_phone_numbers_paragraph) */}
+            <div className="vads-u-margin-bottom--4" id="field-phone-numbers">
+              <h2 id="how-to-contact-us-police">How to contact us</h2>
+              <p>
+                Use our non-emergency phone number to request more information
+                about VA police at PLACEHOLDER FIELD OFFICE ENTITY TITLE.
+              </p>
+              <p>
+                You can call us at{' '}
+                <va-telephone
+                  contact="PLACEHOLDER phoneNumber.contact"
+                  extension="PLACEHOLDER phoneNumber.extension"
+                ></va-telephone>
+                <span>000-000-00000</span>
+              </p>
+            </div>
+            {/* How to request a VA police report (field_cc_police_report) */}
+            <div
+              className="vads-u-margin-bottom--3"
+              id="field-va-police-reports"
+            >
+              PLACEHOLDER VA POLICE REPORTS
+            </div>
+            {/* Other questions you may have about VA police (field_cc_faq) */}
+            <div className="vads-u-margin-bottom--3" id="field-cc-faq-police">
+              PLACEHOLDER FAQ
+            </div>
           </article>
         </div>
       </div>

--- a/src/templates/layouts/vamcSystemVaPolice/index.tsx
+++ b/src/templates/layouts/vamcSystemVaPolice/index.tsx
@@ -1,7 +1,7 @@
-import { VamcSystemVaPolice as FormattedVamcSystemVaPolice } from "@/types/formatted/vamcSystemVaPolice"
-import { ContentFooter } from "@/templates/common/contentFooter"
-import { useEffect } from "react"
-import { SideNavMenu } from "@/types/formatted/sideNav"
+import { VamcSystemVaPolice as FormattedVamcSystemVaPolice } from '@/types/formatted/vamcSystemVaPolice'
+import { ContentFooter } from '@/templates/common/contentFooter'
+import { useEffect } from 'react'
+import { SideNavMenu } from '@/types/formatted/sideNav'
 
 type VamcSystemVaPoliceProps = {
   title: string
@@ -15,17 +15,16 @@ declare const window: customWindow
 
 export function VamcSystemVaPolice({
   title,
-  path,
   menu,
- }: FormattedVamcSystemVaPolice) {
-   useEffect(() => {
-      window.sideNav = menu
-    }, [menu])
+}: FormattedVamcSystemVaPolice) {
+  useEffect(() => {
+    window.sideNav = menu
+  }, [menu])
 
   return (
     <div className="va-l-detail-page va-facility-page">
       <div className="usa-grid usa-grid-full">
-         {/* Nav data fille in by a separate script from `window.sideNav` */}
+        {/* Nav data fille in by a separate script from `window.sideNav` */}
         <nav aria-label="secondary" data-widget-type="side-nav" />
         {/* Main page content */}
         <div className="usa-width-three-fourths">
@@ -35,6 +34,5 @@ export function VamcSystemVaPolice({
         </div>
       </div>
     </div>
-
   )
 }

--- a/src/types/formatted/vamcSystemVaPolice.ts
+++ b/src/types/formatted/vamcSystemVaPolice.ts
@@ -1,5 +1,11 @@
 import { PublishedEntity } from './publishedEntity'
+import { Administration } from '@/types/formatted/administration'
+import { SideNavMenu } from '@/types/formatted/sideNav'
+
 
 export type VamcSystemVaPolice = PublishedEntity & {
-  title: string
+  title: string,
+  administration: Administration,
+  menu: SideNavMenu,
+  path: string,
 }

--- a/src/types/formatted/vamcSystemVaPolice.ts
+++ b/src/types/formatted/vamcSystemVaPolice.ts
@@ -2,10 +2,8 @@ import { PublishedEntity } from './publishedEntity'
 import { Administration } from '@/types/formatted/administration'
 import { SideNavMenu } from '@/types/formatted/sideNav'
 
-
 export type VamcSystemVaPolice = PublishedEntity & {
-  title: string,
-  administration: Administration,
-  menu: SideNavMenu,
-  path: string,
+  title: string
+  menu: SideNavMenu
+  path: string
 }


### PR DESCRIPTION
# Description

This finishes the scaffolding of VAMC System VA Police page.

## Generated description
This pull request introduces a new feature to support the `VAMC_SYSTEM_VA_POLICE` content type, including its integration into the codebase, test coverage, and feature flag configuration. The changes span multiple files to enable data fetching, formatting, rendering, and testing for this new content type.

### Feature Integration for `VAMC_SYSTEM_VA_POLICE`:

#### Feature Flags:
* Added `FEATURE_NEXT_BUILD_CONTENT_VAMC_SYSTEM_VA_POLICE=true` to `envs/.env.test` and `envs/.env.tugboat` to enable the feature in specific environments. [[1]](diffhunk://#diff-e75bb93390eacf9e914ed4ca735dd499f1ccf7e35263609813f3466952a02595R36) [[2]](diffhunk://#diff-831aaee303b0dc99e20f0f512c2c921d217fd2441d33ee0913caf2d5a88030b7R53)

#### Data Queries and Type Definitions:
* Introduced `vamcSystemVaPolice` query in `src/data/queries/vamcSystemVaPolice.ts` to fetch and format data for the new content type.
* Updated `src/data/queries/index.ts` to include `VamcSystemVaPolice` in imports and the `QUERIES_MAP`. [[1]](diffhunk://#diff-4736203072bd77be64e5041b8727a153d8cb72e7ffec7c999324edb7a43c44d2R49) [[2]](diffhunk://#diff-4736203072bd77be64e5041b8727a153d8cb72e7ffec7c999324edb7a43c44d2R81)
* Added `VAMC_SYSTEM_VA_POLICE` to `RESOURCE_TYPES` and `PAGE_RESOURCE_TYPES` in `src/lib/constants/resourceTypes.ts`. [[1]](diffhunk://#diff-0f166e583f45b572526e9ba231932770bb596a001d8c6ae03b34ac493d3b6048R18) [[2]](diffhunk://#diff-0f166e583f45b572526e9ba231932770bb596a001d8c6ae03b34ac493d3b6048R37)
* Defined types for `NodeVamcSystemVaPolice` and `VamcSystemVaPolice` in `src/types/drupal/node.ts` and `src/types/formatted/vamcSystemVaPolice.ts`. [[1]](diffhunk://#diff-a5035ec5110b73d89f63d6fbe12f3bd0af37cf28d17289acfd0bdb8c0932ccbbR73) [[2]](diffhunk://#diff-a5035ec5110b73d89f63d6fbe12f3bd0af37cf28d17289acfd0bdb8c0932ccbbR434-R437) [[3]](diffhunk://#diff-94935119f478655e4dde9d0b48f56c0501054bf1cc1894f3fea142ca9bf98bb5R1-R9)

#### Rendering and Page Integration:
* Added a new layout component `VamcSystemVaPolice` in `src/templates/layouts/vamcSystemVaPolice/index.tsx` for rendering the content type.
* Updated `src/pages/[[...slug]].tsx` to render `VamcSystemVaPolice` based on the resource type. ([src/pages/[[...slug]].tsxR44](diffhunk://#diff-5f218029560343be88582c198bb3b04e4c18259a5e716a88250afabe4466f957R44), [src/pages/[[...slug]].tsxR63](diffhunk://#diff-5f218029560343be88582c198bb3b04e4c18259a5e716a88250afabe4466f957R63), [src/pages/[[...slug]].tsxR177-R181](diffhunk://#diff-5f218029560343be88582c198bb3b04e4c18259a5e716a88250afabe4466f957R177-R181))

#### Testing and Validation:
* Added unit tests for the query (`vamcSystemVaPolice.test.tsx`) and layout component (`index.test.tsx`) to ensure proper functionality. [[1]](diffhunk://#diff-905bfa1fd5fe109b40c19aba6d1926575f0861c9c8910fd278025d8cecb9679aR1-R26) [[2]](diffhunk://#diff-ae7e3db85ccfbc90acd2f46c21e7ad00e5ad211e9094ba14b20ac943f0f9e2e2R1-R54)
* Created a snapshot test for the data formatting in `vamcSystemVaPolice.test.tsx.snap`.
* Introduced a Playwright test (`vamcSystemVaPolice.spec.js`) for end-to-end validation of the page rendering and accessibility.

#### Storybook Example:
* Added a Storybook story for the `VamcSystemVaPolice` component to facilitate UI testing and development.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/20871

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps
Routes to test (tugboat)
- [Alaska health care](https://pr1047-ugnxgh3xg1qlzudxelvowpfgyoqfdu4z.tugboat.vfs.va.gov/alaska-health-care/va-police/)
- [Eastern Colorado health care](https://pr1047-ugnxgh3xg1qlzudxelvowpfgyoqfdu4z.tugboat.vfs.va.gov/eastern-colorado-health-care/va-police/)
- [Spokane health care](https://pr1047-ugnxgh3xg1qlzudxelvowpfgyoqfdu4z.tugboat.vfs.va.gov/spokane-health-care/va-police/)


## Screenshots

![Screenshot 2025-05-23 at 11 09 37 AM](https://github.com/user-attachments/assets/cca662ca-0728-4034-bfdb-b99972493db9)


---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.