### PR TITLE
Locations Listing - Add Lovell Breadcrumbs

### DIFF
--- a/src/data/queries/locationsListing.ts
+++ b/src/data/queries/locationsListing.ts
@@ -19,6 +19,7 @@ import { formatter as formatAdministration } from './administration'
 import { formatter as formatImage } from '@/data/queries/mediaImage'
 import { PAGE_SIZES } from '@/lib/constants/pageSizes'
 import { queries } from '.'
+import { getLovellVariantOfBreadcrumbs } from '@/lib/drupal/lovell/utils'
 
 // Define the query params for fetching node--locations_listing.
 export const params: QueryParams<null> = () => {
@@ -39,6 +40,7 @@ type LocationsListingData = {
   mainFacilities: NodeHealthCareLocalFacility[]
   healthClinicFacilities: NodeHealthCareLocalFacility[]
   mobileFacilities: NodeHealthCareLocalFacility[]
+  lovell?: ExpandedStaticPropsContext['lovell']
 }
 // Implement the data loader.
 export const data: QueryData<
@@ -87,6 +89,7 @@ export const data: QueryData<
     mainFacilities,
     healthClinicFacilities,
     mobileFacilities,
+    lovell: opts.context?.lovell,
   }
 }
 
@@ -99,6 +102,7 @@ export const formatter: QueryFormatter<
   mainFacilities,
   healthClinicFacilities,
   mobileFacilities,
+  lovell,
 }) => {
   const formattedMenu = buildSideNavDataFromMenu(entity.path.alias, menu)
   // Mobile clinics don't include VA Health Connect phone numbers in production so we add a flag to exclude them
@@ -117,7 +121,10 @@ export const formatter: QueryFormatter<
       : null,
     image: formatImage(facility.field_media),
   })
-
+  let { breadcrumbs } = entity
+  if (lovell?.isLovellVariantPage) {
+    breadcrumbs = getLovellVariantOfBreadcrumbs(breadcrumbs, lovell.variant)
+  }
   return {
     ...entityBaseFields(entity),
     administration: formatAdministration(entity.field_administration),
@@ -134,5 +141,6 @@ export const formatter: QueryFormatter<
     mobileFacilities: mobileFacilities.map((facility) =>
       formatFacility(facility, false)
     ),
+    breadcrumbs,
   }
 }

--- a/src/types/drupal/node.ts
+++ b/src/types/drupal/node.ts
@@ -449,4 +449,5 @@ export interface NodeLeadershipListing extends DrupalNode {
 
 export interface NodeLocationsListing extends DrupalNode {
   field_description: string
+  breadcrumbs: BreadcrumbItem[]
 }

--- a/src/types/formatted/locationsListing.ts
+++ b/src/types/formatted/locationsListing.ts
@@ -3,6 +3,7 @@ import { SideNavMenu } from '@/types/formatted/sideNav'
 import { NodeHealthCareRegionPage } from '../drupal/node'
 import { Administration } from '@/types/formatted/administration'
 import { HealthCareLocalFacility } from './healthCareLocalFacility'
+import { LovellChildVariant } from '@/lib/drupal/lovell/types'
 
 export type MinimalLocalFacility = Pick<
   HealthCareLocalFacility,
@@ -25,4 +26,5 @@ export type LocationsListing = PublishedEntity & {
   mainFacilities: MinimalLocalFacility[]
   healthClinicFacilities: MinimalLocalFacility[]
   mobileFacilities: MinimalLocalFacility[]
+  lovell?: LovellChildVariant
 }


### PR DESCRIPTION
# Description

What does this PR address?

## Generated description

This pull request introduces changes to support Lovell variant pages in the `locationsListing` query and formatter. The updates include modifications to handle breadcrumbs specific to Lovell variants and adjustments to the data types and structures to accommodate the new `lovell` property.

### Updates to `locationsListing` query and formatter:

* **Added support for Lovell variant breadcrumbs**:
  - Imported `getLovellVariantOfBreadcrumbs` utility to modify breadcrumbs for Lovell variant pages. (`src/data/queries/locationsListing.ts`, [src/data/queries/locationsListing.tsR22](diffhunk://#diff-bd9fa099a45ae5efad2771d3be89c3ca5c4bd2b41099034ee69ca2e92275f76fR22))
  - Updated the `formatter` function to check if the page is a Lovell variant and adjust breadcrumbs accordingly. (`src/data/queries/locationsListing.ts`, [src/data/queries/locationsListing.tsL120-R127](diffhunk://#diff-bd9fa099a45ae5efad2771d3be89c3ca5c4bd2b41099034ee69ca2e92275f76fL120-R127))
  - Included `breadcrumbs` in the formatter's return object. (`src/data/queries/locationsListing.ts`, [src/data/queries/locationsListing.tsR144](diffhunk://#diff-bd9fa099a45ae5efad2771d3be89c3ca5c4bd2b41099034ee69ca2e92275f76fR144))

* **Introduced `lovell` property**:
  - Added `lovell` to the `LocationsListingData` type and passed it through the query data loader. (`src/data/queries/locationsListing.ts`, [[1]](diffhunk://#diff-bd9fa099a45ae5efad2771d3be89c3ca5c4bd2b41099034ee69ca2e92275f76fR43) [[2]](diffhunk://#diff-bd9fa099a45ae5efad2771d3be89c3ca5c4bd2b41099034ee69ca2e92275f76fR92)
  - Integrated `lovell` into the formatter function for processing. (`src/data/queries/locationsListing.ts`, [src/data/queries/locationsListing.tsR105](diffhunk://#diff-bd9fa099a45ae5efad2771d3be89c3ca5c4bd2b41099034ee69ca2e92275f76fR105))

### Updates to data types:

* **Extended `NodeLocationsListing` type**:
  - Added a `breadcrumbs` property to support breadcrumb handling in Lovell variant pages. (`src/types/drupal/node.ts`, [src/types/drupal/node.tsR452](diffhunk://#diff-a5035ec5110b73d89f63d6fbe12f3bd0af37cf28d17289acfd0bdb8c0932ccbbR452))

* **Updated `LocationsListing` type**:
  - Added an optional `lovell` property of type `LovellChildVariant`. (`src/types/formatted/locationsListing.ts`, [src/types/formatted/locationsListing.tsR29](diffhunk://#diff-0afb055f43f8449e4f06f97256078ceff9f57fcb3aa7c4f4b91395263499cdebR29))
  - Imported `LovellChildVariant` type for use in `LocationsListing`. (`src/types/formatted/locationsListing.ts`, [src/types/formatted/locationsListing.tsR6](diffhunk://#diff-0afb055f43f8449e4f06f97256078ceff9f57fcb3aa7c4f4b91395263499cdebR6))
## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes  [21573](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21573)

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

Check tugboat or local to verify that lovell va and or tricare has a corresponding breadcrumb.

## QA steps

In ticket

## Screenshots

<img width="1090" alt="image" src="https://github.com/user-attachments/assets/6fb604dd-508a-43c6-b10b-1286efd91d7a" />

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/828155f7-b50e-497b-8c96-dc1f783778a6" />


---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```