### PR TITLE
Vets Center: Correct defects in "Also called" subtitle

### DIFF
--- a/src/templates/layouts/vetCenter/index.test.tsx
+++ b/src/templates/layouts/vetCenter/index.test.tsx
@@ -220,4 +220,97 @@ describe('VetCenter with valid data', () => {
     expect(screen.queryByText(/1010 Delafield Road/)).toBeInTheDocument()
     expect(screen.queryByText(/In the spotlight/)).toBeInTheDocument()
   })
+
+  describe('Also called functionality', () => {
+    test('renders "Also called" text when officialName is different from title', () => {
+      const dataWithDifferentOfficialName = {
+        ...mockData,
+        title: 'Pittsburgh Vet Center',
+        officialName: 'Pittsburgh Veterans Center for Readjustment',
+      }
+
+      render(<VetCenter {...dataWithDifferentOfficialName} />)
+
+      // Should render the "Also called" text
+      expect(
+        screen.getByText(
+          'Also called the Pittsburgh Veterans Center for Readjustment'
+        )
+      ).toBeInTheDocument()
+
+      // Should have the h1 with aria-describedby pointing to the "Also called" element
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading).toHaveAttribute('aria-describedby', 'vet-center-title')
+
+      // Should have the correct ID on the "Also called" paragraph
+      const alsoCalledElement = screen.getByText(
+        'Also called the Pittsburgh Veterans Center for Readjustment'
+      )
+      expect(alsoCalledElement).toHaveAttribute('id', 'vet-center-title')
+    })
+
+    test('does not render "Also called" text when officialName is same as title', () => {
+      const dataWithSameNames = {
+        ...mockData,
+        title: 'Pittsburgh Vet Center',
+        officialName: 'Pittsburgh Vet Center',
+      }
+
+      render(<VetCenter {...dataWithSameNames} />)
+
+      // Should not render the "Also called" text
+      expect(screen.queryByText(/Also called the/)).not.toBeInTheDocument()
+
+      // h1 should not have aria-describedby attribute
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading).not.toHaveAttribute('aria-describedby')
+    })
+
+    test('does not render "Also called" text when officialName is null', () => {
+      const dataWithNullOfficialName = {
+        ...mockData,
+        title: 'Pittsburgh Vet Center',
+        officialName: null,
+      }
+
+      render(<VetCenter {...dataWithNullOfficialName} />)
+
+      // Should not render the "Also called" text
+      expect(screen.queryByText(/Also called the/)).not.toBeInTheDocument()
+
+      // h1 should not have aria-describedby attribute
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading).not.toHaveAttribute('aria-describedby')
+    })
+
+    test('does not render "Also called" text when officialName is empty string', () => {
+      const dataWithEmptyOfficialName = {
+        ...mockData,
+        title: 'Pittsburgh Vet Center',
+        officialName: '',
+      }
+
+      render(<VetCenter {...dataWithEmptyOfficialName} />)
+
+      // Should not render the "Also called" text
+      expect(screen.queryByText(/Also called the/)).not.toBeInTheDocument()
+
+      // h1 should not have aria-describedby attribute
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading).not.toHaveAttribute('aria-describedby')
+    })
+
+    test('handles case where title is null but officialName exists', () => {
+      const dataWithNullTitle = {
+        ...mockData,
+        title: null,
+        officialName: 'Pittsburgh Veterans Center for Readjustment',
+      }
+
+      render(<VetCenter {...dataWithNullTitle} />)
+
+      // Should not render the "Also called" text when title is null
+      expect(screen.queryByText(/Also called the/)).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/templates/layouts/vetCenter/index.test.tsx
+++ b/src/templates/layouts/vetCenter/index.test.tsx
@@ -300,7 +300,7 @@ describe('VetCenter with valid data', () => {
       expect(heading).not.toHaveAttribute('aria-describedby')
     })
 
-    test('handles case where title is null but officialName exists', () => {
+    test('does not render "Also called" when title is null but officialName exists', () => {
       const dataWithNullTitle = {
         ...mockData,
         title: null,

--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -154,15 +154,28 @@ export function VetCenter({
     )
   }
 
+  const alsoCalled =
+    officialName && title !== officialName
+      ? `Also called the ${officialName}`
+      : null
+  const alsoCalledId = 'vet-center-title'
+
   return (
     <div className="usa-grid usa-grid-full">
       <div className="usa-width-three-fourths">
         <article className="usa-content va-l-facility-detail vads-u-padding-bottom--0">
           {title && (
             <>
-              <h1 aria-describedby="vet-center-title">{title}</h1>
-              {officialName && title !== officialName && (
-                <p id="vet-center-title">Also called the {officialName}</p>
+              <h1 aria-describedby={alsoCalled ? alsoCalledId : undefined}>
+                {title}
+              </h1>
+              {alsoCalled && (
+                <p
+                  id={alsoCalledId}
+                  className="vads-u-font-family--serif vads-u-font-size--lg vads-u-font-weight--bold"
+                >
+                  {alsoCalled}
+                </p>
               )}
             </>
           )}


### PR DESCRIPTION
# Description

These changes correct some small defects in the "Also called" subtitle of the Vets Center pages, which shows the official name of the vets center as opposed to its common name.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21554

## Testing Steps

- Visit http://localhost:3999/st-paul-vet-center/ and check the page title and the `<p>` element below it. Should have an `aria-describedby` on the title that points to the subtitle element. 
- If you go to http://localhost:3999/boston-vet-center/, you should find that the title doesn't have an `aria-describeby` attribute, because there's nothing to point to.

Also check the ticket for details about intended behavior.

## Screenshots

Before:
<img width="710" alt="Screenshot 2025-07-03 at 3 07 04 PM" src="https://github.com/user-attachments/assets/cb4a110c-775b-4191-a0fb-5175cac89ea1" />

After:
<img width="740" alt="Screenshot 2025-07-03 at 3 06 51 PM" src="https://github.com/user-attachments/assets/dfb41f18-2e0f-473d-8fbd-1573f8a7aab7" />
