### PR TITLE
Vets Center: Fix schema.org validation errors

### DIFF
--- a/src/templates/layouts/vetCenter/SchemaScript.tsx
+++ b/src/templates/layouts/vetCenter/SchemaScript.tsx
@@ -78,31 +78,31 @@ export function SchemaScript({ vetCenter }: SchemaScriptProps) {
           '@type': 'ContactPoint',
           telephone: service?.phoneNumber || null,
         },
+        serviceLocation: {
+          '@type': 'Place', // Changed from 'GovernmentOffice' in production
+          name: title,
+          address: {
+            '@type': 'PostalAddress',
+            streetAddress:
+              fieldAddress.address_line1 +
+              (address.address_line2
+                ? `${address.address_line1}${address.address_line2}`
+                : address.address_line1),
+            addressLocality: fieldAddress?.locality,
+            addressRegion: fieldAddress?.administrative_area,
+            postalCode: fieldAddress?.postal_code,
+          },
+          geo: {
+            '@type': 'GeoCoordinates',
+            latitude: geolocation.lat.toString(),
+            longitude: geolocation.lon.toString(),
+          },
+        },
       },
       provider: {
         '@type': 'GovernmentOrganization',
         name: 'Veterans Affairs',
         url: 'https://www.va.gov',
-      },
-      serviceLocation: {
-        '@type': 'Place',
-        name: title,
-        address: {
-          '@type': 'PostalAddress',
-          streetAddress:
-            fieldAddress.address_line1 +
-            (address.address_line2
-              ? `${address.address_line1}${address.address_line2}`
-              : address.address_line1),
-          addressLocality: fieldAddress?.locality,
-          addressRegion: fieldAddress?.administrative_area,
-          postalCode: fieldAddress?.postal_code,
-        },
-        geo: {
-          '@type': 'GeoCoordinates',
-          latitude: geolocation.lat.toString(),
-          longitude: geolocation.lon.toString(),
-        },
       },
     }))
   }

--- a/src/templates/layouts/vetCenter/__snapshots__/index.test.tsx.snap
+++ b/src/templates/layouts/vetCenter/__snapshots__/index.test.tsx.snap
@@ -80,6 +80,21 @@ exports[`VetCenter with valid data renders schema.org structured data scripts co
     },
     "availableChannel": {
       "@type": "ServiceChannel",
+      "serviceLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Pittsburgh",
+          "addressRegion": "PA",
+          "streetAddress": "1010 Delafield Road1010 Delafield Road",
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": "40.42665609",
+          "longitude": "-80.05719073",
+        },
+        "name": "Test title",
+      },
       "servicePhone": {
         "@type": "ContactPoint",
         "telephone": null,
@@ -91,21 +106,6 @@ exports[`VetCenter with valid data renders schema.org structured data scripts co
       "@type": "GovernmentOrganization",
       "name": "Veterans Affairs",
       "url": "https://www.va.gov",
-    },
-    "serviceLocation": {
-      "@type": "Place",
-      "address": {
-        "@type": "PostalAddress",
-        "addressLocality": "Pittsburgh",
-        "addressRegion": "PA",
-        "streetAddress": "1010 Delafield Road1010 Delafield Road",
-      },
-      "geo": {
-        "@type": "GeoCoordinates",
-        "latitude": "40.42665609",
-        "longitude": "-80.05719073",
-      },
-      "name": "Test title",
     },
     "serviceOperator": {
       "@type": "GovernmentOrganization",
@@ -127,6 +127,21 @@ exports[`VetCenter with valid data renders schema.org structured data scripts co
     },
     "availableChannel": {
       "@type": "ServiceChannel",
+      "serviceLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Pittsburgh",
+          "addressRegion": "PA",
+          "streetAddress": "1010 Delafield Road1010 Delafield Road",
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": "40.42665609",
+          "longitude": "-80.05719073",
+        },
+        "name": "Test title",
+      },
       "servicePhone": {
         "@type": "ContactPoint",
         "telephone": null,
@@ -138,21 +153,6 @@ exports[`VetCenter with valid data renders schema.org structured data scripts co
       "@type": "GovernmentOrganization",
       "name": "Veterans Affairs",
       "url": "https://www.va.gov",
-    },
-    "serviceLocation": {
-      "@type": "Place",
-      "address": {
-        "@type": "PostalAddress",
-        "addressLocality": "Pittsburgh",
-        "addressRegion": "PA",
-        "streetAddress": "1010 Delafield Road1010 Delafield Road",
-      },
-      "geo": {
-        "@type": "GeoCoordinates",
-        "latitude": "40.42665609",
-        "longitude": "-80.05719073",
-      },
-      "name": "Test title",
     },
     "serviceOperator": {
       "@type": "GovernmentOrganization",
@@ -174,6 +174,21 @@ exports[`VetCenter with valid data renders schema.org structured data scripts co
     },
     "availableChannel": {
       "@type": "ServiceChannel",
+      "serviceLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Pittsburgh",
+          "addressRegion": "PA",
+          "streetAddress": "1010 Delafield Road1010 Delafield Road",
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": "40.42665609",
+          "longitude": "-80.05719073",
+        },
+        "name": "Test title",
+      },
       "servicePhone": {
         "@type": "ContactPoint",
         "telephone": null,
@@ -185,21 +200,6 @@ exports[`VetCenter with valid data renders schema.org structured data scripts co
       "@type": "GovernmentOrganization",
       "name": "Veterans Affairs",
       "url": "https://www.va.gov",
-    },
-    "serviceLocation": {
-      "@type": "Place",
-      "address": {
-        "@type": "PostalAddress",
-        "addressLocality": "Pittsburgh",
-        "addressRegion": "PA",
-        "streetAddress": "1010 Delafield Road1010 Delafield Road",
-      },
-      "geo": {
-        "@type": "GeoCoordinates",
-        "latitude": "40.42665609",
-        "longitude": "-80.05719073",
-      },
-      "name": "Test title",
     },
     "serviceOperator": {
       "@type": "GovernmentOrganization",


### PR DESCRIPTION
# Description

Moving this one object fixed all validation errors, which is what @brianseek originally suggested. Decided to leave the rest of the detected differences with prod. Left a comment about the location one.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21836

## Testing Steps

Visit http://localhost:3999/secaucus-vet-center/ and paste the contents into the [schema.org validator](https://validator.schema.org/).

## Screenshots

<img width="1624" height="1056" alt="Screenshot 2025-07-23 at 4 48 47 PM" src="https://github.com/user-attachments/assets/377d9acf-ad46-41f4-9a32-70b953941e24" />
