### PR TITLE
Vets Center: Transform HTML content for various content fields

### DIFF
--- a/src/data/queries/accordion.ts
+++ b/src/data/queries/accordion.ts
@@ -1,6 +1,7 @@
 import { QueryFormatter } from 'next-drupal-query'
 import { ParagraphAccordion } from '@/types/drupal/paragraph'
 import { AccordionItem } from '@/types/formatted/accordion'
+import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
 
 export const formatter: QueryFormatter<ParagraphAccordion, AccordionItem> = (
   entity: ParagraphAccordion
@@ -10,6 +11,6 @@ export const formatter: QueryFormatter<ParagraphAccordion, AccordionItem> = (
     id: entity.id,
     entityId: entity.drupal_internal__id,
     header: entity.field_header || null,
-    html: entity.field_rich_wysiwyg.processed,
+    html: getHtmlFromField(entity.field_rich_wysiwyg),
   }
 }

--- a/src/data/queries/featuredContent.ts
+++ b/src/data/queries/featuredContent.ts
@@ -3,6 +3,7 @@ import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import { ParagraphFeaturedContent } from '@/types/drupal/paragraph'
 import { FeaturedContent } from '@/types/formatted/featuredContent'
 import { queries } from '.'
+import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
 
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude(['field_cta'])
@@ -18,7 +19,7 @@ export const formatter: QueryFormatter<
     id: entity.id,
     entityId: entity.drupal_internal__id || null,
     title: entity.field_section_header,
-    description: entity.field_description.processed || null,
+    description: getHtmlFromField(entity.field_description) || null,
     link: entity.field_cta
       ? queries.formatData('paragraph--button', entity.field_cta)
       : null,

--- a/src/data/queries/tests/__snapshots__/vetCenterHealthServices.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/vetCenterHealthServices.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`healthServices formatData outputs formatted data 1`] = `
     "body": "<p>Military sexual trauma can happen to both men and women. If you experienced sexual assault or harassment during military service - no matter when you served – we provide counseling and treatment.</p>
 ",
     "commonlyTreatedCondition": null,
-    "description": "Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.",
     "name": "Military sexual trauma care",
     "vetCenterComConditions": null,
     "vetCenterFriendlyName": null,

--- a/src/data/queries/tests/__snapshots__/vetCenterOutstations.test.ts.snap
+++ b/src/data/queries/tests/__snapshots__/vetCenterOutstations.test.ts.snap
@@ -562,7 +562,7 @@ exports[`VetCenterOutstation formatData handles ccFeaturedContent not getting fe
       "header": "Appointments",
       "html": "<p><strong>Contacting the Springfield Vet Center</strong></p>
 <ul>
-<li>Please call <strong>413-737-5167</strong> to speak with a staff member that will assist you with scheduling an appointment, questions you may have or provide an appropriate referral.</li>
+<li>Please call <strong><va-telephone contact="413-737-5167" extension=""></va-telephone></strong> to speak with a staff member that will assist you with scheduling an appointment, questions you may have or provide an appropriate referral.</li>
 <li>Same day services available, call for details.</li>
 <li>Non-traditional hours (including every other Saturday) available by appointment.</li>
 <li>If you call us and reach the 24/7 Vet Center Call Center which is located in Colorado, you may leave a message with their team.&nbsp; They can provide a warm hand-off to us and we will contact you right away.&nbsp; If you call outside of our normal operating hours the Vet Center Call Center will answer your call.</li>
@@ -590,7 +590,7 @@ exports[`VetCenterOutstation formatData handles ccFeaturedContent not getting fe
       "header": "Transportation services and schedule",
       "html": "<p><strong>Bus:</strong> Pioneer Valley Transit Authority has a stop within 500 ft of the Springfield Vet Center. Visit <a href="http://www.pvta.com/schedules.php">http://www.pvta.com/schedules.php</a>.</p>
 <p>&nbsp;</p>
-<p><strong>DAV: </strong>Local DAV Transportation may be contacted&nbsp;directly at <strong>413-582-3078</strong>. Veteran must provide the following information to schedule transportation services; first and last name, Last 4 SSN, pick up street address, contact number, location of appointment, and time of appointment.</p>
+<p><strong>DAV: </strong>Local DAV Transportation may be contacted&nbsp;directly at <strong><va-telephone contact="413-582-3078" extension=""></va-telephone></strong>. Veteran must provide the following information to schedule transportation services; first and last name, Last 4 SSN, pick up street address, contact number, location of appointment, and time of appointment.</p>
 <p>Check with your local senior center for low cost transportation options.</p>
 ",
       "id": "90289c88-e193-4237-a74e-8cef0152413f",
@@ -1148,7 +1148,7 @@ exports[`VetCenterOutstation formatData outputs formatted data 1`] = `
       "header": "Appointments",
       "html": "<p><strong>Contacting the Springfield Vet Center</strong></p>
 <ul>
-<li>Please call <strong>413-737-5167</strong> to speak with a staff member that will assist you with scheduling an appointment, questions you may have or provide an appropriate referral.</li>
+<li>Please call <strong><va-telephone contact="413-737-5167" extension=""></va-telephone></strong> to speak with a staff member that will assist you with scheduling an appointment, questions you may have or provide an appropriate referral.</li>
 <li>Same day services available, call for details.</li>
 <li>Non-traditional hours (including every other Saturday) available by appointment.</li>
 <li>If you call us and reach the 24/7 Vet Center Call Center which is located in Colorado, you may leave a message with their team.&nbsp; They can provide a warm hand-off to us and we will contact you right away.&nbsp; If you call outside of our normal operating hours the Vet Center Call Center will answer your call.</li>
@@ -1176,7 +1176,7 @@ exports[`VetCenterOutstation formatData outputs formatted data 1`] = `
       "header": "Transportation services and schedule",
       "html": "<p><strong>Bus:</strong> Pioneer Valley Transit Authority has a stop within 500 ft of the Springfield Vet Center. Visit <a href="http://www.pvta.com/schedules.php">http://www.pvta.com/schedules.php</a>.</p>
 <p>&nbsp;</p>
-<p><strong>DAV: </strong>Local DAV Transportation may be contacted&nbsp;directly at <strong>413-582-3078</strong>. Veteran must provide the following information to schedule transportation services; first and last name, Last 4 SSN, pick up street address, contact number, location of appointment, and time of appointment.</p>
+<p><strong>DAV: </strong>Local DAV Transportation may be contacted&nbsp;directly at <strong><va-telephone contact="413-582-3078" extension=""></va-telephone></strong>. Veteran must provide the following information to schedule transportation services; first and last name, Last 4 SSN, pick up street address, contact number, location of appointment, and time of appointment.</p>
 <p>Check with your local senior center for low cost transportation options.</p>
 ",
       "id": "90289c88-e193-4237-a74e-8cef0152413f",

--- a/src/data/queries/tests/__snapshots__/vetCenterOutstations.test.ts.snap
+++ b/src/data/queries/tests/__snapshots__/vetCenterOutstations.test.ts.snap
@@ -213,7 +213,6 @@ exports[`VetCenterOutstation formatData handles ccFeaturedContent not getting fe
       "body": "<p>Military sexual trauma can happen to both men and women. If you experienced sexual assault or harassment during military service - no matter when you served – we provide counseling and treatment.</p>
 ",
       "commonlyTreatedCondition": null,
-      "description": "Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.",
       "name": "Military sexual trauma care",
       "vetCenterComConditions": null,
       "vetCenterFriendlyName": null,
@@ -380,7 +379,6 @@ exports[`VetCenterOutstation formatData handles ccFeaturedContent not getting fe
       "body": "<p>Military sexual trauma can happen to both men and women. If you experienced sexual assault or harassment during military service - no matter when you served – we provide counseling and treatment.</p>
 ",
       "commonlyTreatedCondition": null,
-      "description": "Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.",
       "name": "Military sexual trauma care",
       "vetCenterComConditions": null,
       "vetCenterFriendlyName": null,
@@ -896,7 +894,6 @@ exports[`VetCenterOutstation formatData outputs formatted data 1`] = `
       "body": "<p>Military sexual trauma can happen to both men and women. If you experienced sexual assault or harassment during military service - no matter when you served – we provide counseling and treatment.</p>
 ",
       "commonlyTreatedCondition": null,
-      "description": "Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.",
       "name": "Military sexual trauma care",
       "vetCenterComConditions": null,
       "vetCenterFriendlyName": null,
@@ -966,7 +963,6 @@ exports[`VetCenterOutstation formatData outputs formatted data 1`] = `
       "body": "<p>Military sexual trauma can happen to both men and women. If you experienced sexual assault or harassment during military service - no matter when you served – we provide counseling and treatment.</p>
 ",
       "commonlyTreatedCondition": null,
-      "description": "Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.",
       "name": "Military sexual trauma care",
       "vetCenterComConditions": null,
       "vetCenterFriendlyName": null,

--- a/src/data/queries/tests/vetCenterHealthServices.test.tsx
+++ b/src/data/queries/tests/vetCenterHealthServices.test.tsx
@@ -38,7 +38,6 @@ describe('healthServices formatData', () => {
         field_vet_center_com_conditions: null,
         field_commonly_treated_condition: null,
         field_vet_center_service_descrip: null,
-        description: { processed: null },
       },
       field_body: null,
     }))
@@ -56,7 +55,6 @@ describe('healthServices formatData', () => {
       expect(service.vetCenterComConditions).toBeNull()
       expect(service.commonlyTreatedCondition).toBeNull()
       expect(service.vetCenterServiceDescription).toBeNull()
-      expect(service.description).toBeNull()
       expect(service.body).toBeNull()
     })
   })

--- a/src/data/queries/vetCenter.ts
+++ b/src/data/queries/vetCenter.ts
@@ -147,13 +147,15 @@ export const formatter: QueryFormatter<NodeVetCenter, FormattedVetCenter> = (
     ccNonTraditionalHours: {
       type: PARAGRAPH_RESOURCE_TYPES.WYSIWYG as Wysiwyg['type'],
       id: entity.id || null,
-      html: entity.field_cc_non_traditional_hours.fetched.field_wysiwyg[0]
-        .processed,
+      html: getHtmlFromField(
+        entity.field_cc_non_traditional_hours.fetched.field_wysiwyg[0]
+      ),
     },
     ccVetCenterCallCenter: {
       type: PARAGRAPH_RESOURCE_TYPES.WYSIWYG as Wysiwyg['type'],
-      html: entity.field_cc_vet_center_call_center.fetched.field_wysiwyg[0]
-        .processed,
+      html: getHtmlFromField(
+        entity.field_cc_vet_center_call_center.fetched.field_wysiwyg[0]
+      ),
       id: entity.id || null,
     },
     ccVetCenterFaqs: buildFaqs(entity.field_cc_vet_center_faqs),

--- a/src/data/queries/vetCenter.ts
+++ b/src/data/queries/vetCenter.ts
@@ -18,6 +18,7 @@ import { Button } from '@/types/formatted/button'
 import { Wysiwyg } from '@/types/formatted/wysiwyg'
 import { getNestedIncludes } from '@/lib/utils/queries'
 import { getHtmlFromDrupalContent } from '@/lib/utils/getHtmlFromDrupalContent'
+import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
 
 // Define the query params for fetching node--vet_center.
 export const params: QueryParams<null> = () => {
@@ -120,7 +121,9 @@ export const formatter: QueryFormatter<NodeVetCenter, FormattedVetCenter> = (
         question: question.field_question[0]?.value || null,
         answers: [
           {
-            html: question.field_answer[0]?.field_wysiwyg[0]?.value || null,
+            html:
+              getHtmlFromField(question.field_answer[0]?.field_wysiwyg[0]) ||
+              null,
           },
         ],
         header: question.label || null,

--- a/src/data/queries/vetCenterHealthServices.ts
+++ b/src/data/queries/vetCenterHealthServices.ts
@@ -36,7 +36,6 @@ export const formatter: QueryFormatter<
         getHtmlFromDrupalContent(
           serviceEntity.field_vet_center_service_descrip
         ) || null,
-      description: getHtmlFromField(serviceEntity.description) || null,
       body: getHtmlFromField(item.field_body) || null,
     }
   })

--- a/src/data/queries/vetCenterHealthServices.ts
+++ b/src/data/queries/vetCenterHealthServices.ts
@@ -5,6 +5,8 @@ import {
 } from '@/types/formatted/vetCenterHealthServices'
 import { QueryFormatter, QueryParams } from 'next-drupal-query'
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
+import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
+import { getHtmlFromDrupalContent } from '@/lib/utils/getHtmlFromDrupalContent'
 
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams().addInclude([
@@ -31,9 +33,11 @@ export const formatter: QueryFormatter<
       commonlyTreatedCondition:
         serviceEntity.field_commonly_treated_condition || null,
       vetCenterServiceDescription:
-        serviceEntity.field_vet_center_service_descrip || null,
-      description: serviceEntity.description?.processed || null,
-      body: item.field_body?.processed || null,
+        getHtmlFromDrupalContent(
+          serviceEntity.field_vet_center_service_descrip
+        ) || null,
+      description: getHtmlFromField(serviceEntity.description) || null,
+      body: getHtmlFromField(item.field_body) || null,
     }
   })
 }

--- a/src/templates/components/vetCenterHealthServices/healthServices.stories.ts
+++ b/src/templates/components/vetCenterHealthServices/healthServices.stories.ts
@@ -19,7 +19,6 @@ const sampleServices: FormattedHealthServices = [
     vetCenterComConditions: 'Common Conditions etc...',
     commonlyTreatedCondition: null,
     vetCenterServiceDescription: 'PTSD care description...',
-    description: 'PTSD care detailed description...',
     body: '<p>PTSD care body content...</p>',
   },
   {
@@ -30,7 +29,6 @@ const sampleServices: FormattedHealthServices = [
     vetCenterComConditions: null,
     commonlyTreatedCondition: null,
     vetCenterServiceDescription: 'Couples and family counseling...',
-    description: 'Couples and family counseling detailed description...',
     body: '<p>Couples and family counseling body content...</p>',
   },
   {
@@ -41,7 +39,6 @@ const sampleServices: FormattedHealthServices = [
     vetCenterComConditions: null,
     commonlyTreatedCondition: null,
     vetCenterServiceDescription: 'Community engagement description...',
-    description: 'Community engagement detailed description...',
     body: '<p>PCommunity engagement body content...</p>',
   },
 ]

--- a/src/templates/components/vetCenterHealthServicesList/index.tsx
+++ b/src/templates/components/vetCenterHealthServicesList/index.tsx
@@ -24,10 +24,14 @@ function ServicesList({ services }: ServicesListProps) {
               <p>{service.vetCenterComConditions}</p>
             )}
             {service.vetCenterServiceDescription && (
-              <p>{service.vetCenterServiceDescription}</p>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: service.vetCenterServiceDescription,
+                }}
+              />
             )}
             {service.body && (
-              <div dangerouslySetInnerHTML={{ __html: service.body }} />
+              <p dangerouslySetInnerHTML={{ __html: service.body }} />
             )}
           </va-accordion-item>
         ))}

--- a/src/templates/components/vetCenterHealthServicesList/index.tsx
+++ b/src/templates/components/vetCenterHealthServicesList/index.tsx
@@ -31,7 +31,7 @@ function ServicesList({ services }: ServicesListProps) {
               />
             )}
             {service.body && (
-              <p dangerouslySetInnerHTML={{ __html: service.body }} />
+              <div dangerouslySetInnerHTML={{ __html: service.body }} />
             )}
           </va-accordion-item>
         ))}

--- a/src/templates/layouts/vetCenter/vetCenter.stories.ts
+++ b/src/templates/layouts/vetCenter/vetCenter.stories.ts
@@ -109,8 +109,6 @@ export const Example: Story = {
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
           'If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and support through private counseling and group therapy. We can also refer you to VA or community counseling for treatment and therapy resources.',
-        description:
-          '<p>If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and treatment support such as private counseling, group therapy and medication. It’s never too late to get help.</p>',
         body: '<p>Pittsburgh Vet Center offers individual and group counseling.</p><p>Specialty care includes</p><ul><li>Evidence based therapies such as; Cognitive Processing Therapy (CPT) and Prolonged Exposure (PE).</li><li>Whole health activities such as yoga and mindfulness</li><li>Seeking Safety for PTSD and substance abuse disorder dual diagnosis</li></ul>',
       },
       {
@@ -121,8 +119,6 @@ export const Example: Story = {
         vetCenterComConditions: null,
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
-          'We offer couples and family counseling to support you as you work toward meeting your goals.',
-        description:
           'We offer couples and family counseling to support you as you work toward meeting your goals.',
         body: '<p>Pittsburgh Vet Center counselors on-site to offer family and couples counseling.</p><p>Specialty care includes</p><ul><li>Couples counseling and support</li><li>Spouse and Significant Other groups</li></ul>',
       },
@@ -135,8 +131,6 @@ export const Example: Story = {
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
           'If you experienced sexual assault or harassment during military service, we can help you get the counseling you need. Any Veteran or service member, including members of the National Guard and Reserve forces, who experienced military sexual trauma is eligible to receive counseling. This applies to people of all genders from any service era.',
-        description:
-          'Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.',
         body: '<p>Pittsburgh Vet Center offers individual and group counseling by counselors with specific training related to military sexual trauma care.</p>',
       },
     ],
@@ -151,8 +145,6 @@ export const Example: Story = {
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
           'If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and support through private counseling and group therapy. We can also refer you to VA or community counseling for treatment and therapy resources.',
-        description:
-          '<p>If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and treatment support such as private counseling, group therapy and medication. It’s never too late to get help.</p>',
         body: '<p>Pittsburgh Vet Center offers individual and group counseling.</p><p>Specialty care includes</p><ul><li>Evidence based therapies such as; Cognitive Processing Therapy (CPT) and Prolonged Exposure (PE).</li><li>Whole health activities such as yoga and mindfulness</li><li>Seeking Safety for PTSD and substance abuse disorder dual diagnosis</li></ul>',
       },
     ],
@@ -165,8 +157,6 @@ export const Example: Story = {
         vetCenterComConditions: null,
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
-          'We offer couples and family counseling to support you as you work toward meeting your goals.',
-        description:
           'We offer couples and family counseling to support you as you work toward meeting your goals.',
         body: '<p>Pittsburgh Vet Center counselors on-site to offer family and couples counseling.</p><p>Specialty care includes</p><ul><li>Couples counseling and support</li><li>Spouse and Significant Other groups</li></ul>',
       },
@@ -181,8 +171,6 @@ export const Example: Story = {
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
           'If you experienced sexual assault or harassment during military service, we can help you get the counseling you need. Any Veteran or service member, including members of the National Guard and Reserve forces, who experienced military sexual trauma is eligible to receive counseling. This applies to people of all genders from any service era.',
-        description:
-          'Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.',
         body: '<p>Pittsburgh Vet Center offers individual and group counseling by counselors with specific training related to military sexual trauma care.</p>',
       },
     ],

--- a/src/templates/layouts/vetCenterOutstation/vetCenterOutstation.stories.ts
+++ b/src/templates/layouts/vetCenterOutstation/vetCenterOutstation.stories.ts
@@ -102,8 +102,6 @@ export const Example: Story = {
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
           'If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and support through private counseling and group therapy. We can also refer you to VA or community counseling for treatment and therapy resources.',
-        description:
-          '<p>If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and treatment support such as private counseling, group therapy and medication. It’s never too late to get help.</p>',
         body: '<p>Pittsburgh Vet Center offers individual and group counseling.</p><p>Specialty care includes</p><ul><li>Evidence based therapies such as; Cognitive Processing Therapy (CPT) and Prolonged Exposure (PE).</li><li>Whole health activities such as yoga and mindfulness</li><li>Seeking Safety for PTSD and substance abuse disorder dual diagnosis</li></ul>',
       },
       {
@@ -114,8 +112,6 @@ export const Example: Story = {
         vetCenterComConditions: null,
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
-          'We offer couples and family counseling to support you as you work toward meeting your goals.',
-        description:
           'We offer couples and family counseling to support you as you work toward meeting your goals.',
         body: '<p>Pittsburgh Vet Center counselors on-site to offer family and couples counseling.</p><p>Specialty care includes</p><ul><li>Couples counseling and support</li><li>Spouse and Significant Other groups</li></ul>',
       },
@@ -128,8 +124,6 @@ export const Example: Story = {
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
           'If you experienced sexual assault or harassment during military service, we can help you get the counseling you need. Any Veteran or service member, including members of the National Guard and Reserve forces, who experienced military sexual trauma is eligible to receive counseling. This applies to people of all genders from any service era.',
-        description:
-          'Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.',
         body: '<p>Pittsburgh Vet Center offers individual and group counseling by counselors with specific training related to military sexual trauma care.</p>',
       },
     ],
@@ -144,8 +138,6 @@ export const Example: Story = {
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
           'If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and support through private counseling and group therapy. We can also refer you to VA or community counseling for treatment and therapy resources.',
-        description:
-          '<p>If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and treatment support such as private counseling, group therapy and medication. It’s never too late to get help.</p>',
         body: '<p>Pittsburgh Vet Center offers individual and group counseling.</p><p>Specialty care includes</p><ul><li>Evidence based therapies such as; Cognitive Processing Therapy (CPT) and Prolonged Exposure (PE).</li><li>Whole health activities such as yoga and mindfulness</li><li>Seeking Safety for PTSD and substance abuse disorder dual diagnosis</li></ul>',
       },
     ],
@@ -158,8 +150,6 @@ export const Example: Story = {
         vetCenterComConditions: null,
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
-          'We offer couples and family counseling to support you as you work toward meeting your goals.',
-        description:
           'We offer couples and family counseling to support you as you work toward meeting your goals.',
         body: '<p>Pittsburgh Vet Center counselors on-site to offer family and couples counseling.</p><p>Specialty care includes</p><ul><li>Couples counseling and support</li><li>Spouse and Significant Other groups</li></ul>',
       },
@@ -174,8 +164,6 @@ export const Example: Story = {
         commonlyTreatedCondition: null,
         vetCenterServiceDescription:
           'If you experienced sexual assault or harassment during military service, we can help you get the counseling you need. Any Veteran or service member, including members of the National Guard and Reserve forces, who experienced military sexual trauma is eligible to receive counseling. This applies to people of all genders from any service era.',
-        description:
-          'Military sexual trauma can happen to both genders. If you experienced sexual assault or harassment during military service—no matter when you served—we provide counseling and treatment.',
         body: '<p>Pittsburgh Vet Center offers individual and group counseling by counselors with specific training related to military sexual trauma care.</p>',
       },
     ],

--- a/src/types/formatted/vetCenterHealthServices.ts
+++ b/src/types/formatted/vetCenterHealthServices.ts
@@ -6,7 +6,6 @@ export interface VetCenterHealthService {
   vetCenterComConditions?: string
   commonlyTreatedCondition?: string
   vetCenterServiceDescription?: string
-  description?: string
   body?: string
 }
 


### PR DESCRIPTION
# Description

There were a lot of different content fields that needed to be transformed so they'd pick up on things like phone number.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21464
Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21563

## Testing Steps

- http://localhost:3999/omaha-vet-center/ - "In the spotlight" section
- http://localhost:3999/boston-vet-center/ - "Where can I get help after hours?"
- http://localhost:3999/greensboro-vet-center/#item-suicide-prevention - "Suicide prevention" (https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21563)

## Screenshots
<img width="1624" height="1056" alt="Screenshot 2025-07-11 at 4 39 16 PM" src="https://github.com/user-attachments/assets/840cec1b-b79d-452e-89ad-0f74a3f779f0" />

<img width="1624" height="1056" alt="Screenshot 2025-07-11 at 4 19 22 PM" src="https://github.com/user-attachments/assets/b4d750b0-b355-44c6-9c3c-dcf90904a656" />

<img width="1624" height="1056" alt="Screenshot 2025-07-11 at 4 38 27 PM" src="https://github.com/user-attachments/assets/002d3fe5-26c0-44f0-8dd6-b288da5e1796" />
