### PR TITLE
Fix FAQ objects having missing ids

### DIFF
--- a/src/lib/drupal/paragraphs.ts
+++ b/src/lib/drupal/paragraphs.ts
@@ -125,7 +125,7 @@ export function entityFetchedParagraphsToNormalParagraphs<T>(
   const { type, bundle, target_id, ...properties } = paragraph
   return {
     type: `${type}--${bundle}`,
-    entityId: target_id,
+    id: target_id,
     ...Object.fromEntries(Object.entries(properties).map(convertProperty)),
   } as DrupalParagraph
 }

--- a/src/products/vamcSystemVaPolice/__snapshots__/query.test.ts.snap
+++ b/src/products/vamcSystemVaPolice/__snapshots__/query.test.ts.snap
@@ -36,11 +36,11 @@ exports[`VamcSystemVaPolice formatData outputs formatted data 1`] = `
         "answers": [
           {
             "html": "<p>VA police are armed and uniformed federal law enforcement officers. They provide law enforcement and security services to Veterans and their families at VA medical centers and other VA health facilities. Services include crime prevention and investigation, maintaining law and order, vehicle and foot patrols, telecommunication services, and workplace violence prevention.</p>",
-            "id": null,
+            "id": "141565",
             "type": "paragraph--wysiwyg",
           },
         ],
-        "id": null,
+        "id": "141566",
         "question": "What services do VA police provide?",
         "type": "paragraph--q_a",
       },
@@ -48,11 +48,11 @@ exports[`VamcSystemVaPolice formatData outputs formatted data 1`] = `
         "answers": [
           {
             "html": "<p>VA police and local law enforcement work together to respond to crimes that happen on VA property. VA police and local law enforcement partners train together on skills and tactics such as active threat drills, crisis intervention training, disaster response, and more.</p>",
-            "id": null,
+            "id": "141567",
             "type": "paragraph--wysiwyg",
           },
         ],
-        "id": null,
+        "id": "141568",
         "question": "Do VA police work with local law enforcement?",
         "type": "paragraph--q_a",
       },
@@ -66,11 +66,11 @@ exports[`VamcSystemVaPolice formatData outputs formatted data 1`] = `
 <p>Transitioning service members may be eligible for employment training, internship, and apprenticeship opportunities with VA police through the DOD SkillBridge program. For more information, email <a href="mailto:Skillbridge.vapolice@va.gov">Skillbridge.vapolice@va.gov</a>.</p>
 
 <p><a href="https://skillbridge.osd.mil/">Learn more about the DOD SkillBridge program</a></p>",
-            "id": null,
+            "id": "141569",
             "type": "paragraph--wysiwyg",
           },
         ],
-        "id": null,
+        "id": "141570",
         "question": "Am I eligible to join the VA police force?",
         "type": "paragraph--q_a",
       },
@@ -78,11 +78,11 @@ exports[`VamcSystemVaPolice formatData outputs formatted data 1`] = `
         "answers": [
           {
             "html": "<p>As a part of its mission to “protect those who served,” VA police across the country will begin to use in-car and body-worn cameras by the end of 2023. This policy increases the safety of VA facilities by promoting transparency and accountability.</p>",
-            "id": null,
+            "id": "141571",
             "type": "paragraph--wysiwyg",
           },
         ],
-        "id": null,
+        "id": "141572",
         "question": "Why do VA police wear body-worn cameras?",
         "type": "paragraph--q_a",
       },
@@ -90,11 +90,11 @@ exports[`VamcSystemVaPolice formatData outputs formatted data 1`] = `
         "answers": [
           {
             "html": "<p>VA is committed to protecting the privacy of the Veterans, families, caregivers, and survivors we serve. All local VA privacy officers and VA police officers attend extensive privacy training before officers begin using body-worn cameras.</p>",
-            "id": null,
+            "id": "141573",
             "type": "paragraph--wysiwyg",
           },
         ],
-        "id": null,
+        "id": "141574",
         "question": "How will my privacy be protected?",
         "type": "paragraph--q_a",
       },


### PR DESCRIPTION
# Description

I was using the post-transformed name for it when I originally made a conscious effort to include the id, but I needed to use the pre-transformed name. The symptom was that some id attributes in the DOM were rendering as `qa-null`, but now they have proper values.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21873

## Testing Steps

http://localhost:3999/secaucus-vet-center/ and scroll to the bottom and inspect the one of the accordion items, looking for the markup that's pointed out in the ticket.

## Screenshots

Before:

<img width="555" height="160" alt="Screenshot 2025-08-07 at 5 05 13 PM" src="https://github.com/user-attachments/assets/10742b9f-195f-4055-b7b4-d36f70a23666" />

After:

<img width="557" height="157" alt="Screenshot 2025-08-07 at 5 06 16 PM" src="https://github.com/user-attachments/assets/02fc3349-1f8b-4f65-85f2-fbd9bb2064fa" />


