### PR TITLE
updated env vars for DD RUM

### DIFF
--- a/envs/.env.dev
+++ b/envs/.env.dev
@@ -28,6 +28,10 @@ NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_AUTH=N9BisSDKAwJENFQtQIEvXQ
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_PREVIEW=env-423
 
+# Datadog Connection
+NEXT_PUBLIC_DATADOG_RUM_SERVICE=nextjs-frontend
+NEXT_PUBLIC_DATADOG_RUM_SESSION_SAMPLE_RATE=100
+
 # Feature flags for enabling content types. These should only be added when you are preparing to go to prod and are testing on dev.
 # It is better to test these from the CMS backend for dev than here.
 FEATURE_NEXT_BUILD_CONTENT_EVENT_LISTING=true

--- a/envs/.env.example
+++ b/envs/.env.example
@@ -42,6 +42,7 @@ NEXT_PUBLIC_DATADOG_RUM_APP_ID=
 NEXT_PUBLIC_DATADOG_RUM_CLIENT_TOKEN=
 # Retrieve this from Datadog RUM settings - Search 'Nextjs' for the application
 NEXT_PUBLIC_DATADOG_RUM_SERVICE=
+NEXT_PUBLIC_DATADOG_RUM_SESSION_SAMPLE_RATE=100
 
 # for local redis server
 REDIS_URL=redis://127.0.0.1:6379

--- a/envs/.env.prod
+++ b/envs/.env.prod
@@ -28,6 +28,10 @@ NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_AUTH=XWK-rHkcb1wp4DCOCzhPiQ
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_PREVIEW=env-1
 
+# Datadog Connection
+NEXT_PUBLIC_DATADOG_RUM_SERVICE=nextjs-frontend
+NEXT_PUBLIC_DATADOG_RUM_SESSION_SAMPLE_RATE=10
+
 # FEATURE FLAG VARIABLES FOR CONTENT TYPES SHOULD NEVER BE ADDED TO THE PRODUCTION ENVIRONMENT HERE.
 # Prod's values for these feature flags should always be controlled from the Prod CMS.
 # For example, never add and enable a variable like the following to this file:

--- a/envs/.env.staging
+++ b/envs/.env.staging
@@ -28,6 +28,10 @@ NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID=GTM-WFJWBD
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_AUTH=inC4EKQce9vlWpRVcowiyQ
 NEXT_PUBLIC_GOOGLE_TAG_MANAGER_PREVIEW=env-661
 
+# Datadog Connection
+NEXT_PUBLIC_DATADOG_RUM_SERVICE=nextjs-frontend
+NEXT_PUBLIC_DATADOG_RUM_SESSION_SAMPLE_RATE=100
+
 # Feature flags for enabling content types. These should only be added when you are preparing to go to prod and are testing on staging.
 # It is better to test these from the CMS backend for staging than here.
 # FEATURE_NEXT_BUILD_CONTENT_EVENT_LISTING=true

--- a/envs/.env.test
+++ b/envs/.env.test
@@ -20,6 +20,10 @@ DRUPAL_CLIENT_SECRET=clientSecret
 # Configure the localhost port for the Next.js dev server
 PORT=3999
 
+# Datadog Connection
+NEXT_PUBLIC_DATADOG_RUM_SERVICE=nextjs-frontend
+NEXT_PUBLIC_DATADOG_RUM_SESSION_SAMPLE_RATE=100
+
 # The Testing environment file list of flags should always match .env.tugboat's list.
 # Tugboat is used for Playwright testing, and this environment is use for unit testing.
 # Please keep these in sync.


### PR DESCRIPTION
## Generated description


This pull request introduces environment variable updates to integrate Datadog RUM (Real User Monitoring) across various environments. The changes ensure consistent configuration for Datadog RUM in development, staging, testing, and example `.env` files.

### Datadog RUM Integration:

* Added `NEXT_PUBLIC_DATADOG_RUM_SERVICE` and `NEXT_PUBLIC_DATADOG_RUM_SESSION_SAMPLE_RATE` to the following environment files:
  - `envs/.env.dev` for development
  - `envs/.env.staging` for staging
  - `envs/.env.test` for testing
  - `envs/.env.example` as a template/example

## Ticket

[Ticket](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21446)




## Testing Steps

Explain the steps needed for testing

Should be able to view Datadog RUM events for all nextjs server envs. This is dependent on infra PR request to be deployed.

https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3763
