### PR TITLE
Fix icon alignment in location services

### DIFF
--- a/src/templates/layouts/healthCareLocalFacility/HealthServices/ServiceLocation.tsx
+++ b/src/templates/layouts/healthCareLocalFacility/HealthServices/ServiceLocation.tsx
@@ -98,7 +98,7 @@ export const ServiceLocation = ({
                 icon={fieldReferralRequired === '1' ? 'check_circle' : 'cancel'}
                 size="3"
                 data-testid="referral-icon"
-              ></va-icon>
+              ></va-icon>{' '}
               {fieldReferralRequired === '1'
                 ? 'A referral is required'
                 : 'A referral is not required'}


### PR DESCRIPTION
# Description

There was some whitespace inconsistency causing a difference in the gap between the icon and the text. This is one way to make it consistent. We could also get rid of the extra space on all of them. However, I don't like how close the icons are when I remove the space. It looks really crowded.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21608

## Testing Steps

Go to http://localhost:3999/central-texas-health-care/locations/olin-e-teague-veterans-center/#advice-nurse and take a look at the three icons for "Visit our office...", "Virtual visits...", and "A referall...". In the fixed version, the space between the icons and text should be consistent across the three rows.

## Screenshots

Before:
<img width="429" alt="Screenshot 2025-07-03 at 2 16 47 PM" src="https://github.com/user-attachments/assets/340ed935-3a37-4704-9698-f6eff49a5844" />

After:
<img width="420" alt="Screenshot 2025-07-03 at 2 13 06 PM" src="https://github.com/user-attachments/assets/1d37b696-ab86-4330-82a4-669d6f0ec18d" />

With annotation to see the alignment:
<img width="420" alt="alignment" src="https://github.com/user-attachments/assets/062007fc-0b3b-4845-9488-047e6e25087d" />
