### PR TITLE
Fix 403 breakage during content release

### DIFF
--- a/packages/proxy-fetcher/src/index.ts
+++ b/packages/proxy-fetcher/src/index.ts
@@ -92,15 +92,17 @@ export const getFetcher = (
             statusText: response.statusText,
           }
         )
-        throw new Error(
-          `Failed request to ${response.url}: ${response.status} ${response.statusText}`
-        )
-      }
 
-      // Don't retry if we shouldn't
-      if ([404, 403].includes(response.status)) {
-        const { AbortError } = await import('p-retry')
-        throw new AbortError(response.statusText)
+        const errorMessage = `Failed request to ${response.url}: ${response.status} ${response.statusText}`
+
+        // Don't retry if we shouldn't
+        if ([404, 403].includes(response.status)) {
+          log(`Aborting retry: ${response.status} received`)
+          const { AbortError } = await import('p-retry')
+          throw new AbortError(errorMessage)
+        }
+
+        throw new Error(errorMessage)
       }
 
       return response

--- a/packages/proxy-fetcher/src/index.ts
+++ b/packages/proxy-fetcher/src/index.ts
@@ -99,7 +99,7 @@ export const getFetcher = (
         if ([404, 403].includes(response.status)) {
           log(`Aborting retry: ${response.status} received`)
           const { AbortError } = await import('p-retry')
-          throw new AbortError(errorMessage)
+          throw new AbortError(new Error(errorMessage, { cause: response }))
         }
 
         throw new Error(errorMessage)

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -361,6 +361,19 @@ export async function getStaticProps(context: GetStaticPropsContext) {
   } catch (err) {
     error('Error in getStaticProps:', err)
     error(`SSG env var: ${process.env.SSG} (${typeof process.env.SSG})`)
+
+    // If we get a 403, it's probably because we're trying to preview an unpublished page.
+    // Return a 404 instead of failing the build.
+    //
+    // NOTE: The cause is added to the AbortError message in proxy-fetcher
+    if (err.cause?.status === 403) {
+      log('getStaticProps: 403 received; returning notFound')
+      return {
+        notFound: true,
+      }
+    }
+
+    // If we're in SSG mode, exit the build process. Otherwise, return a 404.
     if (process.env.SSG === 'true') {
       const fs = await import('fs')
       const path = await import('path')

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -352,6 +352,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       }
     } catch (error) {
       if (error instanceof DoNotPublishError) {
+        log('getStaticProps: DoNotPublishError, returning notFound')
         return { notFound: true }
       } else {
         throw error

--- a/src/test/slug.test.tsx
+++ b/src/test/slug.test.tsx
@@ -24,6 +24,10 @@ jest.mock('@/lib/drupal/drupalClient', () => ({
 
 describe('[[...slug]].tsx', () => {
   describe('getStaticProps', () => {
+    afterEach(() => {
+      jest.resetAllMocks()
+    })
+
     const mockContext = { params: { slug: ['test-path'] }, preview: false }
     it('returns notFound when DoNotPublishError is thrown', async () => {
       // Mock the expanded context
@@ -49,6 +53,28 @@ describe('[[...slug]].tsx', () => {
 
       // Assert that getStaticPropsResource was called
       expect(getStaticPropsResource).toHaveBeenCalled()
+    })
+
+    it('returns notFound when translatePath returns a 403', async () => {
+      // Mock the expanded context
+      const mockExpandedContext = { drupalPath: '/test-path', preview: false }
+
+      // Mock the functions
+      ;(getExpandedStaticPropsContext as jest.Mock).mockReturnValue(
+        mockExpandedContext
+      )
+      ;(drupalClient.translatePath as jest.Mock).mockRejectedValue(
+        new Error('Failed to fetch the thing', { cause: { status: 403 } })
+      )
+
+      // Call getStaticProps
+      const result = await getStaticProps(mockContext)
+
+      // Assert that notFound is returned
+      expect(result).toEqual({ notFound: true })
+
+      // Assert that getStaticPropsResource was called
+      expect(getStaticPropsResource).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
# Description

When we get a 403 while calling `/translate-path` during the content build, it's likely because a page has been archived between the start of the build (when we ask Drupal for all the paths to build) and when we get to building this specific page. This PR does a few things together to make sure the content release when this happens:
1. Actually aborts early if `proxy-fetcher` encounters a 404 or 403 error (this wasn't actually happening before)
2. Passes in the `cause` to the `AbortError` it throws
3. Reads that `cause` in the `catch` that handles the `drupalClient.translatePath()` error, and if the `status` received from the endpoint is 403, just returns a 404 and moves on

We can expand the third point there if we need to handle other such cases later.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21717