### PR TITLE
fix: remove duplicate id

### DIFF
--- a/src/templates/layouts/healthCareLocalFacility/index.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/index.tsx
@@ -95,7 +95,7 @@ export function HealthCareLocalFacility({
   const regionBasePath = path.split('/')[1]
 
   return (
-    <div className="interior" id="content">
+    <div className="interior">
       <div className="usa-grid usa-grid-full">
         {/* Nav data fille in by a separate script from `window.sideNav` */}
         <nav aria-label="secondary" data-widget-type="side-nav" />

--- a/src/templates/layouts/locationsListing/index.tsx
+++ b/src/templates/layouts/locationsListing/index.tsx
@@ -24,7 +24,7 @@ export function LocationsListing({
     window.sideNav = menu
   }, [menu])
   return (
-    <div className="interior" id="content">
+    <div className="interior">
       <main className="va-l-detail-page va-facility-page">
         <div className="usa-grid usa-grid-full">
           {/* Sidebar Navigation */}

--- a/src/templates/layouts/questionAnswer/index.tsx
+++ b/src/templates/layouts/questionAnswer/index.tsx
@@ -42,7 +42,7 @@ export const QuestionAnswer = ({
     }
   }
   return (
-    <div id="content" className="interior" data-template="node-q_a">
+    <div className="interior" data-template="node-q_a">
       <div className="va-l-detail-page">
         <div className="usa-grid usa-grid-full">
           <div className="usa-width-three-fourths">

--- a/src/templates/layouts/resourcesSupport/index.tsx
+++ b/src/templates/layouts/resourcesSupport/index.tsx
@@ -45,7 +45,6 @@ export const ResourcesSupport = ({
 }: FormattedResourcesSupport) => {
   return (
     <div
-      id="content"
       className="interior"
       data-template="node-support_resources_detail_page"
       data-resource-type="node--support_resources_detail_page"


### PR DESCRIPTION
# Description

Removes the duplicate `id="content"`.

All these components are rendered from `ResourcePage` in (`[[...slug]].tsx`) which renders a `div#content` already.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21605