### PR TITLE
VACMS-21460: Update broken links report

### DIFF
--- a/scripts/create-combined-reports.js
+++ b/scripts/create-combined-reports.js
@@ -107,7 +107,7 @@ const createCombinedReports = () => {
   )
 
   // Generate a CSV report
-  let csvReport = `Parent Link, Child Link, Error Code\n`
+  let csvReport = `Source, Broken Link, Error Code\n`
   for (const parent of Object.keys(combinedJson.brokenLinksByParent)) {
     const sanitizedParent = parent.replace(/,/g, ',,')
     for (const child of combinedJson.brokenLinksByParent[parent]) {

--- a/scripts/create-combined-reports.js
+++ b/scripts/create-combined-reports.js
@@ -63,49 +63,6 @@ const createCombinedReports = () => {
     )}`
   )
 
-  let markDownReport = ''
-
-  // Output a markdown report for easy readability.
-  markDownReport += `# VA.gov broken link report\n`
-  markDownReport += `Found ${combinedJson.metrics.brokenLinkCount} broken links on ${combinedJson.metrics.pagesScanned} pages.\n`
-  const dateTime = new Date().toString()
-  markDownReport += `Report generated: ${dateTime}\n\n`
-
-  // First group by source page
-  markDownReport += `## Broken links grouped by source page\n`
-  for (const parent of Object.keys(combinedJson.brokenLinksByParent)) {
-    markDownReport += `Source: ${parent}\n`
-    for (const child of combinedJson.brokenLinksByParent[parent]) {
-      markDownReport += `- ${child.url}, response code ${child.status}\n`
-    }
-    markDownReport += `\n`
-  }
-  markDownReport += `\n`
-
-  // Group by broken link.
-  markDownReport += `## Broken links grouped by destination\n`
-  markDownReport += `Each broken link and all the pages it appears on.\n\n`
-  for (const child of Object.keys(combinedJson.brokenLinksByLink)) {
-    markDownReport += `Broken destination: ${child}\n`
-    for (const parent of combinedJson.brokenLinksByLink[child]) {
-      markDownReport += `- ${parent.parent}\n`
-    }
-    markDownReport += `\n`
-  }
-
-  // Write markdown report to file
-  fs.writeFile('broken-links-report.md', markDownReport, (err) => {
-    if (err) {
-      console.error(err)
-    }
-  })
-
-  console.log(
-    `\n Report Markdown file written to: ${chalk.green(
-      process.cwd() + '/broken-links-report.md'
-    )}`
-  )
-
   // Generate a CSV report
   let csvReport = `Source, Broken Link, Error Code\n`
   for (const parent of Object.keys(combinedJson.brokenLinksByParent)) {
@@ -115,13 +72,6 @@ const createCombinedReports = () => {
       csvReport += `${sanitizedParent},${sanitizedChildUrl},${child.status}\n`
     }
   }
-
-  // Write markdown report to file
-  fs.writeFile('broken-links-report.csv', csvReport, (err) => {
-    if (err) {
-      console.error(err)
-    }
-  })
 
   console.log(
     `\n Report CSV file written to: ${chalk.green(

--- a/scripts/create-combined-reports.js
+++ b/scripts/create-combined-reports.js
@@ -73,6 +73,13 @@ const createCombinedReports = () => {
     }
   }
 
+  // Write csv report to file
+  fs.writeFile('broken-links-report.csv', csvReport, (err) => {
+    if (err) {
+      console.error(err)
+    }
+  })
+
   console.log(
     `\n Report CSV file written to: ${chalk.green(
       process.cwd() + '/broken-links-report.csv'


### PR DESCRIPTION
# Description

This ticket changes the header text of the csv report and removes the markdown report.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21460

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

Explain the steps needed for testing

## QA steps
- [ ] In the terminal, run `SITE_URL="https://va.gov" node scripts/check-broken-links.js`
- [ ] Confirm that the script completes with a message similar to the following: 
```
Of an initial 23842 pages, scanned total of 889550 links on 23842
Detected 1299 broken
```
- [ ] Change the name of the output: `mv broken-links-report.json broken-links-report-run.json`
- [ ] Run `SITE_URL="https://va.gov" node scripts/create-combined-reports.js`
- [ ] Confirm that no .md file was generated
- [ ] Inspect the "broken-links-report.csv"
- [ ] Confirm that it begins with "Source, Broken Link, Error Code"
- [ ] Confirm that the file structure is as the following example shows:
```
http://www.va.gov/eastern-colorado-health-care/stories/navy-veteran-uses-art-to-help-self-provide-beauty-to-va-eastern-colorado-surrounding-area/,https://lonesomegoose.com/,404
http://www.va.gov/milwaukee-health-care/news-releases/three-historic-buildings-on-milwaukee-va-campus-to-be-renovated-for-service-of-veterans/,https://www.facebook.com/ajourneytothelightministries/,400
```

## Screenshots
### Running the script
<img width="1674" height="911" alt="Image" src="https://github.com/user-attachments/assets/649a3ca2-0575-4c24-97a1-1b512335ee6e" />

### CSV file
<img width="1257" height="729" alt="Screenshot 2025-07-25 at 1 50 02 PM" src="https://github.com/user-attachments/assets/b439efd8-e960-4dad-9142-aaa9001a77c7" />

- Add links to additional PRs here:

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.
