### PR TITLE
VADS 3458: remove right margin from feedback button

### DIFF
--- a/src/assets/styles/globals.css
+++ b/src/assets/styles/globals.css
@@ -20,6 +20,10 @@ body {
   padding-top: 0.78125rem;
 }
 
+va-button#mdFormButton::part(button) {
+  margin-right: 0px;
+}
+
 .feedback-button {
   background-color: var(color-primary);
   font-size: 1rem;


### PR DESCRIPTION
# Description

The `va-button` web component uses USWDS styles which has a right margin. When the button is used in a way that makes it right aligned to content (like the feedback button), this right margin should be removed. For those special scenarios, the web component has a `part` attribute that can be styled through the shadow dom. That is what this PR is doing for the feedback button.

Here is the feedback button in question: 

https://github.com/department-of-veterans-affairs/next-build/blob/ec31c5b604e7d5c2d35330967d66c957fc0dd047/src/templates/common/contentFooter/index.tsx#L47-L61


## Ticket

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3458

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

Explain the steps needed for testing

## QA steps

What needs to be checked to prove this works? 
- Review the feedback button at the bottom of the content on this page: http://localhost:3999/boston-health-care/events/

What needs to be checked to prove it didn't break any related things?
What variations of circumstances (users, actions, values) need to be checked?

## Screenshots

**Before**: 

![before](https://github.com/user-attachments/assets/24f4cee9-a192-4a42-941d-c6a4e52dfb56)

**After**:

![after](https://github.com/user-attachments/assets/c7f93c75-192d-4a73-9a53-4df43008c61a)

## Is this PR blocked by another PR?

- Add the `DO NOT MERGE` label
- Add links to additional PRs here:

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.