### PR TITLE
Change the label for "Mental health phone" to "Mental health care"

### DIFF
--- a/src/templates/components/facilityListing/index.test.tsx
+++ b/src/templates/components/facilityListing/index.test.tsx
@@ -97,15 +97,15 @@ describe('FacilityListing with valid data', () => {
     )
     expect(healthConnectPhone).toBeInTheDocument()
 
-    // Check mental health phone
-    expect(screen.getByText('Mental health phone:')).toBeInTheDocument()
+    // Check Mental health phone number
+    expect(screen.getByText('Mental health care:')).toBeInTheDocument()
     const mentalHealthPhone = container.querySelector(
       `va-telephone[contact="${mockFacility.fieldTelephone.field_phone_number.replace(/-/g, '')}"]`
     )
     expect(mentalHealthPhone).toBeInTheDocument()
     expect(mentalHealthPhone).toHaveAttribute(
       'message-aria-describedby',
-      'Mental health phone'
+      'Mental health care'
     )
   })
 

--- a/src/templates/layouts/healthCareLocalFacility/Phone.test.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/Phone.test.tsx
@@ -37,7 +37,7 @@ describe('Phone', () => {
       />
     )
 
-    expect(screen.getByText('Mental health phone:')).toBeInTheDocument()
+    expect(screen.getByText('Mental health care:')).toBeInTheDocument()
     const tel = container.querySelector('va-telephone')
     expect(tel).toHaveAttribute('not-clickable')
     expect(tel.getAttribute('contact')).toBe('1234567890')
@@ -69,7 +69,7 @@ describe('Phone', () => {
 
     expect(screen.getByText('Main phone:')).toBeInTheDocument()
     expect(screen.getByText('VA health connect:')).toBeInTheDocument()
-    expect(screen.getByText('Mental health phone:')).toBeInTheDocument()
+    expect(screen.getByText('Mental health care:')).toBeInTheDocument()
 
     // Main phone
     expect(vaTelephoneElements[0].getAttribute('contact')).toBe('1234567890')

--- a/src/templates/layouts/healthCareLocalFacility/Phone.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/Phone.tsx
@@ -40,7 +40,7 @@ export const Phone = ({
           className="vads-u-margin--0"
           {...formatParagraphPhoneNumber(fieldTelephone)}
           // Note that this label is hardcoded for certain node types, like `node--health_care_local_facility`
-          label="Mental health phone"
+          label="Mental health care"
         />
       )}
     </div>

--- a/src/templates/layouts/vamcSystem/index.test.tsx
+++ b/src/templates/layouts/vamcSystem/index.test.tsx
@@ -149,7 +149,7 @@ describe('VamcSystem with valid data', () => {
       // Check for phone numbers
       expect(screen.getByText('Main phone:')).toBeInTheDocument()
       expect(screen.getByText('VA health connect:')).toBeInTheDocument()
-      expect(screen.getByText('Mental health phone:')).toBeInTheDocument()
+      expect(screen.getByText('Mental health care:')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
# Description

Changes the label for "Mental health phone" to "Mental health care". @omahane did a deep dive into Git history and concluded that this was the original label. @mmiddaugh confirmed that this is what it should be.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21251