### PR TITLE
Add repomix config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ certs/VA-mozilla-combined.pem
 # processEnv() stuff
 build_id
 exit_code
+
+# repomix
+*repomix-output.txt

--- a/.repomixignore
+++ b/.repomixignore
@@ -1,0 +1,21 @@
+# Jest snapshots
+*.snap
+
+# Storybook stories
+*.stories.*
+
+# Mock data
+*.mock.*
+src/products/**/mock.js*
+
+# Add the path to the mock file you want to include here.
+# Alternatively, use the --include flag to include specific files:
+# repomix --include src/path/to/my-data.mock.json
+#
+# src/path/to/my-data.mock.json
+
+# Pages unrelated to templates and migrating them
+src/pages/_playground/*
+src/pages/api/*
+src/pages/data/*
+src/pages/demo/*

--- a/.repomixignore
+++ b/.repomixignore
@@ -7,6 +7,7 @@
 # Mock data
 *.mock.*
 src/products/**/mock.js*
+src/mocks/*
 
 # Add the path to the mock file you want to include here.
 # Alternatively, use the --include flag to include specific files:

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -1,0 +1,35 @@
+{
+  "input": {
+    "maxFileSize": 52428800
+  },
+  "output": {
+    "filePath": "next-build-repomix-output.txt",
+    "style": "plain",
+    "parsableStyle": false,
+    "fileSummary": true,
+    "directoryStructure": true,
+    "files": true,
+    "removeComments": false,
+    "removeEmptyLines": false,
+    "compress": false,
+    "topFilesLength": 5,
+    "showLineNumbers": false,
+    "copyToClipboard": false,
+    "git": {
+      "sortByChanges": true,
+      "sortByChangesMaxCommits": 100
+    }
+  },
+  "include": ["src/"],
+  "ignore": {
+    "useGitignore": true,
+    "useDefaultPatterns": true,
+    "customPatterns": []
+  },
+  "security": {
+    "enableSecurityCheck": true
+  },
+  "tokenCount": {
+    "encoding": "o200k_base"
+  }
+}


### PR DESCRIPTION
# Description

Adds a [repomix](https://github.com/yamadashy/repomix) config for plugging into the likes of ChatGPT.

It's a low-hanging fruit for incorporating some AI into template migration and can be useful for things like describing what you need and seeing if there's already an existing component that does what you want. I intend to use it to help out with template migration.