### PR TITLE
Vets Center: "Our commitment" mission explainer

### DIFF
--- a/src/data/queries/tests/vetCenter.test.tsx
+++ b/src/data/queries/tests/vetCenter.test.tsx
@@ -44,4 +44,85 @@ describe('VetCenter formatter function', () => {
       0
     )
   })
+
+  describe('Mission Explainer functionality', () => {
+    // Helper function to create mission explainer mock data
+    const createMissionExplainerMock = (
+      headingArray: Array<{ value: string } | undefined> = [],
+      bodyArray: Array<{
+        value: string
+        format: string
+        processed: string
+      } | null> = []
+    ) => ({
+      ...VetCenterMock,
+      field_mission_explainer: {
+        target_type: 'paragraph',
+        target_id: '158439',
+        target_field: null,
+        fetched_bundle: 'magichead_group',
+        fetched: {
+          field_magichead_body: bodyArray,
+          field_magichead_heading: headingArray,
+        },
+      },
+    })
+
+    test('formats mission explainer correctly when data is present', () => {
+      const formattedVetCenter = formatter(VetCenterMock)
+
+      expect(formattedVetCenter.missionExplainer).toBeDefined()
+      expect(formattedVetCenter.missionExplainer.heading).toBe('Our commitment')
+      expect(formattedVetCenter.missionExplainer.body).toContain(
+        'We offer a range of services'
+      )
+      expect(formattedVetCenter.missionExplainer.body).toContain(
+        'talk therapy to recreational activities'
+      )
+    })
+
+    test('returns null for mission explainer when heading is missing', () => {
+      const mockWithMissingHeading = createMissionExplainerMock(
+        [], // Empty heading array
+        [
+          {
+            value: '<p>Some body content</p>',
+            format: 'rich_text_limited',
+            processed: '<p>Some body content</p>',
+          },
+        ]
+      )
+
+      const formattedVetCenter = formatter(mockWithMissingHeading)
+      expect(formattedVetCenter.missionExplainer).toBeNull()
+    })
+
+    test('returns null for mission explainer when body is missing', () => {
+      const mockWithMissingBody = createMissionExplainerMock(
+        [{ value: 'Our commitment' }],
+        [] // Empty body array
+      )
+
+      const formattedVetCenter = formatter(mockWithMissingBody)
+      expect(formattedVetCenter.missionExplainer).toBeNull()
+    })
+
+    test('returns null for mission explainer when both heading and body are missing', () => {
+      const mockWithMissingBoth = createMissionExplainerMock([], [])
+
+      const formattedVetCenter = formatter(mockWithMissingBoth)
+      expect(formattedVetCenter.missionExplainer).toBeNull()
+    })
+
+    test('handles undefined mission explainer field gracefully', () => {
+      const mockWithUndefinedFields = createMissionExplainerMock(
+        [undefined], // Array with undefined value
+        [null] // Array with null value
+      )
+
+      // Should not throw an error and should return null
+      const formattedVetCenter = formatter(mockWithUndefinedFields)
+      expect(formattedVetCenter.missionExplainer).toBeNull()
+    })
+  })
 })

--- a/src/data/queries/vetCenter.ts
+++ b/src/data/queries/vetCenter.ts
@@ -139,6 +139,14 @@ export const formatter: QueryFormatter<NodeVetCenter, FormattedVetCenter> = (
     }
   }
 
+  const missionExplainer = {
+    heading:
+      entity.field_mission_explainer.fetched.field_magichead_heading[0]?.value,
+    body: getHtmlFromField(
+      entity.field_mission_explainer.fetched.field_magichead_body[0] ?? null
+    ),
+  }
+
   return {
     ...entityBaseFields(entity),
     address: entity.field_address,
@@ -162,13 +170,10 @@ export const formatter: QueryFormatter<NodeVetCenter, FormattedVetCenter> = (
     ccVetCenterFeaturedCon: entity.field_cc_vet_center_featured_con,
     geolocation: entity.field_geolocation,
     introText: entity.field_intro_text,
-    missionExplainer: {
-      heading:
-        entity.field_mission_explainer.fetched.field_magichead_heading[0].value,
-      body: getHtmlFromField(
-        entity.field_mission_explainer.fetched.field_magichead_body[0]
-      ),
-    },
+    missionExplainer:
+      missionExplainer.heading && missionExplainer.body
+        ? missionExplainer
+        : null,
     lastSavedByAnEditor: entity.field_last_saved_by_an_editor ?? null,
     officeHours: entity.field_office_hours,
     officialName: entity.field_official_name,

--- a/src/data/queries/vetCenter.ts
+++ b/src/data/queries/vetCenter.ts
@@ -18,6 +18,7 @@ import { Button } from '@/types/formatted/button'
 import { Wysiwyg } from '@/types/formatted/wysiwyg'
 import { getNestedIncludes } from '@/lib/utils/queries'
 import { getHtmlFromDrupalContent } from '@/lib/utils/getHtmlFromDrupalContent'
+import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
 
 // Define the query params for fetching node--vet_center.
 export const params: QueryParams<null> = () => {
@@ -161,6 +162,13 @@ export const formatter: QueryFormatter<NodeVetCenter, FormattedVetCenter> = (
     ccVetCenterFeaturedCon: entity.field_cc_vet_center_featured_con,
     geolocation: entity.field_geolocation,
     introText: entity.field_intro_text,
+    missionExplainer: {
+      heading:
+        entity.field_mission_explainer.fetched.field_magichead_heading[0].value,
+      body: getHtmlFromField(
+        entity.field_mission_explainer.fetched.field_magichead_body[0]
+      ),
+    },
     lastSavedByAnEditor: entity.field_last_saved_by_an_editor ?? null,
     officeHours: entity.field_office_hours,
     officialName: entity.field_official_name,

--- a/src/mocks/vetCenter.mock.js
+++ b/src/mocks/vetCenter.mock.js
@@ -1022,6 +1022,28 @@ export const mockResponse = {
       ],
     },
   ],
+  field_mission_explainer: {
+    target_type: 'paragraph',
+    target_id: '158439',
+    target_field: null,
+    fetched_bundle: 'magichead_group',
+    fetched: {
+      field_magichead_body: [
+        {
+          value:
+            "<ul><li>We offer a range of services, from talk therapy to recreational activities. Our team will work with you to identify your goals and make a plan to meet them. We'll help you and your family build meaningful connections to improve your quality of life.</li><li>Our counseling is confidential. We won’t share any information about you or the services you receive without your permission—except in a life-threatening situation. Our records can't be accessed by other VA offices, the Defense Department, military units, or community providers.</li><li>We encourage you to contact us, even if you're not sure you're eligible. We'll find a way to connect you with the help you need.</li></ul>",
+          format: 'rich_text_limited',
+          processed:
+            "<ul>\n<li>We offer a range of services, from talk therapy to recreational activities. Our team will work with you to identify your goals and make a plan to meet them. We'll help you and your family build meaningful connections to improve your quality of life.</li>\n<li>Our counseling is confidential. We won’t share any information about you or the services you receive without your permission—except in a life-threatening situation. Our records can't be accessed by other VA offices, the Defense Department, military units, or community providers.</li>\n<li>We encourage you to contact us, even if you're not sure you're eligible. We'll find a way to connect you with the help you need.</li>\n</ul>\n",
+        },
+      ],
+      field_magichead_heading: [
+        {
+          value: 'Our commitment',
+        },
+      ],
+    },
+  },
   field_media: {
     type: 'media--image',
     id: '6982c62d-26f7-41bf-a4ed-3ec4e6e9f198',

--- a/src/templates/layouts/vetCenter/index.test.tsx
+++ b/src/templates/layouts/vetCenter/index.test.tsx
@@ -350,4 +350,38 @@ describe('VetCenter with valid data', () => {
     // Verify the contact attribute contains the phone number without dashes
     expect(vaTelephoneElement?.getAttribute('contact')).toBe('1234567890')
   })
+
+  describe('Mission Explainer functionality', () => {
+    test('renders mission explainer when data is present', () => {
+      render(<VetCenter {...mockData} />)
+
+      // Check that the mission explainer va-summary-box is rendered
+      const summaryBox = document.querySelector('va-summary-box')
+      expect(summaryBox).toBeInTheDocument()
+
+      // Check that the heading is rendered correctly
+      expect(screen.getByText('Our commitment')).toBeInTheDocument()
+
+      // Check that the body content is rendered
+      expect(
+        screen.getByText(/We offer a range of services/)
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(/talk therapy to recreational activities/)
+      ).toBeInTheDocument()
+    })
+
+    test('does not render mission explainer when data is missing', () => {
+      const dataWithoutMissionExplainer = {
+        ...mockData,
+        missionExplainer: null,
+      }
+
+      render(<VetCenter {...dataWithoutMissionExplainer} />)
+
+      // Check that the mission explainer va-summary-box is not rendered
+      const summaryBox = document.querySelector('va-summary-box')
+      expect(summaryBox).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/templates/layouts/vetCenter/index.test.tsx
+++ b/src/templates/layouts/vetCenter/index.test.tsx
@@ -81,6 +81,10 @@ describe('VetCenter with valid data', () => {
       },
     ],
     introText: 'Test introText',
+    missionExplainer: {
+      heading: 'Our commitment',
+      body: "<p>We offer a range of services, from talk therapy to recreational activities. Our team will work with you to identify your goals and make a plan to meet them. We'll help you and your family build meaningful connections to improve your quality of life.</p>",
+    },
     officeHours: [
       { day: 0, starthours: null, endhours: null, comment: 'Closed' },
       { day: 1, starthours: 800, endhours: 1630, comment: '' },

--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -18,6 +18,7 @@ export function VetCenter({
   geolocation,
   featuredContent,
   introText,
+  missionExplainer,
   officeHours,
   officialName,
   operatingStatusFacility,
@@ -187,6 +188,19 @@ export function VetCenter({
             <div className="va-introtext">
               <p>{introText}</p>
             </div>
+          )}
+          {missionExplainer && (
+            <va-summary-box
+              class="vads-u-margin-bottom--4 medium-screen:vads-u-margin-bottom--0"
+              data-header-id-excluded="true"
+            >
+              <h2 slot="headline">{missionExplainer.heading}</h2>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: missionExplainer.body,
+                }}
+              />
+            </va-summary-box>
           )}
           <va-on-this-page></va-on-this-page>
 

--- a/src/types/drupal/field_type.d.ts
+++ b/src/types/drupal/field_type.d.ts
@@ -136,6 +136,15 @@ export interface FieldCCText {
   }
 }
 
+export interface FieldMissionExplainer {
+  target_id?: string
+  fetched_bundle: string
+  fetched: {
+    field_magichead_body: FieldFormattedText[]
+    field_magichead_heading: Pick<FieldFormattedText, 'value'>[]
+  }
+}
+
 export type FieldGeoLocation = {
   value: string
   geo_type: string

--- a/src/types/drupal/node.ts
+++ b/src/types/drupal/node.ts
@@ -16,6 +16,7 @@ import {
   FieldGeoLocation,
   VetCenterFieldHealthServicesArray,
   BreadcrumbItem,
+  FieldMissionExplainer,
 } from './field_type'
 import { DrupalMediaDocument, DrupalMediaImage } from './media'
 import {
@@ -180,6 +181,7 @@ export interface NodeVetCenter extends DrupalNode {
   field_cc_vet_center_featured_con: ParagraphCCFeaturedContent
   field_geolocation: FieldGeoLocation
   field_intro_text: string
+  field_mission_explainer: FieldMissionExplainer
   field_last_saved_by_an_editor?: string
   field_office_hours: FieldOfficeHours[]
   field_official_name: string

--- a/src/types/formatted/vetCenter.ts
+++ b/src/types/formatted/vetCenter.ts
@@ -23,7 +23,7 @@ export type VetCenter = PublishedEntity & {
   missionExplainer: {
     heading: string
     body: string
-  }
+  } | null
   lastSavedByAnEditor: string | null
   officeHours: FieldOfficeHours[]
   officialName: string

--- a/src/types/formatted/vetCenter.ts
+++ b/src/types/formatted/vetCenter.ts
@@ -20,6 +20,10 @@ export type VetCenter = PublishedEntity & {
   ccVetCenterFaqs: PublishedQaSection
   geolocation: FieldGeoLocation
   introText: string
+  missionExplainer: {
+    heading: string
+    body: string
+  }
   lastSavedByAnEditor: string | null
   officeHours: FieldOfficeHours[]
   officialName: string


### PR DESCRIPTION
# Description

Adds the "Our commitment" box based on [the original template](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/site/layouts/vet_center.drupal.liquid#L35-L40).

- Adds new TypeScript types for defining that data
- Adds functionality to the query formatter
- Adds the new content to the Vets Center page component
- Adds appropriate unit tests

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21556

## Testing Steps

http://localhost:3999/greensboro-vet-center/

## Screenshots

<img width="827" height="760" alt="Screenshot 2025-07-11 at 10 33 21 AM" src="https://github.com/user-attachments/assets/411e8b31-fa96-403b-b94b-400f7faa0d83" />