### PR TITLE
Fix timing for next build prod content release.

### DIFF
--- a/.github/workflows/content-release-prod.yml
+++ b/.github/workflows/content-release-prod.yml
@@ -7,11 +7,8 @@ on:
   schedule:
     # Content release to prod is every 30 minutes between the hours of 8 am - 8 pm ET,
     # with the exception of 3:30 pm ET to allow for CMS deploy.
-    # cron times are UTC
-    # Every 30 minutes, at 12:00 AM through 12:59 AM, 01:00 PM through 7:59 PM, and 09:00 PM through 11:59 PM, Monday through Friday
-    - cron: "*/30 0,13-19,21-23 * * 1-5"
-    # At 08:00 PM, Monday through Friday
-    - cron: "0 20 * * 1-5"
+    - cron: "*/30 12-18,20-23 * * 1-5"
+    - cron: "0 19 * * 1-5"
 
 
   # Runs on API call. Used for CMS-driven build triggers.


### PR DESCRIPTION
# Description

This corrects the timing for Next Build Prod content release which was all off by 1 hour.

## Ticket

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21714


## QA steps
This code moves everything one hour earlier. Please check the existing times for Next Build Prod Content Release https://github.com/department-of-veterans-affairs/next-build/actions/workflows/content-release-prod.yml

These should be every 00 and 30 from 8 am to 8 pm ET, except for 3 pm, which should only be at 3:00 and not at 3:30 pm ET.
