### PR TITLE
Vets Center: Remove extra utility classes

### DIFF
--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -171,7 +171,7 @@ export function VetCenter({
               <p>{introText}</p>
             </div>
           )}
-          <va-on-this-page class="vads-u-margin-left--1 vads-u-margin-bottom--0 vads-u-padding-bottom--0"></va-on-this-page>
+          <va-on-this-page></va-on-this-page>
 
           {/* Locations and contact */}
           <h2 id="locations-and-contact-information">


### PR DESCRIPTION
# Description

Removes unnecessary classes on the `on-this-page` (table of contents) component. The web component itself has some internal padding that causes the text inside to be misaligned with the left edge of the page content, but that's how it is in production. Maybe in the future we could give it some negative margin or something to align the edge properly.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21557

## Testing Steps

[Explain the steps needed for testing](http://localhost:3999/boston-vet-center/)

## Screenshots

It's hard to tell, but in the after shot, it's shifted less to the right.

Before:

<img width="703" alt="Screenshot 2025-07-04 at 10 42 25 AM" src="https://github.com/user-attachments/assets/c72c6d8b-54c2-4613-bdc1-d4d34afb24a9" />

After:

<img width="707" alt="Screenshot 2025-07-04 at 10 42 00 AM" src="https://github.com/user-attachments/assets/b3871d8a-8369-4ac1-839e-d407ae06b39d" />
