### PR TITLE
Also fetch bifurcated Lovell stories and events for Lovell VAMC system pages

### DIFF
--- a/src/data/queries/tests/vamcSystem.test.tsx
+++ b/src/data/queries/tests/vamcSystem.test.tsx
@@ -10,12 +10,37 @@ import mockEventData from '@/products/event/mock.json'
 import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 import { params } from '../vamcSystem'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+import { LOVELL } from '@/lib/drupal/lovell/constants'
+import { ExpandedStaticPropsContext } from '@/lib/drupal/staticProps'
 
 const mockFeaturedEventData = {
   ...mockEventData,
   // Just to differentiate in the snapshot
   field_featured: true,
   title: 'Dodgeball Club',
+}
+
+// Mock story data for parent stories (Lovell federal)
+const mockParentStoryData = {
+  ...mockStoryData,
+  title: 'Parent Federal Story',
+  id: 'parent-story-id',
+}
+
+// Mock event data for parent events (Lovell federal)
+const mockParentEventData = {
+  ...mockEventData,
+  title: 'Parent Federal Event',
+  id: 'parent-event-id',
+  field_featured: true,
+}
+
+// Mock non-featured event for fallback testing
+const mockNonFeaturedEventData = {
+  ...mockEventData,
+  title: 'Non-featured Event',
+  id: 'non-featured-event-id',
+  field_featured: false,
 }
 
 jest.mock('@/lib/drupal/query', () => ({
@@ -25,16 +50,52 @@ jest.mock('@/lib/drupal/query', () => ({
     nodeType: string,
     params: DrupalJsonApiParams
   ) => {
+    const queryObj = params.getQueryObject()
+    
     switch (nodeType) {
       case RESOURCE_TYPES.VAMC_FACILITY:
         return { data: [mockFacilityData] }
+      
       case RESOURCE_TYPES.STORY:
-        return { data: [mockStoryData] }
-      case RESOURCE_TYPES.EVENT:
-        if (params.getQueryObject().filter.field_featured === '1') {
-          return { data: [mockFeaturedEventData] }
+        // Check if this is a Lovell federal query (has administration filter)
+        const isLovellParentStoryQuery = queryObj.filter && 
+          Object.keys(queryObj.filter).some(key => 
+            key.includes('field_administration.drupal_internal__tid')
+          )
+        
+        if (isLovellParentStoryQuery) {
+          // Return parent stories for Lovell federal queries
+          return { data: [mockParentStoryData] }
         }
-        return { data: [mockEventData] }
+        
+        // Return regular stories for system-specific queries
+        return { data: [mockStoryData] }
+      
+      case RESOURCE_TYPES.EVENT:
+        // Check if this is a Lovell federal query
+        const isLovellParentEventQuery = queryObj.filter && 
+          Object.keys(queryObj.filter).some(key => 
+            key.includes('field_administration.drupal_internal__tid')
+          )
+        
+        const isFeatured = queryObj.filter?.field_featured === '1'
+        
+        if (isLovellParentEventQuery) {
+          // Return parent events for Lovell federal queries
+          if (isFeatured) {
+            return { data: [mockParentEventData] }
+          } else {
+            return { data: [{ ...mockParentEventData, field_featured: false }] }
+          }
+        }
+        
+        // Return system-specific events
+        if (isFeatured) {
+          return { data: [mockFeaturedEventData] }
+        } else {
+          return { data: [mockNonFeaturedEventData] }
+        }
+      
       default:
         return { data: [] }
     }
@@ -68,5 +129,245 @@ describe('VamcSystem formatData', () => {
     expect(
       await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { id: mockData.id })
     ).toMatchSnapshot()
+  })
+
+  describe('Lovell variant functionality', () => {
+    test('outputs formatted data with Lovell VA variant context', async () => {
+      const lovellContext: ExpandedStaticPropsContext = {
+        path: '',
+        drupalPath: '',
+        listing: { isListingPage: false, firstPagePath: '', page: 0 },
+        lovell: {
+          isLovellVariantPage: true,
+          variant: LOVELL.va.variant,
+        },
+      }
+
+      const result = await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { 
+        id: mockData.id, 
+        context: lovellContext 
+      })
+      
+      // Verify that featuredStories includes both system and parent stories
+      expect(result.featuredStories).toHaveLength(2)
+      expect(result.featuredStories.some(story => story.title === mockStoryData.title)).toBe(true)
+      expect(result.featuredStories.some(story => story.title === mockParentStoryData.title)).toBe(true)
+      
+      // Verify that featuredEvents includes both system and parent events
+      expect(result.featuredEvents).toHaveLength(2)
+      expect(result.featuredEvents.some(event => event.title === mockFeaturedEventData.title)).toBe(true)
+      expect(result.featuredEvents.some(event => event.title === mockParentEventData.title)).toBe(true)
+    })
+
+    test('outputs formatted data with Lovell TRICARE variant context', async () => {
+      const lovellContext: ExpandedStaticPropsContext = {
+        path: '',
+        drupalPath: '',
+        listing: { isListingPage: false, firstPagePath: '', page: 0 },
+        lovell: {
+          isLovellVariantPage: true,
+          variant: LOVELL.tricare.variant,
+        },
+      }
+
+      const result = await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { 
+        id: mockData.id, 
+        context: lovellContext 
+      })
+      
+      // Should have the same behavior as VA variant - includes both system and parent content
+      expect(result.featuredStories).toHaveLength(2)
+      expect(result.featuredEvents).toHaveLength(2)
+    })
+
+    test('handles non-Lovell variant pages (regular behavior)', async () => {
+      const regularContext: ExpandedStaticPropsContext = {
+        path: '',
+        drupalPath: '',
+        listing: { isListingPage: false, firstPagePath: '', page: 0 },
+        lovell: {
+          isLovellVariantPage: false,
+          variant: null,
+        },
+      }
+
+      const result = await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { 
+        id: mockData.id, 
+        context: regularContext 
+      })
+
+      // Should only have system-specific content, not parent content
+      expect(result.featuredStories).toHaveLength(1)
+      expect(result.featuredStories[0].title).toBe(mockStoryData.title)
+      
+      expect(result.featuredEvents).toHaveLength(1)
+      expect(result.featuredEvents[0].title).toBe(mockFeaturedEventData.title)
+    })
+
+         test('handles context with non-Lovell lovell property', async () => {
+       const contextWithoutLovell: ExpandedStaticPropsContext = {
+         path: '',
+         drupalPath: '',
+         listing: { isListingPage: false, firstPagePath: '', page: 0 },
+         lovell: {
+           isLovellVariantPage: false,
+           variant: null,
+         },
+       }
+
+       const result = await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { 
+         id: mockData.id, 
+         context: contextWithoutLovell 
+       })
+
+       // Should behave like non-Lovell variant
+       expect(result.featuredStories).toHaveLength(1)
+       expect(result.featuredEvents).toHaveLength(1)
+     })
+
+    test('handles no context provided', async () => {
+      const result = await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { 
+        id: mockData.id 
+      })
+
+      // Should behave like non-Lovell variant
+      expect(result.featuredStories).toHaveLength(1)
+      expect(result.featuredEvents).toHaveLength(1)
+    })
+
+    test('inherits parent content when system has no featured content (Lovell variant)', async () => {
+      // Create a mock that returns empty for system queries but content for parent queries
+      const mockWithNoSystemContent = jest.fn((nodeType: string, params: DrupalJsonApiParams) => {
+        const queryObj = params.getQueryObject()
+        
+        switch (nodeType) {
+          case RESOURCE_TYPES.VAMC_FACILITY:
+            return { data: [mockFacilityData] }
+          
+          case RESOURCE_TYPES.STORY:
+            const isLovellParentStoryQuery = queryObj.filter && 
+              Object.keys(queryObj.filter).some(key => 
+                key.includes('field_administration.drupal_internal__tid')
+              )
+            
+            if (isLovellParentStoryQuery) {
+              // Return parent stories for Lovell federal queries
+              return { data: [mockParentStoryData] }
+            }
+            
+            // Return empty for system-specific queries
+            return { data: [] }
+          
+          case RESOURCE_TYPES.EVENT:
+            const isLovellParentEventQuery = queryObj.filter && 
+              Object.keys(queryObj.filter).some(key => 
+                key.includes('field_administration.drupal_internal__tid')
+              )
+            
+            const isFeatured = queryObj.filter?.field_featured === '1'
+            
+            if (isLovellParentEventQuery) {
+              // Return parent events for Lovell federal queries
+              if (isFeatured) {
+                return { data: [mockParentEventData] }
+              } else {
+                return { data: [{ ...mockParentEventData, field_featured: false }] }
+              }
+            }
+            
+            // Return empty for system-specific queries (no featured or non-featured events)
+            return { data: [] }
+          
+          default:
+            return { data: [] }
+        }
+      })
+
+      // Temporarily replace the mock
+      const originalMock = require('@/lib/drupal/query').fetchAndConcatAllResourceCollectionPages
+      require('@/lib/drupal/query').fetchAndConcatAllResourceCollectionPages = mockWithNoSystemContent
+
+      try {
+        const lovellContext: ExpandedStaticPropsContext = {
+          path: '',
+          drupalPath: '',
+          listing: { isListingPage: false, firstPagePath: '', page: 0 },
+          lovell: {
+            isLovellVariantPage: true,
+            variant: LOVELL.va.variant,
+          },
+        }
+
+        const result = await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { 
+          id: mockData.id, 
+          context: lovellContext 
+        })
+
+        // Should only have parent content, no system content
+        expect(result.featuredStories).toHaveLength(1)
+        expect(result.featuredStories[0].title).toBe(mockParentStoryData.title)
+        
+        expect(result.featuredEvents).toHaveLength(1)
+        expect(result.featuredEvents[0].title).toBe(mockParentEventData.title)
+        
+        // Should have no fallback event since we found featured events from parent
+        expect(result.fallbackEvent).toBeNull()
+      } finally {
+        // Restore the original mock
+        require('@/lib/drupal/query').fetchAndConcatAllResourceCollectionPages = originalMock
+      }
+    })
+  })
+
+  describe('Event fallback functionality', () => {
+    // Mock scenario where no featured events exist
+    const mockWithNoFeaturedEvents = jest.fn()
+
+    beforeEach(() => {
+      mockWithNoFeaturedEvents.mockImplementation((nodeType: string, params: DrupalJsonApiParams) => {
+        const queryObj = params.getQueryObject()
+        
+        if (nodeType === RESOURCE_TYPES.EVENT && queryObj.filter?.field_featured === '1') {
+          // No featured events
+          return { data: [] }
+        }
+        
+        if (nodeType === RESOURCE_TYPES.EVENT && queryObj.filter?.field_featured === '0') {
+          // Return non-featured event as fallback
+          return { data: [mockNonFeaturedEventData] }
+        }
+        
+        // Default behavior for other cases
+        return { data: [] }
+      })
+    })
+
+    test('uses fallback event when no featured events exist', async () => {
+      // Temporarily mock the function to return no featured events
+      const originalMock = require('@/lib/drupal/query').fetchAndConcatAllResourceCollectionPages
+      require('@/lib/drupal/query').fetchAndConcatAllResourceCollectionPages = mockWithNoFeaturedEvents
+
+      try {
+        const result = await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { 
+          id: mockData.id 
+        })
+
+        expect(result.featuredEvents).toHaveLength(0)
+        expect(result.fallbackEvent).toBeTruthy()
+        expect(result.fallbackEvent?.title).toBe(mockNonFeaturedEventData.title)
+      } finally {
+        // Restore the original mock
+        require('@/lib/drupal/query').fetchAndConcatAllResourceCollectionPages = originalMock
+      }
+    })
+
+    test('has no fallback event when featured events exist', async () => {
+      const result = await queries.getData(RESOURCE_TYPES.VAMC_SYSTEM, { 
+        id: mockData.id 
+      })
+
+      expect(result.featuredEvents.length).toBeGreaterThan(0)
+      expect(result.fallbackEvent).toBeNull()
+    })
   })
 })


### PR DESCRIPTION
# Description

Lovell VA and TRICARE system pages were supposed to be showing featured stories that belonged to the VA _federal_ (parent/shared/bifurcated) administration as well as their own variant-specific stories. @omahane found [some functions in the old content-build project](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/stages/build/drupal/process-lovell-pages.js#L189) that did similar things, and I noticed that they were treating events similarly. It made sense to me to apply this same logic to the events as well, so I did. I'll include screenshots below showing that we were previously showing a fallback event on the Lovell VA system page but now we get an actual featured event from the parent Lovell page now that we're querying for it.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21521

## Testing Steps

The following pages should now show stories and events that they weren't previously showing: 

- http://localhost:3999/lovell-federal-health-care-va/
- http://localhost:3999/lovell-federal-health-care-tricare/

## Screenshots

Before (one distant-future fallback event, no stories):

<img width="1624" alt="Screenshot 2025-07-02 at 12 28 35 PM" src="https://github.com/user-attachments/assets/b01d0e95-d981-4e98-9fc4-038f0fec6cce" />

After (one bifurcated Lovell event, two bifurcated Lovell featured stories):

<img width="1624" alt="Screenshot 2025-07-02 at 12 28 51 PM" src="https://github.com/user-attachments/assets/4384e514-941f-42ea-968e-fb968af89977" />
