### PR TITLE
Wrap "See all locations" in semantic tag

### DIFF
--- a/src/templates/layouts/vamcSystem/index.tsx
+++ b/src/templates/layouts/vamcSystem/index.tsx
@@ -88,12 +88,13 @@ export function VamcSystem({
                   basePath={path}
                 />
               ))}
-              <va-link
-                active
-                className="vads-u-font-size--md vads-u-display--block vads-u-width--full"
-                href={`${path}/locations`}
-                text="See all locations"
-              ></va-link>
+              <p className="vads-u-margin-y--0">
+                <va-link
+                  active
+                  href={`${path}/locations`}
+                  text="See all locations"
+                ></va-link>
+              </p>
             </section>
 
             {/* Manage your health online section */}


### PR DESCRIPTION
# Description

Wraps the locations link in a `<p>` tag like all the other "See all..." links on the page so it inherits the typography styles.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21425

## Testing Steps



## Screenshots

<img width="1624" alt="Screenshot 2025-06-10 at 5 56 47 PM" src="https://github.com/user-attachments/assets/365702b2-296f-4f04-ba1c-144d34968615" />
