### PR TITLE
Vets Center: Add the `ContentFooter`

### DIFF
--- a/src/templates/layouts/vetCenter/index.test.tsx
+++ b/src/templates/layouts/vetCenter/index.test.tsx
@@ -389,6 +389,15 @@ describe('VetCenter with valid data', () => {
     expect(vaTelephoneElement?.getAttribute('contact')).toBe('1234567890')
   })
 
+  test('renders feedback button in ContentFooter component', () => {
+    const { container } = render(<VetCenter {...mockData} />)
+
+    // Check that the feedback button is present from the va-button component
+    expect(
+      container.querySelector('va-button[id="mdFormButton"]')
+    ).toBeInTheDocument()
+  })
+
   describe('Mission Explainer functionality', () => {
     test('renders mission explainer when data is present', () => {
       render(<VetCenter {...mockData} />)

--- a/src/templates/layouts/vetCenter/index.tsx
+++ b/src/templates/layouts/vetCenter/index.tsx
@@ -11,6 +11,7 @@ import { ExpandableOperatingStatus } from './ExpandableOperatingStatus'
 import { PhoneNumber } from '@/templates/common/phoneNumber'
 import { SchemaScript } from './SchemaScript'
 import { Address } from '@/templates/layouts/healthCareLocalFacility/Address'
+import { ContentFooter } from '@/templates/common/contentFooter'
 
 export function VetCenter(vetCenterProps: FormattedVetCenter) {
   const {
@@ -239,6 +240,8 @@ export function VetCenter(vetCenterProps: FormattedVetCenter) {
           {ccVetCenterFaqs && <QaSection {...ccVetCenterFaqs} />}
 
           <va-back-to-top></va-back-to-top>
+
+          <ContentFooter />
 
           <SchemaScript vetCenter={vetCenterProps} />
         </article>


### PR DESCRIPTION
# Description

Adds the `ContentFooter` just like the other pages.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21565

## Testing Steps

Take a look at the bottom of http://localhost:3999/secaucus-vet-center/

## Screenshots

I just noticed that the feedback button has different inner padding than production, but that's the case for this content footer component on other pages.

<img width="1624" height="1056" alt="Screenshot 2025-07-23 at 5 16 47 PM" src="https://github.com/user-attachments/assets/0c1f4e84-395f-461d-87ed-a41528a73554" />
