### PR TITLE
Vets Center: Wrap featured-content links in semantic tags for typography styles

### DIFF
--- a/src/templates/common/featuredContent/index.tsx
+++ b/src/templates/common/featuredContent/index.tsx
@@ -20,12 +20,14 @@ export function FeaturedContent({
         />
       )}
       {link && link.url && (
-        <va-link
-          href={link.url}
-          text={link.label}
-          active={true}
-          data-testid="featured-content-link"
-        />
+        <p>
+          <va-link
+            href={link.url}
+            text={link.label}
+            active={true}
+            data-testid="featured-content-link"
+          />
+        </p>
       )}
     </va-card>
   )


### PR DESCRIPTION
# Description

Wraps links for featured content in p tags to get typography styles.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21561

## Testing Steps

http://localhost:3999/st-paul-vet-center/ and take a look at the "In the spotlight" section

## Screenshots

Before (with default font size blown up):

<img width="796" height="716" alt="Screenshot 2025-07-15 at 11 17 51 AM" src="https://github.com/user-attachments/assets/074cf21c-476a-4ecb-bad5-b8a3f037ff55" />

After (with default font size blown up):

<img width="839" height="778" alt="Screenshot 2025-07-15 at 11 16 26 AM" src="https://github.com/user-attachments/assets/01f08cf6-039a-4b6e-a3cf-87b25942bb84" />
