### PR TITLE
VACMS-21550: Adds Lovell variant breadcrumb

### DIFF
--- a/src/data/queries/vamcSystemVaPolice.ts
+++ b/src/data/queries/vamcSystemVaPolice.ts
@@ -2,10 +2,7 @@ import { QueryData, QueryFormatter, QueryParams } from 'next-drupal-query'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { NodeVamcSystemVaPolice } from '@/types/drupal/node'
 import { VamcSystemVaPolice } from '@/types/formatted/vamcSystemVaPolice'
-import {
-  PARAGRAPH_RESOURCE_TYPES,
-  RESOURCE_TYPES,
-} from '@/lib/constants/resourceTypes'
+import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 import { ExpandedStaticPropsContext } from '@/lib/drupal/staticProps'
 import {
   entityBaseFields,
@@ -15,8 +12,8 @@ import {
 import { Menu } from '@/types/drupal/menu'
 import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
 import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
-import { QaSection as FormattedQaSection } from '@/types/formatted/qaSection'
 import { buildFaqs } from '@/data/utils/ccFaqs'
+import { getLovellVariantOfBreadcrumbs } from '@/lib/drupal/lovell/utils'
 
 // Define the query params for fetching node--vamc_system_va_police.
 export const params: QueryParams<null> = () => {
@@ -36,6 +33,7 @@ export type VamcSystemVaPoliceDataOpts = {
 type VamcSystemVaPoliceData = {
   entity: NodeVamcSystemVaPolice
   menu: Menu | null
+  lovell?: ExpandedStaticPropsContext['lovell']
 }
 
 // Implement the data loader.
@@ -63,18 +61,23 @@ export const data: QueryData<
       )
     : null
 
-  return { entity, menu }
+  return { entity, menu, lovell: opts.context?.lovell }
 }
 
 export const formatter: QueryFormatter<
   VamcSystemVaPoliceData,
   VamcSystemVaPolice
-> = ({ entity, menu }) => {
+> = ({ entity, menu, lovell }) => {
+  let { breadcrumbs } = entity
+  if (lovell?.isLovellVariantPage) {
+    breadcrumbs = getLovellVariantOfBreadcrumbs(breadcrumbs, lovell.variant)
+  }
   const formattedMenu = buildSideNavDataFromMenu(entity.path.alias, menu)
 
   return {
     ...entityBaseFields(entity),
     title: entity.title,
+    breadcrumbs,
     path: entity.path.alias,
     menu: formattedMenu,
     policeOverview: {

--- a/src/types/drupal/node.ts
+++ b/src/types/drupal/node.ts
@@ -433,6 +433,7 @@ export interface NodeSupportService extends DrupalNode {
 }
 
 export interface NodeVamcSystemVaPolice extends DrupalNode {
+  breadcrumbs: BreadcrumbItem[]
   field_administration: FieldAdministration
   field_cc_va_police_overview: FieldCCText
   field_phone_numbers_paragraph: ParagraphPhoneNumber[]

--- a/src/types/formatted/vamcSystemVaPolice.ts
+++ b/src/types/formatted/vamcSystemVaPolice.ts
@@ -4,6 +4,7 @@ import { Wysiwyg } from '@/types/formatted/wysiwyg'
 import { PhoneNumber } from '@/types/formatted/phoneNumber'
 import { FeaturedContent } from './featuredContent'
 import { QaSection } from './qaSection'
+import { LovellChildVariant } from '@/lib/drupal/lovell/types'
 
 export type VamcSystemVaPolice = PublishedEntity & {
   title: string
@@ -14,4 +15,5 @@ export type VamcSystemVaPolice = PublishedEntity & {
   phoneNumber: PhoneNumber
   policeReport: FeaturedContent
   faqs: QaSection
+  lovellVariant?: LovellChildVariant
 }


### PR DESCRIPTION
# Description

Adds Lovell variant breadcrumb.

## Generated description

This pull request updates the `vamcSystemVaPolice` query and related types to incorporate support for Lovell variant pages. The changes include adding breadcrumbs handling for Lovell variants, extending type definitions, and modifying the query formatter to include new data fields.

### Updates to `vamcSystemVaPolice` query:

* **Breadcrumbs for Lovell variant pages**: Added logic to modify breadcrumbs when the page is identified as a Lovell variant. This is handled using the `getLovellVariantOfBreadcrumbs` function. (`[src/data/queries/vamcSystemVaPolice.tsL66-R80](diffhunk://#diff-11afa3bd343eba8224d394fe15756ee7dd351d577763900ad71120f6e9e0bf3cL66-R80)`)
* **Return updated data fields**: The query now returns `lovell` data from the `opts.context` to support Lovell-specific functionality. (`[src/data/queries/vamcSystemVaPolice.tsL66-R80](diffhunk://#diff-11afa3bd343eba8224d394fe15756ee7dd351d577763900ad71120f6e9e0bf3cL66-R80)`)

### Type extensions:

* **`NodeVamcSystemVaPolice` type**: Added a `breadcrumbs` field to support breadcrumb data in the Drupal node type. (`[src/types/drupal/node.tsR436](diffhunk://#diff-a5035ec5110b73d89f63d6fbe12f3bd0af37cf28d17289acfd0bdb8c0932ccbbR436)`)
* **`VamcSystemVaPolice` type**: Added an optional `lovellVariant` field to represent Lovell-specific variants in the formatted type. (`[src/types/formatted/vamcSystemVaPolice.tsR18](diffhunk://#diff-94935119f478655e4dde9d0b48f56c0501054bf1cc1894f3fea142ca9bf98bb5R18)`)

### Import adjustments:

* **Removed unused imports**: Cleaned up unused imports, such as `QaSection` and `PARAGRAPH_RESOURCE_TYPES`, and added necessary imports like `LovellChildVariant` and `getLovellVariantOfBreadcrumbs`. (`[[1]](diffhunk://#diff-11afa3bd343eba8224d394fe15756ee7dd351d577763900ad71120f6e9e0bf3cL18-R16)`, `[[2]](diffhunk://#diff-11afa3bd343eba8224d394fe15756ee7dd351d577763900ad71120f6e9e0bf3cL5-R5)`, `[[3]](diffhunk://#diff-94935119f478655e4dde9d0b48f56c0501054bf1cc1894f3fea142ca9bf98bb5R7)`)

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21550

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

Explain the steps needed for testing

## QA steps
- [x] Go to Boston health care VA Police page
- [x] Confirm that the breadcrumb is unchanged
- [x] Go to Lovell Federal health care - VA VA Police page
- [x] Confirm that the breadcrumb reflects the VA variant:
  - [x] The breadcrumb includes "Lovell Federal health care - VA"
  - [x] The URL ends with "/lovell-federal-health-care-va"

## Screenshots
![Screenshot 2025-06-27 at 10 20 56 AM](https://github.com/user-attachments/assets/c70d05ef-f2dd-408e-a82a-0903fe9db1af)

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.