### PR TITLE
Send an event via `recordEvents` like the original

### DIFF
--- a/src/templates/common/relatedLinks/index.test.tsx
+++ b/src/templates/common/relatedLinks/index.test.tsx
@@ -1,6 +1,13 @@
 import { render } from '@testing-library/react'
+import { fireEvent } from '@testing-library/dom'
 import { RelatedLinks } from '.'
 import { FormattedRelatedLinks } from '@/types/formatted/relatedLinks'
+import { recordEvent } from '@/lib/analytics/recordEvent'
+
+// Mock recordEvent
+jest.mock('@/lib/analytics/recordEvent', () => ({
+  recordEvent: jest.fn(),
+}))
 
 describe('RelatedLinks Component', () => {
   test('renders the correct number of links when there are multiple', () => {
@@ -60,5 +67,30 @@ describe('RelatedLinks Component', () => {
     expect(container.innerHTML).toContain(
       'href="https://va.gov/burials-memorials/schedule-a-burial"'
     )
+  })
+
+  test('clicking a link sends correct params to recordEvent', () => {
+    const sectionTitle = 'Related information'
+    const title = 'Eligibility for burial in a VA national cemetery'
+    const relatedLinks: FormattedRelatedLinks = {
+      links: [
+        {
+          uri: 'https://va.gov/burials-memorials/eligibility',
+          title,
+          summary:
+            'Here is a summary for this URL so you can see how it displays underneath.',
+        },
+      ],
+      sectionTitle,
+    }
+    const { container } = render(<RelatedLinks {...relatedLinks} />)
+    const linkEl = container.querySelector('va-link')
+
+    fireEvent.click(linkEl)
+    expect(recordEvent).toHaveBeenCalledWith({
+      event: 'nav-featured-content-link-click',
+      'featured-content-header': sectionTitle,
+      'featured-content-click-label': title,
+    })
   })
 })

--- a/src/templates/common/relatedLinks/index.tsx
+++ b/src/templates/common/relatedLinks/index.tsx
@@ -1,5 +1,6 @@
 import { isEmpty } from 'lodash'
 import { FormattedRelatedLinks } from '@/types/formatted/relatedLinks'
+import { recordEvent } from '@/lib/analytics/recordEvent'
 
 export const RelatedLinks = ({
   links,
@@ -12,7 +13,18 @@ export const RelatedLinks = ({
   const renderLink = (uri: string, title: string, summary?: string) => (
     <>
       <p className="vads-u-margin--0">
-        <va-link disable-analytics href={uri} text={title} />
+        <va-link
+          disable-analytics
+          onClick={() =>
+            recordEvent({
+              event: 'nav-featured-content-link-click',
+              'featured-content-header': sectionTitle,
+              'featured-content-click-label': title,
+            })
+          }
+          href={uri}
+          text={title}
+        />
       </p>
       {summary && <p className="vads-u-margin--0">{summary}</p>}
     </>


### PR DESCRIPTION
# Description

The "Other services" links were missing custom analytics events that are present in production. The links in [the original template](https://github.com/department-of-veterans-affairs/content-build/blob/0a5b0ab4db49c212b77ff2e54d8da78b29fcf55d/src/site/paragraphs/facilities/list_of_link_teasers_facility.drupal.liquid#L54) were calling a `recordEvent` function, to which we already have an analog in next-build. I've updated the component for this section to call it with the same parameters.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21522

## Testing Steps

I'm not sure if there's a better way to test the analytics events, but I was adding a console log to [the event function](https://github.com/department-of-veterans-affairs/next-build/blob/pwolfert/related-links-event/src/lib/analytics/index.tsx#L28) and setting my browser console to preserve the log between refreshes. Then you click on one of the links in the "Other services" section of a facility or region page. Here are a links to one of each:

- http://localhost:3999/new-york-harbor-health-care/locations/margaret-cochran-corbin-va-campus/
- http://localhost:3999/new-york-harbor-health-care/