### PR TITLE
No longer release content to dev and staging on merge to main.

### DIFF
--- a/.github/workflows/content-release-dev.yml
+++ b/.github/workflows/content-release-dev.yml
@@ -6,11 +6,6 @@ on:
   # This currently UTC -> EDT.
   schedule:
     - cron: "05 9 * * 1-5"
-  # Runs each time there is a new Production Tag created.
-  workflow_run:
-    workflows: ['Create Production Tag']
-    types: [completed]
-    branches: [main]
 
 concurrency: next-build-content-release-dev
 

--- a/.github/workflows/content-release-staging.yml
+++ b/.github/workflows/content-release-staging.yml
@@ -6,11 +6,6 @@ on:
   # This currently UTC -> EDT.
   schedule:
     - cron: "35 9 * * 1-5"
-  # Runs each time there is a new Production Tag created.
-  workflow_run:
-    workflows: ['Create Production Tag']
-    types: [completed]
-    branches: [main]
 
 concurrency: next-build-content-release-staging
 


### PR DESCRIPTION
# Description

This removes content release to Dev & Staging on every code merge. Dev & Staging will continue to build nightly, and they can also be released at any time manually.

# QA

There is no way to test this ahead of time 😓 But, this is a very simple change and there's no reason to think anything will go wrong; and if something does go wrong it will only affect Dev and Staging and we can fix it.


