### PR TITLE
Remove unused id that is repeated in the DOM

### DIFF
--- a/src/templates/common/googleMapsDirections/index.tsx
+++ b/src/templates/common/googleMapsDirections/index.tsx
@@ -8,7 +8,6 @@ export const GoogleMapsDirections = ({ address, location = null }) => {
       class="vads-u-display--block vads-u-margin-top--0"
       href={googleMapsUrl}
       name="maps-directions"
-      id="google-map-directions"
       text={`Get directions on Google Maps`}
       data-testid="maps-directions"
       label={location && `Get directions on Google Maps to ${location}`}


### PR DESCRIPTION
# Description

Removing this unused and duplicate id. This component is rendered multiple times on vamc system pages, which results in that id showing up multiple times in the DOM.

## Generated description

### Problem

The GoogleMapsDirections component had a hardcoded id="google-map-directions" attribute, which caused duplicate IDs when the component was used multiple times on the same page. This violates HTML standards and creates accessibility issues.

### Solution

Removed the hardcoded id="google-map-directions" attribute from the va-link element in the GoogleMapsDirections component.

### Impact

- Pages affected: Event pages and facility pages that display multiple Google Maps direction links
- Accessibility: Eliminates duplicate ID violations that could interfere with screen readers and other assistive technologies
- HTML validation: Pages now pass HTML validation without duplicate ID errors

### Files Changed

- src/templates/common/googleMapsDirections/index.tsx

### Testing

The component maintains all existing functionality while fixing the duplicate ID issue. Existing tests continue to pass, and the component can now be safely used multiple times on the same page without HTML validation errors.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21606