### PR TITLE
Vets Center: Use standard `PhoneNumber` component

### DIFF
--- a/src/templates/layouts/vetCenter/index.test.tsx
+++ b/src/templates/layouts/vetCenter/index.test.tsx
@@ -220,4 +220,22 @@ describe('VetCenter with valid data', () => {
     expect(screen.queryByText(/1010 Delafield Road/)).toBeInTheDocument()
     expect(screen.queryByText(/In the spotlight/)).toBeInTheDocument()
   })
+
+  test('renders phone number with standardized PhoneNumber component', () => {
+    render(<VetCenter {...mockData} />)
+
+    // Check that the phone number is displayed with "Main phone" label
+    expect(screen.getByText(/Main phone:/)).toBeInTheDocument()
+
+    // Check that the phone number is rendered using the va-telephone component
+    const phoneElement = screen.getByTestId('phone')
+    expect(phoneElement).toBeInTheDocument()
+
+    // Check that the va-telephone component is present
+    const vaTelephoneElement = document.querySelector('va-telephone')
+    expect(vaTelephoneElement).toBeInTheDocument()
+
+    // Verify the contact attribute contains the phone number without dashes
+    expect(vaTelephoneElement?.getAttribute('contact')).toBe('1234567890')
+  })
 })

--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -7,6 +7,7 @@ import VetCenterHealthServices from '@/templates/components/vetCenterHealthServi
 import { FeaturedContent } from '@/templates/common/featuredContent'
 import { QaSection } from '@/templates/components/qaSection'
 import { Accordion } from '@/templates/components/accordion'
+import { PhoneNumber } from '@/templates/common/phoneNumber'
 
 export function VetCenter({
   address,
@@ -213,14 +214,11 @@ export function VetCenter({
                       />
                     </div>
 
-                    <h4 className="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
-                      Direct line
-                    </h4>
-                    <div className="vads-u-margin-bottom--3">
-                      <div className="main-phone vads-u-margin-bottom--1">
-                        <a href={`tel:${phoneNumber}`}>{phoneNumber}</a>
-                      </div>
-                    </div>
+                    <PhoneNumber
+                      className="vads-u-margin-y--3"
+                      label="Main phone"
+                      number={phoneNumber}
+                    />
 
                     <Hours
                       headerType="standard"


### PR DESCRIPTION
# Description

The old code was just using an anchor tag with the `tel:` prefix for the number. We have a more sophisticated component for this now, so we're going to use it. Should satisfy all the requirements of the ticket. (Also changes the label and doesn't use a heading so we're more consistent with the other places where phone numbers are displayed on the site.)

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21558

## Testing Steps

Go to http://localhost:3999/boston-vet-center/ and look at the locations and contact info section.

## Screenshots

### Before:

<img width="737" alt="Screenshot 2025-07-04 at 11 34 12 AM" src="https://github.com/user-attachments/assets/6ee22f21-2ae0-445f-9831-e3c8b3f1d13e" />

### After:

<img width="724" alt="Screenshot 2025-07-04 at 11 37 48 AM" src="https://github.com/user-attachments/assets/008cffc2-694d-4ad4-b9a4-ff8703745c4e" />
