### PR TITLE
Content release warnings

### DIFF
--- a/.github/workflows/content-release.yml
+++ b/.github/workflows/content-release.yml
@@ -122,6 +122,7 @@ jobs:
       SETUP_START_TIME: ${{ steps.export-setup-start-time.outputs.SETUP_START_TIME }}
       SETUP_END_TIME: ${{ steps.export-setup-end-time.outputs.SETUP_END_TIME }}
       YARN_OUTPUT: ${{ steps.export-yarn-output.outputs.YARN_OUTPUT }}
+      EXPORT_WARNINGS: ${{ steps.export-warnings.outputs.EXPORT_WARNINGS }}
     container:
       image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/node-22.16.0-bullseye:latest
       credentials:
@@ -213,6 +214,12 @@ jobs:
             cd out
             ls -l
           fi
+
+    - name: Check for warnings during build
+      id: export-warnings
+      run: |
+        cd main
+        echo EXPORT_WARNINGS=$([ -f logs/warnings.md ] && cat logs/warnings.md || echo '') >> $GITHUB_OUTPUT
 
     - name: Build sitemap
       run: |
@@ -326,6 +333,16 @@ jobs:
         continue-on-error: true
         with:
           payload: '{"attachments": [{"color": "#07711E","blocks": [{"type": "section","text": {"type": "mrkdwn","text": "Successfully released content to S3 with next-build release: ${{ needs.validate-build-status.outputs.TAG }}"}}]}]}'
+          channel_id: ${{ env.SLACK_CHANNEL }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Notify Slack of warnings
+        if: ${{ needs.build.outputs.EXPORT_WARNINGS != '' }}
+        uses: department-of-veterans-affairs/platform-release-tools-actions/slack-notify@8c496a4b0c9158d18edcd9be8722ed0f79e8c5b4 # main
+        continue-on-error: true
+        with:
+          payload: '{ "attachments": [ { "color": "#FFBE2E", "blocks": [ { "type": "section", "text": { "type": "mrkdwn", "text": "Warnings for next-build release: ${{ needs.validate-build-status.outputs.TAG }}" } }, { "type": "divider" }, { "type": "section", "text": { "type": "mrkdwn", "text": "${{ needs.build.outputs.EXPORT_WARNINGS }}" } } ] } ] }'
           channel_id: ${{ env.SLACK_CHANNEL }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ exit_code
 
 # repomix
 *repomix-output.txt
+
+# logs
+logs/

--- a/envs/.env.dev
+++ b/envs/.env.dev
@@ -39,8 +39,8 @@ NEXT_PUBLIC_DATADOG_RUM_SESSION_SAMPLE_RATE=100
 
 # Feature flags for enabling content types. These should only be added when you are preparing to go to prod and are testing on dev.
 # It is better to test these from the CMS backend for dev than here.
-FEATURE_NEXT_BUILD_CONTENT_EVENT_LISTING=true
-FEATURE_NEXT_BUILD_CONTENT_EVENT=true
-FEATURE_NEXT_BUILD_CONTENT_HEALTH_CARE_LOCAL_FACILITY=true
+# FEATURE_NEXT_BUILD_CONTENT_EVENT_LISTING=true
+# FEATURE_NEXT_BUILD_CONTENT_EVENT=true
+# FEATURE_NEXT_BUILD_CONTENT_HEALTH_CARE_LOCAL_FACILITY=true
 FEATURE_NEXT_BUILD_CONTENT_LOCATIONS_LISTING=true
 

--- a/packages/proxy-fetcher/src/index.ts
+++ b/packages/proxy-fetcher/src/index.ts
@@ -78,6 +78,8 @@ export const getFetcher = (
     // Wrap fetching in p-retry for resilience.
     const retryCount = 5
     const wrappedCrossFetch = async (attempt) => {
+      // 10% of the time, fail the request with a mocked 403 error AI!
+
       const response = await crossFetch(input, {
         ...options,
       })

--- a/packages/proxy-fetcher/src/index.ts
+++ b/packages/proxy-fetcher/src/index.ts
@@ -78,16 +78,21 @@ export const getFetcher = (
     // Wrap fetching in p-retry for resilience.
     const retryCount = 5
     const wrappedCrossFetch = async (attempt) => {
-      // In non-production environments, simulate 403 errors 10% of the time
-      if (attempt === 1 && process.env.NODE_ENV !== 'production' && Math.floor(Math.random() * 10) === 0) {
+      // As a test, mock a failed request 10% of the time.
+      const url = typeof input === 'string' ? input : input.url
+      if (
+        attempt === 1 &&
+        url.includes('translate-path') &&
+        Math.random() < 0.1
+      ) {
         const mockResponse = {
           ok: false,
           status: 403,
           statusText: 'Forbidden',
           url: typeof input === 'string' ? input : input.url,
-        };
+        }
 
-        const logOrError = attempt <= retryCount ? log : error;
+        const logOrError = attempt <= retryCount ? log : error
         logOrError(
           `[MOCKED] Failed request (Attempt ${attempt} of ${retryCount + 1}): %o`,
           {
@@ -95,11 +100,17 @@ export const getFetcher = (
             status: mockResponse.status,
             statusText: mockResponse.statusText,
           }
-        );
+        )
 
-        const { AbortError } = await import('p-retry');
-        throw new AbortError(new Error(`Failed request to ${mockResponse.url}: ${mockResponse.status} ${mockResponse.statusText}`, { cause: mockResponse }));
+        const { AbortError } = await import('p-retry')
+        throw new AbortError(
+          new Error(
+            `Failed request to ${mockResponse.url}: ${mockResponse.status} ${mockResponse.statusText}`,
+            { cause: mockResponse }
+          )
+        )
       }
+      // End test
 
       const response = await crossFetch(input, {
         ...options,

--- a/scripts/yarn/export.js
+++ b/scripts/yarn/export.js
@@ -2,35 +2,53 @@ import { processEnv } from 'env-loader'
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import Debug from 'debug'
 
-// Clean the export directory to get tugboat working
+const exportLog = Debug('next-build:export')
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const logsDir = path.resolve(__dirname, '../../logs')
+
+/**
+ * Pre-build housekeeping
+ */
 if (process.env.BUILD_OPTION === 'static') {
-  const __filename = fileURLToPath(import.meta.url)
-  const __dirname = path.dirname(__filename)
-
+  // Clean the export directory to get tugboat working
   const exportBuildPath = path.resolve(__dirname, '../../.next/export')
   if (fs.existsSync(exportBuildPath)) {
+    exportLog('Cleaning export directory')
     fs.rmdirSync(exportBuildPath, { recursive: true, force: true })
+  }
+
+  // Clean the warning logs
+  if (fs.existsSync(logsDir)) {
+    exportLog('Cleaning logs directory')
+    fs.rmdirSync(logsDir, { recursive: true, force: true })
   }
 }
 
 await processEnv('next build', true)
 
+/**
+ * Post-build processing
+ */
 if (process.env.BUILD_OPTION === 'static') {
-  const __filename = fileURLToPath(import.meta.url)
-  const __dirname = path.dirname(__filename)
-  const logsDir = path.resolve(__dirname, '../../logs')
-  
+  // Concatenate all warning-*.md files into a single warnings.md file
   // Get all warning-*.md files
-  const files = fs.readdirSync(logsDir).filter(file => file.startsWith('warning-') && file.endsWith('.md'))
-  
+  const files = fs
+    .readdirSync(logsDir)
+    .filter((file) => file.startsWith('warning-') && file.endsWith('.md'))
+
+  exportLog(`Found ${files.length} warning files to process`)
+
   const warnings = []
-  
+
   for (const file of files) {
     const filePath = path.join(logsDir, file)
     const content = fs.readFileSync(filePath, 'utf8')
     const lines = content.split('\n')
-    
+
     for (const line of lines) {
       if (line.trim() === '') continue
       const match = line.match(/^\[(\d+)\]:::(.*)$/)
@@ -41,14 +59,15 @@ if (process.env.BUILD_OPTION === 'static') {
       }
     }
   }
-  
+
   // Sort by timestamp
   warnings.sort((a, b) => a[0] - b[0])
-  
+
   // Create content with just the messages
-  const outputContent = warnings.map(w => w[1]).join('\n')
-  
+  const outputContent = warnings.map((w) => w[1]).join('\n')
+
   // Write to warnings.md
   const outputPath = path.join(logsDir, 'warnings.md')
+  exportLog(`Writing ${warnings.length} warnings to ${outputPath}`)
   fs.writeFileSync(outputPath, outputContent)
 }

--- a/scripts/yarn/export.js
+++ b/scripts/yarn/export.js
@@ -16,11 +16,39 @@ if (process.env.BUILD_OPTION === 'static') {
 
 await processEnv('next build', true)
 
-// Implement this AI!
 if (process.env.BUILD_OPTION === 'static') {
-  // Read each warning-*.md file in the `logs/` directory
-  // Parse each line into a `[timestamp, mesage]` tuple
-  //   Each line takes the following format `[unix_timestamp]:::[mesasge]`
-  // Sort the tuples by timestamp
-  // Write each message to `logs/warnings.md`
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename)
+  const logsDir = path.resolve(__dirname, '../../logs')
+  
+  // Get all warning-*.md files
+  const files = fs.readdirSync(logsDir).filter(file => file.startsWith('warning-') && file.endsWith('.md'))
+  
+  const warnings = []
+  
+  for (const file of files) {
+    const filePath = path.join(logsDir, file)
+    const content = fs.readFileSync(filePath, 'utf8')
+    const lines = content.split('\n')
+    
+    for (const line of lines) {
+      if (line.trim() === '') continue
+      const match = line.match(/^\[(\d+)\]:::(.*)$/)
+      if (match) {
+        const timestamp = parseInt(match[1], 10)
+        const message = match[2].trim()
+        warnings.push([timestamp, message])
+      }
+    }
+  }
+  
+  // Sort by timestamp
+  warnings.sort((a, b) => a[0] - b[0])
+  
+  // Create content with just the messages
+  const outputContent = warnings.map(w => w[1]).join('\n')
+  
+  // Write to warnings.md
+  const outputPath = path.join(logsDir, 'warnings.md')
+  fs.writeFileSync(outputPath, outputContent)
 }

--- a/scripts/yarn/export.js
+++ b/scripts/yarn/export.js
@@ -15,3 +15,12 @@ if (process.env.BUILD_OPTION === 'static') {
 }
 
 await processEnv('next build', true)
+
+// Implement this AI!
+if (process.env.BUILD_OPTION === 'static') {
+  // Read each warning-*.md file in the `logs/` directory
+  // Parse each line into a `[timestamp, mesage]` tuple
+  //   Each line takes the following format `[unix_timestamp]:::[mesasge]`
+  // Sort the tuples by timestamp
+  // Write each message to `logs/warnings.md`
+}

--- a/scripts/yarn/export.js
+++ b/scripts/yarn/export.js
@@ -51,7 +51,10 @@ if (process.env.BUILD_OPTION === 'static') {
 
     for (const line of lines) {
       if (line.trim() === '') continue
-      const match = line.match(/^\[(\d+)\]:::(.*)$/)
+      // Match lines that start with a timestamp
+      // Alternatively, we could write JSON as log lines and parse them...if we
+      // had more metadata. ¯\_(ツ)_/¯
+      const match = line.match(/^\(\d+)\:::(.*)$/)
       if (match) {
         const timestamp = parseInt(match[1], 10)
         const message = match[2].trim()

--- a/src/lib/utils/writeWarningToFile.ts
+++ b/src/lib/utils/writeWarningToFile.ts
@@ -1,0 +1,15 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const logsDir = path.resolve(__dirname, '../../../logs')
+
+export const writeWarningToFile = (warning: string) => {
+  const timestamp = Math.floor(Date.now() / 1000)
+  fs.appendFileSync(
+    path.join(logsDir, `warnings-${process.pid}.md`),
+    `${timestamp}:::${warning}` + '\n'
+  )
+}

--- a/src/lib/utils/writeWarningToFile.ts
+++ b/src/lib/utils/writeWarningToFile.ts
@@ -1,13 +1,10 @@
 import fs from 'fs'
 import path from 'path'
-import { fileURLToPath } from 'url'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
 const logsDir = path.resolve(__dirname, '../../../logs')
 
 export const writeWarningToFile = (warning: string) => {
   const timestamp = Math.floor(Date.now() / 1000)
+  fs.mkdirSync(path.resolve(logsDir), { recursive: true })
   fs.appendFileSync(
     path.join(logsDir, `warnings-${process.pid}.md`),
     `${timestamp}:::${warning}` + '\n'

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -80,6 +80,7 @@ import { VamcSystemVaPolice } from '@/products/vamcSystemVaPolice/template'
 import { LeadershipListing } from '@/products/leadershipListing/template'
 import { VbaFacility } from '@/templates/layouts/vbaFacility'
 import { VetCenterLocationListing } from '@/templates/layouts/vetCenterLocationListing'
+import { writeWarningToFile } from '@/lib/utils/writeWarningToFile'
 
 // IMPORTANT: in order for a content type to build in Next Build, it must have an appropriate
 // environment variable set in one of two places:
@@ -376,6 +377,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     // NOTE: The cause is added to the AbortError message in proxy-fetcher
     if (err.cause?.status === 403) {
       log('getStaticProps: 403 received; returning notFound')
+      writeWarningToFile(`403 received from Drupal for ${context.params?.slug}`)
       return {
         notFound: true,
       }


### PR DESCRIPTION
# Description

When we get 403 errors for archived content during the content release process, we want to know about it. It shouldn't break the build, but we want to know about it. This sends a notification to Slack when we do have 403 errors.

It does it by writing warnings to files (one for each child process, since that's a thing), globs all those warnings from all those files together into a single file (sorted by timestamp for convenience), and if that file exists, sends a warning notification to Slack with its contents.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21757