### PR TITLE
Vets Center: Operating status flags

### DIFF
--- a/additional.d.ts
+++ b/additional.d.ts
@@ -25,6 +25,7 @@ declare namespace JSX {
     'va-accordion'
     'va-accordion-item'
     'va-alert'
+    'va-alert-expandable'
     'va-back-to-top'
     'va-breadcrumbs'
     'va-button'

--- a/src/data/queries/vetCenter.ts
+++ b/src/data/queries/vetCenter.ts
@@ -166,7 +166,9 @@ export const formatter: QueryFormatter<NodeVetCenter, FormattedVetCenter> = (
     officialName: entity.field_official_name,
     operatingStatusFacility: entity.field_operating_status_facility,
     operatingStatusMoreInfo: entity.field_operating_status_more_info
-      ? getHtmlFromDrupalContent(entity.field_operating_status_more_info)
+      ? getHtmlFromDrupalContent(entity.field_operating_status_more_info, {
+          convertNewlines: true,
+        })
       : null,
     phoneNumber: entity.field_phone_number,
     timezone: entity.field_timezone,

--- a/src/data/queries/vetCenter.ts
+++ b/src/data/queries/vetCenter.ts
@@ -17,6 +17,7 @@ import { FeaturedContent } from '@/types/formatted/featuredContent'
 import { Button } from '@/types/formatted/button'
 import { Wysiwyg } from '@/types/formatted/wysiwyg'
 import { getNestedIncludes } from '@/lib/utils/queries'
+import { getHtmlFromDrupalContent } from '@/lib/utils/getHtmlFromDrupalContent'
 
 // Define the query params for fetching node--vet_center.
 export const params: QueryParams<null> = () => {
@@ -164,7 +165,9 @@ export const formatter: QueryFormatter<NodeVetCenter, FormattedVetCenter> = (
     officeHours: entity.field_office_hours,
     officialName: entity.field_official_name,
     operatingStatusFacility: entity.field_operating_status_facility,
-    operatingStatusMoreInfo: entity.field_operating_status_more_info ?? null,
+    operatingStatusMoreInfo: entity.field_operating_status_more_info
+      ? getHtmlFromDrupalContent(entity.field_operating_status_more_info)
+      : null,
     phoneNumber: entity.field_phone_number,
     timezone: entity.field_timezone,
     administration: entity.field_administration,

--- a/src/lib/utils/getHtmlFromDrupalContent.test.ts
+++ b/src/lib/utils/getHtmlFromDrupalContent.test.ts
@@ -1,0 +1,107 @@
+import { getHtmlFromDrupalContent } from './getHtmlFromDrupalContent'
+
+describe('getHtmlFromDrupalContent', () => {
+  test('should apply createPhoneLinks transformation', () => {
+    const input = 'Call us at 555-123-4567 for help'
+    const result = getHtmlFromDrupalContent(input)
+    expect(result).toContain(
+      '<va-telephone contact="555-123-4567" extension=""></va-telephone>'
+    )
+  })
+
+  test('should apply drupalToVaPath transformation for images', () => {
+    const input =
+      '<a href="https://va.gov/sites/default/files/image.jpg">Image</a>'
+    const result = getHtmlFromDrupalContent(input)
+    expect(result).toBe('<a href="/img/image.jpg">Image</a>')
+  })
+
+  test('should apply drupalToVaPath transformation for files', () => {
+    const input =
+      '<a href="https://va.gov/sites/default/files/document.pdf">Document</a>'
+    const result = getHtmlFromDrupalContent(input)
+    expect(result).toBe('<a href="/files/document.pdf">Document</a>')
+  })
+
+  test('should apply newlinesToBr transformation', () => {
+    const input = 'Line 1\nLine 2\nLine 3'
+    const result = getHtmlFromDrupalContent(input)
+    expect(result).toBe('Line 1<br>Line 2<br>Line 3')
+  })
+
+  test('should apply all transformations in sequence', () => {
+    const input =
+      'Call 555-123-4567\nVisit <a href="https://va.gov/sites/default/files/info.pdf">this file</a>\nFor more info'
+    const result = getHtmlFromDrupalContent(input)
+
+    // Should contain phone link
+    expect(result).toContain(
+      '<va-telephone contact="555-123-4567" extension=""></va-telephone>'
+    )
+    // Should contain file path transformation
+    expect(result).toContain('/files/info.pdf')
+    // Should contain br tags for newlines
+    expect(result).toContain('<br>')
+  })
+
+  test('should handle empty string', () => {
+    const input = ''
+    const result = getHtmlFromDrupalContent(input)
+    expect(result).toBe('')
+  })
+
+  test('should handle content with no transformations needed', () => {
+    const input = 'Simple text with no special content'
+    const result = getHtmlFromDrupalContent(input)
+    expect(result).toBe('Simple text with no special content')
+  })
+
+  test('should handle complex content with all transformation types', () => {
+    const input =
+      'Contact: 555-123-4567\nDownload: <a href="https://va.gov/sites/default/files/form.pdf">Form</a>\nImage: <a href="https://va.gov/sites/default/files/photo.jpg">Photo</a>\nThank you!'
+    const result = getHtmlFromDrupalContent(input)
+
+    // Check phone number transformation
+    expect(result).toContain(
+      '<va-telephone contact="555-123-4567" extension=""></va-telephone>'
+    )
+
+    // Check file path transformations
+    expect(result).toContain('/files/form.pdf')
+    expect(result).toContain('/img/photo.jpg')
+
+    // Check newline transformations
+    expect(result).toContain('<br>')
+
+    // Verify structure is maintained
+    expect(result).toContain('Contact:')
+    expect(result).toContain('Download:')
+    expect(result).toContain('Image:')
+    expect(result).toContain('Thank you!')
+  })
+
+  test('should handle mixed newline patterns', () => {
+    const input = 'Start\n\nMiddle\n\n\nEnd'
+    const result = getHtmlFromDrupalContent(input)
+    expect(result).toBe('Start<br><br>Middle<br><br><br>End')
+  })
+
+  test('should preserve existing HTML while adding transformations', () => {
+    const input = '<p>Call 555-123-4567</p>\n<div>More content</div>'
+    const result = getHtmlFromDrupalContent(input)
+
+    // Should preserve HTML tags
+    expect(result).toContain('<p>')
+    expect(result).toContain('</p>')
+    expect(result).toContain('<div>')
+    expect(result).toContain('</div>')
+
+    // Should add phone link
+    expect(result).toContain(
+      '<va-telephone contact="555-123-4567" extension=""></va-telephone>'
+    )
+
+    // Should convert newline to br
+    expect(result).toContain('<br>')
+  })
+})

--- a/src/lib/utils/getHtmlFromDrupalContent.test.ts
+++ b/src/lib/utils/getHtmlFromDrupalContent.test.ts
@@ -1,4 +1,7 @@
-import { getHtmlFromDrupalContent } from './getHtmlFromDrupalContent'
+import {
+  getHtmlFromDrupalContent,
+  GetHtmlFromDrupalContentOptions,
+} from './getHtmlFromDrupalContent'
 
 describe('getHtmlFromDrupalContent', () => {
   test('should apply createPhoneLinks transformation', () => {
@@ -23,16 +26,28 @@ describe('getHtmlFromDrupalContent', () => {
     expect(result).toBe('<a href="/files/document.pdf">Document</a>')
   })
 
-  test('should apply newlinesToBr transformation', () => {
+  test('should apply newlinesToBr transformation when convertNewlines is true', () => {
+    const input = 'Line 1\nLine 2\nLine 3'
+    const result = getHtmlFromDrupalContent(input, { convertNewlines: true })
+    expect(result).toBe('Line 1<br>Line 2<br>Line 3')
+  })
+
+  test('should not convert newlines when convertNewlines is false', () => {
+    const input = 'Line 1\nLine 2\nLine 3'
+    const result = getHtmlFromDrupalContent(input, { convertNewlines: false })
+    expect(result).toBe('Line 1\nLine 2\nLine 3')
+  })
+
+  test('should not convert newlines when no options provided', () => {
     const input = 'Line 1\nLine 2\nLine 3'
     const result = getHtmlFromDrupalContent(input)
-    expect(result).toBe('Line 1<br>Line 2<br>Line 3')
+    expect(result).toBe('Line 1\nLine 2\nLine 3')
   })
 
   test('should apply all transformations in sequence', () => {
     const input =
       'Call 555-123-4567\nVisit <a href="https://va.gov/sites/default/files/info.pdf">this file</a>\nFor more info'
-    const result = getHtmlFromDrupalContent(input)
+    const result = getHtmlFromDrupalContent(input, { convertNewlines: true })
 
     // Should contain phone link
     expect(result).toContain(
@@ -59,7 +74,7 @@ describe('getHtmlFromDrupalContent', () => {
   test('should handle complex content with all transformation types', () => {
     const input =
       'Contact: 555-123-4567\nDownload: <a href="https://va.gov/sites/default/files/form.pdf">Form</a>\nImage: <a href="https://va.gov/sites/default/files/photo.jpg">Photo</a>\nThank you!'
-    const result = getHtmlFromDrupalContent(input)
+    const result = getHtmlFromDrupalContent(input, { convertNewlines: true })
 
     // Check phone number transformation
     expect(result).toContain(
@@ -82,13 +97,13 @@ describe('getHtmlFromDrupalContent', () => {
 
   test('should handle mixed newline patterns', () => {
     const input = 'Start\n\nMiddle\n\n\nEnd'
-    const result = getHtmlFromDrupalContent(input)
+    const result = getHtmlFromDrupalContent(input, { convertNewlines: true })
     expect(result).toBe('Start<br><br>Middle<br><br><br>End')
   })
 
   test('should preserve existing HTML while adding transformations', () => {
     const input = '<p>Call 555-123-4567</p>\n<div>More content</div>'
-    const result = getHtmlFromDrupalContent(input)
+    const result = getHtmlFromDrupalContent(input, { convertNewlines: true })
 
     // Should preserve HTML tags
     expect(result).toContain('<p>')
@@ -103,5 +118,20 @@ describe('getHtmlFromDrupalContent', () => {
 
     // Should convert newline to br
     expect(result).toContain('<br>')
+  })
+
+  test('should handle empty options object', () => {
+    const input = 'Line 1\nLine 2'
+    const result = getHtmlFromDrupalContent(input, {})
+    expect(result).toBe('Line 1\nLine 2') // Should not convert newlines
+  })
+
+  test('should handle options with convertNewlines undefined', () => {
+    const input = 'Line 1\nLine 2'
+    const options: GetHtmlFromDrupalContentOptions = {
+      convertNewlines: undefined,
+    }
+    const result = getHtmlFromDrupalContent(input, options)
+    expect(result).toBe('Line 1\nLine 2') // Should not convert newlines when undefined
   })
 })

--- a/src/lib/utils/getHtmlFromDrupalContent.ts
+++ b/src/lib/utils/getHtmlFromDrupalContent.ts
@@ -1,13 +1,24 @@
 import { drupalToVaPath, newlinesToBr } from './helpers'
 import { createPhoneLinks } from './createPhoneLinks'
 
+export type GetHtmlFromDrupalContentOptions = {
+  convertNewlines?: boolean
+}
+
 /**
  * Extract and transform HTML content from Drupal with various filters applied.
  *
  * Return the HTML string after processing.
  */
-export const getHtmlFromDrupalContent = (content: string): string => {
-  return [createPhoneLinks, drupalToVaPath, newlinesToBr].reduce(
+export const getHtmlFromDrupalContent = (
+  content: string,
+  options: GetHtmlFromDrupalContentOptions = {}
+): string => {
+  const transformers = [createPhoneLinks, drupalToVaPath]
+  if (options.convertNewlines) {
+    transformers.push(newlinesToBr)
+  }
+  return transformers.reduce(
     (contentToTransform, transformFn) => transformFn(contentToTransform),
     content
   )

--- a/src/lib/utils/getHtmlFromDrupalContent.ts
+++ b/src/lib/utils/getHtmlFromDrupalContent.ts
@@ -1,0 +1,14 @@
+import { drupalToVaPath, newlinesToBr } from './helpers'
+import { createPhoneLinks } from './createPhoneLinks'
+
+/**
+ * Extract and transform HTML content from Drupal with various filters applied.
+ *
+ * Return the HTML string after processing.
+ */
+export const getHtmlFromDrupalContent = (content: string): string => {
+  return [createPhoneLinks, drupalToVaPath, newlinesToBr].reduce(
+    (contentToTransform, transformFn) => transformFn(contentToTransform),
+    content
+  )
+}

--- a/src/lib/utils/getHtmlFromField.ts
+++ b/src/lib/utils/getHtmlFromField.ts
@@ -1,6 +1,8 @@
 import { FieldFormattedText } from '@/types/drupal/field_type'
-import { drupalToVaPath } from './helpers'
-import { createPhoneLinks } from './createPhoneLinks'
+import {
+  getHtmlFromDrupalContent,
+  GetHtmlFromDrupalContentOptions,
+} from './getHtmlFromDrupalContent'
 
 /**
  * Extract the processed HTML from a FieldFormattedText field and apply filters.
@@ -8,10 +10,6 @@ import { createPhoneLinks } from './createPhoneLinks'
  * Return the HTML string after processing.
  */
 export const getHtmlFromField = (
-  formattedTextField?: Pick<FieldFormattedText, 'processed'>
-) => {
-  return [createPhoneLinks, drupalToVaPath].reduce(
-    (contentToTransform, transformFn) => transformFn(contentToTransform),
-    formattedTextField?.processed ?? ''
-  )
-}
+  formattedTextField?: Pick<FieldFormattedText, 'processed'>,
+  options?: GetHtmlFromDrupalContentOptions
+) => getHtmlFromDrupalContent(formattedTextField?.processed ?? '', options)

--- a/src/lib/utils/helpers.test.ts
+++ b/src/lib/utils/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   escape,
   numToWord,
   formatDate,
+  newlinesToBr,
 } from './helpers'
 
 describe('truncateWordsOrChar', () => {
@@ -308,5 +309,49 @@ describe('formatDate', () => {
   test('handles invalid inputs', () => {
     expect(() => formatDate('invalid-date')).not.toThrow()
     expect(formatDate('invalid-date')).toBe('Invalid Date')
+  })
+})
+
+describe('newlinesToBr', () => {
+  test('should convert single newline to <br> tag', () => {
+    const input = 'Line 1\nLine 2'
+    const result = newlinesToBr(input)
+    expect(result).toBe('Line 1<br>Line 2')
+  })
+
+  test('should convert multiple newlines to multiple <br> tags', () => {
+    const input = 'Line 1\nLine 2\nLine 3'
+    const result = newlinesToBr(input)
+    expect(result).toBe('Line 1<br>Line 2<br>Line 3')
+  })
+
+  test('should convert consecutive newlines to consecutive <br> tags', () => {
+    const input = 'Line 1\n\nLine 3'
+    const result = newlinesToBr(input)
+    expect(result).toBe('Line 1<br><br>Line 3')
+  })
+
+  test('should handle empty string', () => {
+    const input = ''
+    const result = newlinesToBr(input)
+    expect(result).toBe('')
+  })
+
+  test('should handle string without newlines', () => {
+    const input = 'No newlines here'
+    const result = newlinesToBr(input)
+    expect(result).toBe('No newlines here')
+  })
+
+  test('should handle newlines at the beginning and end', () => {
+    const input = '\nMiddle line\n'
+    const result = newlinesToBr(input)
+    expect(result).toBe('<br>Middle line<br>')
+  })
+
+  test('should handle only newlines', () => {
+    const input = '\n\n\n'
+    const result = newlinesToBr(input)
+    expect(result).toBe('<br><br><br>')
   })
 })

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -154,3 +154,10 @@ export const numToWord = (num) => {
       (num % 10 ? '-' + belowTwenty[(num % 10) - 1] : '')
     )
 }
+
+/**
+ * Convert newline characters to HTML <br> tags.
+ */
+export const newlinesToBr = (content: string): string => {
+  return content.replace(/\n/g, '<br>')
+}

--- a/src/templates/layouts/vetCenter/ExpandableOperatingStatus.test.tsx
+++ b/src/templates/layouts/vetCenter/ExpandableOperatingStatus.test.tsx
@@ -1,0 +1,270 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ExpandableOperatingStatus } from './ExpandableOperatingStatus'
+import { FacilityOperatingStatusFlags } from '@/types/drupal/node'
+
+describe('ExpandableOperatingStatus', () => {
+  describe('with operatingStatusMoreInfo provided', () => {
+    test('renders expandable alert for notice status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="notice"
+          operatingStatusMoreInfo="Additional facility notice information"
+        />
+      )
+
+      const expandableAlert = container.querySelector('va-alert-expandable')
+      expect(expandableAlert).toBeInTheDocument()
+      expect(expandableAlert).toHaveAttribute('trigger', 'Facility notice')
+      expect(expandableAlert).toHaveAttribute('status', 'info')
+      expect(
+        screen.getByText('Additional facility notice information')
+      ).toBeInTheDocument()
+    })
+
+    test('renders expandable alert for limited status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="limited"
+          operatingStatusMoreInfo="Limited services details"
+        />
+      )
+
+      const expandableAlert = container.querySelector('va-alert-expandable')
+      expect(expandableAlert).toBeInTheDocument()
+      expect(expandableAlert).toHaveAttribute(
+        'trigger',
+        'Limited services and hours'
+      )
+      expect(expandableAlert).toHaveAttribute('status', 'info')
+      expect(screen.getByText('Limited services details')).toBeInTheDocument()
+    })
+
+    test('renders expandable alert for temporary_closure status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="temporary_closure"
+          operatingStatusMoreInfo="Closure details and timeline"
+        />
+      )
+
+      const expandableAlert = container.querySelector('va-alert-expandable')
+      expect(expandableAlert).toBeInTheDocument()
+      expect(expandableAlert).toHaveAttribute(
+        'trigger',
+        'Temporary facility closure'
+      )
+      expect(expandableAlert).toHaveAttribute('status', 'warning')
+      expect(
+        screen.getByText('Closure details and timeline')
+      ).toBeInTheDocument()
+    })
+
+    test('renders expandable alert for temporary_location status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="temporary_location"
+          operatingStatusMoreInfo="New temporary location address"
+        />
+      )
+
+      const expandableAlert = container.querySelector('va-alert-expandable')
+      expect(expandableAlert).toBeInTheDocument()
+      expect(expandableAlert).toHaveAttribute('trigger', 'Temporary location')
+      expect(expandableAlert).toHaveAttribute('status', 'warning')
+      expect(
+        screen.getByText('New temporary location address')
+      ).toBeInTheDocument()
+    })
+
+    test('renders expandable alert for virtual_care status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="virtual_care"
+          operatingStatusMoreInfo="Virtual care instructions"
+        />
+      )
+
+      const expandableAlert = container.querySelector('va-alert-expandable')
+      expect(expandableAlert).toBeInTheDocument()
+      expect(expandableAlert).toHaveAttribute('trigger', 'Virtual care only')
+      expect(expandableAlert).toHaveAttribute('status', 'warning')
+      expect(screen.getByText('Virtual care instructions')).toBeInTheDocument()
+    })
+
+    test('renders expandable alert for coming_soon status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="coming_soon"
+          operatingStatusMoreInfo="Opening date and details"
+        />
+      )
+
+      const expandableAlert = container.querySelector('va-alert-expandable')
+      expect(expandableAlert).toBeInTheDocument()
+      expect(expandableAlert).toHaveAttribute('trigger', 'Coming soon')
+      expect(expandableAlert).toHaveAttribute('status', 'warning')
+      expect(screen.getByText('Opening date and details')).toBeInTheDocument()
+    })
+
+    test('renders expandable alert for closed status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="closed"
+          operatingStatusMoreInfo="Facility closure information"
+        />
+      )
+
+      const expandableAlert = container.querySelector('va-alert-expandable')
+      expect(expandableAlert).toBeInTheDocument()
+      expect(expandableAlert).toHaveAttribute('trigger', 'Facility closed')
+      expect(expandableAlert).toHaveAttribute('status', 'warning')
+      expect(
+        screen.getByText('Facility closure information')
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('without operatingStatusMoreInfo (slim alerts)', () => {
+    test('renders slim alert for notice status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="notice"
+          operatingStatusMoreInfo={null}
+        />
+      )
+
+      const alert = container.querySelector('va-alert')
+      expect(alert).toBeInTheDocument()
+      expect(alert).toHaveAttribute('status', 'info')
+      expect(screen.getByText('Facility notice')).toBeInTheDocument()
+
+      // Should not have expandable alert
+      expect(
+        container.querySelector('va-alert-expandable')
+      ).not.toBeInTheDocument()
+    })
+
+    test('renders slim alert for limited status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="limited"
+          operatingStatusMoreInfo={null}
+        />
+      )
+
+      const alert = container.querySelector('va-alert')
+      expect(alert).toBeInTheDocument()
+      expect(alert).toHaveAttribute('status', 'info')
+      expect(screen.getByText('Limited services and hours')).toBeInTheDocument()
+    })
+
+    test('renders slim alert for temporary_closure status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="temporary_closure"
+          operatingStatusMoreInfo={null}
+        />
+      )
+
+      const alert = container.querySelector('va-alert')
+      expect(alert).toBeInTheDocument()
+      expect(alert).toHaveAttribute('status', 'warning')
+      expect(screen.getByText('Temporary facility closure')).toBeInTheDocument()
+    })
+
+    test('renders slim alert for closed status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="closed"
+          operatingStatusMoreInfo={null}
+        />
+      )
+
+      const alert = container.querySelector('va-alert')
+      expect(alert).toBeInTheDocument()
+      expect(alert).toHaveAttribute('status', 'warning')
+      expect(screen.getByText('Facility closed')).toBeInTheDocument()
+    })
+  })
+
+  describe('edge cases and invalid statuses', () => {
+    test('returns null for normal status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="normal"
+          operatingStatusMoreInfo="Should not display"
+        />
+      )
+
+      expect(container.firstChild).toBeNull()
+      expect(screen.queryByText('Should not display')).not.toBeInTheDocument()
+    })
+
+    test('returns null for invalid status', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag={'invalid_status' as FacilityOperatingStatusFlags}
+          operatingStatusMoreInfo="Should not display"
+        />
+      )
+
+      expect(container.firstChild).toBeNull()
+      expect(screen.queryByText('Should not display')).not.toBeInTheDocument()
+    })
+
+    test('handles empty string as more info', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="notice"
+          operatingStatusMoreInfo=""
+        />
+      )
+
+      // Empty string is falsy, so should render slim alert
+      const alert = container.querySelector('va-alert')
+      expect(alert).toBeInTheDocument()
+      expect(alert).toHaveAttribute('slim')
+      expect(
+        container.querySelector('va-alert-expandable')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('styling and attributes', () => {
+    test('applies correct CSS classes and styles to expandable alert', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="notice"
+          operatingStatusMoreInfo="Test info"
+        />
+      )
+
+      const expandableAlert = container.querySelector('va-alert-expandable')
+      expect(expandableAlert).toHaveAttribute(
+        'className',
+        'vads-u-margin-y--0 vamc-facility-expandable-alert'
+      )
+      expect(expandableAlert).toHaveAttribute('style', 'max-width: 303px;')
+    })
+
+    test('applies correct CSS classes and styles to slim alert', () => {
+      const { container } = render(
+        <ExpandableOperatingStatus
+          operatingStatusFlag="notice"
+          operatingStatusMoreInfo={null}
+        />
+      )
+
+      const alert = container.querySelector('va-alert')
+      expect(alert).toHaveAttribute('className', 'vads-u-margin-y--0')
+      expect(alert).toHaveAttribute('style', 'max-width: 303px;')
+
+      const textElement = container.querySelector(
+        'p.vads-u-margin-y--0.vads-u-padding-y--0.vads-u-font-weight--bold'
+      )
+      expect(textElement).toBeInTheDocument()
+    })
+  })
+})

--- a/src/templates/layouts/vetCenter/ExpandableOperatingStatus.test.tsx
+++ b/src/templates/layouts/vetCenter/ExpandableOperatingStatus.test.tsx
@@ -231,40 +231,4 @@ describe('ExpandableOperatingStatus', () => {
       ).not.toBeInTheDocument()
     })
   })
-
-  describe('styling and attributes', () => {
-    test('applies correct CSS classes and styles to expandable alert', () => {
-      const { container } = render(
-        <ExpandableOperatingStatus
-          operatingStatusFlag="notice"
-          operatingStatusMoreInfo="Test info"
-        />
-      )
-
-      const expandableAlert = container.querySelector('va-alert-expandable')
-      expect(expandableAlert).toHaveAttribute(
-        'className',
-        'vads-u-margin-y--0 vamc-facility-expandable-alert'
-      )
-      expect(expandableAlert).toHaveAttribute('style', 'max-width: 303px;')
-    })
-
-    test('applies correct CSS classes and styles to slim alert', () => {
-      const { container } = render(
-        <ExpandableOperatingStatus
-          operatingStatusFlag="notice"
-          operatingStatusMoreInfo={null}
-        />
-      )
-
-      const alert = container.querySelector('va-alert')
-      expect(alert).toHaveAttribute('className', 'vads-u-margin-y--0')
-      expect(alert).toHaveAttribute('style', 'max-width: 303px;')
-
-      const textElement = container.querySelector(
-        'p.vads-u-margin-y--0.vads-u-padding-y--0.vads-u-font-weight--bold'
-      )
-      expect(textElement).toBeInTheDocument()
-    })
-  })
 })

--- a/src/templates/layouts/vetCenter/ExpandableOperatingStatus.tsx
+++ b/src/templates/layouts/vetCenter/ExpandableOperatingStatus.tsx
@@ -1,4 +1,8 @@
 import { FacilityOperatingStatusFlags } from '@/types/drupal/node'
+import {
+  VaAlert,
+  VaAlertExpandable,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings'
 
 const statusAlerts: Record<
   FacilityOperatingStatusFlags,
@@ -35,16 +39,16 @@ export const ExpandableOperatingStatus = ({
     const style = { maxWidth: '303px' }
 
     const alert = operatingStatusMoreInfo ? (
-      <va-alert-expandable
+      <VaAlertExpandable
         trigger={text}
         status={status}
         className="vads-u-margin-y--0 vamc-facility-expandable-alert"
         style={style}
       >
         <p dangerouslySetInnerHTML={{ __html: operatingStatusMoreInfo }} />
-      </va-alert-expandable>
+      </VaAlertExpandable>
     ) : (
-      <va-alert
+      <VaAlert
         status={status}
         className="vads-u-margin-y--0"
         slim
@@ -53,7 +57,7 @@ export const ExpandableOperatingStatus = ({
         <p className="vads-u-margin-y--0 vads-u-padding-y--0 vads-u-font-weight--bold">
           {text}
         </p>
-      </va-alert>
+      </VaAlert>
     )
 
     return <div className="vads-u-margin-bottom--1">{alert}</div>

--- a/src/templates/layouts/vetCenter/ExpandableOperatingStatus.tsx
+++ b/src/templates/layouts/vetCenter/ExpandableOperatingStatus.tsx
@@ -1,0 +1,63 @@
+import { FacilityOperatingStatusFlags } from '@/types/drupal/node'
+
+const statusAlerts: Record<
+  FacilityOperatingStatusFlags,
+  { status: 'info' | 'warning' | 'error'; text: string }
+> = {
+  notice: { status: 'info', text: 'Facility notice' },
+  limited: { status: 'info', text: 'Limited services and hours' },
+  temporary_closure: {
+    status: 'warning',
+    text: 'Temporary facility closure',
+  },
+  temporary_location: { status: 'warning', text: 'Temporary location' },
+  virtual_care: { status: 'warning', text: 'Virtual care only' },
+  coming_soon: { status: 'warning', text: 'Coming soon' },
+  closed: { status: 'warning', text: 'Facility closed' },
+}
+
+interface ExpandableOperatingStatusProps {
+  operatingStatusFlag: FacilityOperatingStatusFlags
+  operatingStatusMoreInfo: string | null
+}
+
+/**
+ * Returns an alert with the appropriate operating status.
+ * Returns null if the operating status is 'normal' or invalid.
+ */
+export const ExpandableOperatingStatus = ({
+  operatingStatusFlag,
+  operatingStatusMoreInfo,
+}: ExpandableOperatingStatusProps) => {
+  const statusAlert = statusAlerts[operatingStatusFlag]
+  if (statusAlert) {
+    const { status, text } = statusAlert
+    const style = { maxWidth: '303px' }
+
+    const alert = operatingStatusMoreInfo ? (
+      <va-alert-expandable
+        trigger={text}
+        status={status}
+        className="vads-u-margin-y--0 vamc-facility-expandable-alert"
+        style={style}
+      >
+        <p>{operatingStatusMoreInfo}</p>
+      </va-alert-expandable>
+    ) : (
+      <va-alert
+        status={status}
+        className="vads-u-margin-y--0"
+        slim
+        style={style}
+      >
+        <p className="vads-u-margin-y--0 vads-u-padding-y--0 vads-u-font-weight--bold">
+          {text}
+        </p>
+      </va-alert>
+    )
+
+    return <div className="vads-u-margin-bottom--1">{alert}</div>
+  }
+
+  return null
+}

--- a/src/templates/layouts/vetCenter/ExpandableOperatingStatus.tsx
+++ b/src/templates/layouts/vetCenter/ExpandableOperatingStatus.tsx
@@ -36,23 +36,20 @@ export const ExpandableOperatingStatus = ({
   const statusAlert = statusAlerts[operatingStatusFlag]
   if (statusAlert) {
     const { status, text } = statusAlert
-    const style = { maxWidth: '303px' }
 
     const alert = operatingStatusMoreInfo ? (
       <VaAlertExpandable
         trigger={text}
         status={status}
-        className="vads-u-margin-y--0 vamc-facility-expandable-alert"
-        style={style}
+        className="vads-u-margin-y--0 vamc-facility-expandable-alert vads-u-measure--1"
       >
         <p dangerouslySetInnerHTML={{ __html: operatingStatusMoreInfo }} />
       </VaAlertExpandable>
     ) : (
       <VaAlert
         status={status}
-        className="vads-u-margin-y--0"
+        className="vads-u-margin-y--0 vads-u-measure--1"
         slim
-        style={style}
       >
         <p className="vads-u-margin-y--0 vads-u-padding-y--0 vads-u-font-weight--bold">
           {text}

--- a/src/templates/layouts/vetCenter/ExpandableOperatingStatus.tsx
+++ b/src/templates/layouts/vetCenter/ExpandableOperatingStatus.tsx
@@ -41,7 +41,7 @@ export const ExpandableOperatingStatus = ({
         className="vads-u-margin-y--0 vamc-facility-expandable-alert"
         style={style}
       >
-        <p>{operatingStatusMoreInfo}</p>
+        <p dangerouslySetInnerHTML={{ __html: operatingStatusMoreInfo }} />
       </va-alert-expandable>
     ) : (
       <va-alert

--- a/src/templates/layouts/vetCenter/index.test.tsx
+++ b/src/templates/layouts/vetCenter/index.test.tsx
@@ -220,4 +220,19 @@ describe('VetCenter with valid data', () => {
     expect(screen.queryByText(/1010 Delafield Road/)).toBeInTheDocument()
     expect(screen.queryByText(/In the spotlight/)).toBeInTheDocument()
   })
+
+  test('renders ExpandableOperatingStatus when operating status is provided', () => {
+    const testDataWithOperatingStatus = {
+      ...mockData,
+      operatingStatusFacility: 'limited' as const,
+      operatingStatusMoreInfo: 'Limited hours due to maintenance',
+    }
+
+    const { container } = render(<VetCenter {...testDataWithOperatingStatus} />)
+
+    expect(container.querySelector('va-alert-expandable')).toBeInTheDocument()
+    expect(
+      screen.getByText('Limited hours due to maintenance')
+    ).toBeInTheDocument()
+  })
 })

--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -7,6 +7,7 @@ import VetCenterHealthServices from '@/templates/components/vetCenterHealthServi
 import { FeaturedContent } from '@/templates/common/featuredContent'
 import { QaSection } from '@/templates/components/qaSection'
 import { Accordion } from '@/templates/components/accordion'
+import { ExpandableOperatingStatus } from './ExpandableOperatingStatus'
 
 export function VetCenter({
   address,
@@ -18,6 +19,8 @@ export function VetCenter({
   introText,
   officeHours,
   officialName,
+  operatingStatusFacility,
+  operatingStatusMoreInfo,
   phoneNumber,
   healthServices,
   counselingHealthServices,
@@ -189,15 +192,10 @@ export function VetCenter({
                       Main Location
                     </h3>
 
-                    {/* For the ExpandableOperatingStatus widget in vets-website */}
-
-                    {/* TODO: potential change to the vets-website widget to not use facilityId as a prop on div */}
-                    {/* <div
-                      data-widget-type={`expandable-operating-status-${fieldFacilityLocatorApiId}`}
-                      facilityId={fieldFacilityLocatorApiId}
-                      status={operatingStatusFacility}
-                      info={operatingStatusMoreInfo}
-                    /> */}
+                    <ExpandableOperatingStatus
+                      operatingStatusFlag={operatingStatusFacility}
+                      operatingStatusMoreInfo={operatingStatusMoreInfo}
+                    />
 
                     <div className="vads-u-margin-bottom--3">
                       <address>

--- a/src/types/formatted/vetCenter.ts
+++ b/src/types/formatted/vetCenter.ts
@@ -11,6 +11,7 @@ import { MediaImage as FormattedMediaImage } from './media'
 import { AccordionItem as FormattedAccordionItem } from './accordion'
 import { Wysiwyg as FormattedWysiwyg } from './wysiwyg'
 import { QaSection as PublishedQaSection } from './qaSection'
+import { FacilityOperatingStatusFlags } from '../drupal/node'
 
 export type VetCenter = PublishedEntity & {
   address: FieldAddress
@@ -22,7 +23,7 @@ export type VetCenter = PublishedEntity & {
   lastSavedByAnEditor: string | null
   officeHours: FieldOfficeHours[]
   officialName: string
-  operatingStatusFacility: string
+  operatingStatusFacility: FacilityOperatingStatusFlags
   operatingStatusMoreInfo: string | null
   phoneNumber: string
   timezone: string


### PR DESCRIPTION
# Description

Ported [the old operating status template](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/includes/operating_status_expandable_alert.liquid) and modeled the new one after [the facility version](https://github.com/department-of-veterans-affairs/next-build/blob/db846cbc427efe5a32f23d99bc455aad8156a12f/src/templates/layouts/healthCareLocalFacility/OperatingStatus.tsx).

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21568

## Testing Steps

- http://localhost:3999/greensboro-vet-center/ has a "Faciility notice" under the "main location" heading
- http://localhost:3999/yakima-valley-vet-center/ has a "Virtual care only" status
- http://localhost:3999/columbus-oh-vet-center/ has a temporary closure

## Screenshots

<img width="768" alt="Screenshot 2025-07-07 at 10 26 05 PM" src="https://github.com/user-attachments/assets/180bb5e6-bad1-4916-86bc-16103ff099e3" />
