### PR TITLE
Vets Center: Fix markup in other locations section

### DIFF
--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -240,15 +240,19 @@ export function VetCenter({
           {/* Other locations */}
           <div className="vads-u-margin-bottom--3">
             <h3 className="vads-u-font-size--lg vads-u-line-height--1 vads-u-margin-bottom--1">
-              Other Locations
+              Other locations
             </h3>
-            <div>
-              <p className="vads-u-margin-bottom--0 vads-u-line-height--4">
-                Vet Centers are community based to be more accessible in areas
-                where you live.
-              </p>
-              <a href={`${path}/locations`}>View more {title} locations</a>
-            </div>
+            <p>
+              Vet Centers are community based to be more accessible in areas
+              where you live.
+            </p>
+            <p>
+              <va-link
+                active
+                href={`${path}/locations`}
+                text={`View more ${title} locations`}
+              ></va-link>
+            </p>
           </div>
 
           {/* Call Center Information */}


### PR DESCRIPTION
# Description

- "locations" in the "Other locations" heading has been lowercased
- Classes have been removed from paragraph text within the "Other locations" section
- Other locations link uses the `<va-link>` component with the `active` prop
- Semantic elements wrap text and link so they have the right typography styles

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21566

## Testing Steps

Go to http://localhost:3999/boston-vet-center/ and take a look at the "Other locations" section

## Screenshots

Before:

<img width="614" alt="Screenshot 2025-07-04 at 3 24 46 PM" src="https://github.com/user-attachments/assets/84625258-1902-409b-88f9-c8fe40fad205" />

After:

<img width="610" alt="Screenshot 2025-07-04 at 3 23 48 PM" src="https://github.com/user-attachments/assets/72ce9e6e-fb99-43cb-8de1-a97623387f19" />
