### PR TITLE
VACMS: 21800 - Top tasks links VAMC Health Listings

### DIFF
--- a/src/data/queries/tests/__snapshots__/vamcHealthServicesListing.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/vamcHealthServicesListing.test.tsx.snap
@@ -2,6 +2,13 @@
 
 exports[`VamcHealthServicesListing formatData outputs formatted data 1`] = `
 {
+  "administration": {
+    "id": "33af76cc-fe8f-467b-bde0-c294e5326592",
+    "resourceIdObjMeta": {
+      "drupal_internal__target_id": 364,
+    },
+    "type": "taxonomy_term--administration",
+  },
   "breadcrumbs": [
     {
       "options": [],
@@ -130,8 +137,10 @@ exports[`VamcHealthServicesListing formatData outputs formatted data 1`] = `
     },
   ],
   "moderationState": "published",
+  "path": "/north-texas-health-care/health-services",
   "published": true,
   "title": "Health services",
   "type": "node--health_services_listing",
+  "vamcEhrSystem": null,
 }
 `;

--- a/src/data/queries/tests/vamcHealthServicesListing.test.tsx
+++ b/src/data/queries/tests/vamcHealthServicesListing.test.tsx
@@ -4,6 +4,7 @@
 
 import { NodeVamcHealthServicesListing } from '@/types/drupal/node'
 import { queries } from '@/data/queries'
+import { formatter } from '@/data/queries/vamcHealthServicesListing'
 import mockData from '@/mocks/vamcHealthServicesListing.mock.json'
 
 const VamcHealthServicesListingMock: NodeVamcHealthServicesListing = mockData[0]
@@ -38,5 +39,12 @@ describe('VamcHealthServicesListing formatData', () => {
     )
 
     expect(result.introText).toBe('')
+  })
+
+  test('includes path, administration, and vamcEhrSystem fields', () => {
+    const result = formatter(VamcHealthServicesListingMock)
+    expect(result.path).toBeDefined()
+    expect(result.administration).toBeDefined()
+    expect(result.vamcEhrSystem).toBeDefined()
   })
 })

--- a/src/data/queries/vamcHealthServicesListing.ts
+++ b/src/data/queries/vamcHealthServicesListing.ts
@@ -11,7 +11,7 @@ import {
 
 // Define the query params for fetching node--health_services_listing.
 export const params: QueryParams<null> = () => {
-  return new DrupalJsonApiParams()
+  return new DrupalJsonApiParams().addInclude(['field_administration'])
 }
 
 // Define the option types for the data loader.
@@ -40,6 +40,10 @@ export const formatter: QueryFormatter<
 > = (entity: NodeVamcHealthServicesListing) => {
   return {
     ...entityBaseFields(entity),
+    title: entity.title,
     introText: entity.field_intro_text,
+    path: entity.path?.alias || null,
+    administration: entity.field_administration || null,
+    vamcEhrSystem: entity.field_office?.field_vamc_ehr_system || null,
   }
 }

--- a/src/templates/layouts/vamcHealthServicesListing/index.test.tsx
+++ b/src/templates/layouts/vamcHealthServicesListing/index.test.tsx
@@ -8,6 +8,9 @@ describe('VamcHealthServicesListing with valid data', () => {
       <VamcHealthServicesListing
         title={'Health services'}
         introText={'Test intro'}
+        path={'/test-facility/health-services'}
+        administration={null}
+        vamcEhrSystem={null}
         id={'test-id'}
         type={'node--health_services_listing'}
         published={true}
@@ -23,6 +26,9 @@ describe('VamcHealthServicesListing with valid data', () => {
       <VamcHealthServicesListing
         title={'Health Services'}
         introText={'This is intro text'}
+        path={'/test-facility/health-services'}
+        administration={null}
+        vamcEhrSystem={null}
         id={'test-id'}
         type={'node--health_services_listing'}
         published={true}
@@ -33,11 +39,48 @@ describe('VamcHealthServicesListing with valid data', () => {
     expect(screen.getByText('This is intro text')).toBeInTheDocument()
   })
 
+  test('renders Top Task links when path is provided', () => {
+    render(
+      <VamcHealthServicesListing
+        title={'Health Services'}
+        introText={'This is intro text'}
+        path={'/boston-health-care/health-services'}
+        administration={null}
+        vamcEhrSystem={null}
+        id={'test-id'}
+        type={'node--health_services_listing'}
+        published={true}
+        lastUpdated={'2023-01-01'}
+      />
+    )
+
+    // Check that the Top Task links are visible using the same approach as locationsListing
+    const makeAppointmentLink = screen.getByText(
+      (_: string, el: Element | null) =>
+        el?.getAttribute('text') === 'Make an appointment'
+    )
+    const healthServicesLink = screen.getByText(
+      (_: string, el: Element | null) =>
+        el?.getAttribute('text') === 'View all health services'
+    )
+    const registerLink = screen.getByText(
+      (_: string, el: Element | null) =>
+        el?.getAttribute('text') === 'Register for care'
+    )
+
+    expect(makeAppointmentLink).toBeInTheDocument()
+    expect(healthServicesLink).toBeInTheDocument()
+    expect(registerLink).toBeInTheDocument()
+  })
+
   test('renders section headings correctly', () => {
     render(
       <VamcHealthServicesListing
         title={'Health Services'}
         introText={'This is intro text'}
+        path={'/test-facility/health-services'}
+        administration={null}
+        vamcEhrSystem={null}
         id={'test-id'}
         type={'node--health_services_listing'}
         published={true}

--- a/src/templates/layouts/vamcHealthServicesListing/index.tsx
+++ b/src/templates/layouts/vamcHealthServicesListing/index.tsx
@@ -1,8 +1,12 @@
 import { VamcHealthServicesListing as FormattedVamcHealthServicesListing } from '@/types/formatted/vamcHealthServicesListing'
+import { RegionalTopTasks } from '@/templates/components/topTasks'
 
 export function VamcHealthServicesListing({
   title,
   introText,
+  path,
+  administration,
+  vamcEhrSystem,
 }: FormattedVamcHealthServicesListing) {
   return (
     <main className="va-l-detail-page va-facility-page">
@@ -28,6 +32,15 @@ export function VamcHealthServicesListing({
             <div className="va-introtext">
               {introText && <p id="office-events-description">{introText}</p>}
             </div>
+
+            {/* Top Task links */}
+            {path && (
+              <RegionalTopTasks
+                path={path}
+                administration={administration}
+                vamcEhrSystem={vamcEhrSystem}
+              />
+            )}
 
             <div className="usa-grid usa-grid-full vads-u-margin-top--0p5 vads-u-margin-bottom--4">
               <div className="usa-grid usa-grid-full vads-u-margin-y--0 vads-u-margin-bottom--0">

--- a/src/types/formatted/vamcHealthServicesListing.ts
+++ b/src/types/formatted/vamcHealthServicesListing.ts
@@ -1,6 +1,11 @@
 import { PublishedEntity } from './publishedEntity'
+import { Administration } from './administration'
+import { VamcEhrSystem } from '@/types/drupal/vamcEhr'
 
 export type VamcHealthServicesListing = PublishedEntity & {
   title: string
   introText: string
+  path: string
+  administration?: Administration
+  vamcEhrSystem: VamcEhrSystem
 }


### PR DESCRIPTION
# Description
Adds top tasks link to Health Pages

This pull request adds new fields to the VAMC Health Services Listing feature and ensures these fields are properly handled throughout the data layer, component, and tests. The most important changes are the inclusion of the `path`, `administration`, and `vamcEhrSystem` fields, as well as the rendering of Top Task links when a path is provided.

**Data fetching and formatting:**
- The data query now includes the `field_administration` relationship, and the formatter outputs the new `path`, `administration`, and `vamcEhrSystem` fields. [[1]](diffhunk://#diff-cd59258596d07741f82789df6648b29400e5efbfb4a2decd44d40dce8d4e6c83L14-R14) [[2]](diffhunk://#diff-cd59258596d07741f82789df6648b29400e5efbfb4a2decd44d40dce8d4e6c83R43-R47)

**Type updates:**
- The `VamcHealthServicesListing` type is updated to include `path`, `administration`, and `vamcEhrSystem` fields.

**Component and rendering:**
- The `VamcHealthServicesListing` component now accepts and passes the new fields, and renders the `RegionalTopTasks` component when a `path` is present. [[1]](diffhunk://#diff-6ed8c5a84f3f075292fddc82f804d777bdadd6bf56671a4d737fd655ce98f6efR2-R9) [[2]](diffhunk://#diff-6ed8c5a84f3f075292fddc82f804d777bdadd6bf56671a4d737fd655ce98f6efR36-R44)

**Testing:**
- Snapshot and unit tests are updated and expanded to check for the presence of the new fields and verify that Top Task links render correctly when a path is provided. [[1]](diffhunk://#diff-e852a91a79a2e5813be8aeedc9e7c92544f62c32f169b842099046a5bf57b397R5-R11) [[2]](diffhunk://#diff-e852a91a79a2e5813be8aeedc9e7c92544f62c32f169b842099046a5bf57b397R140-R144) [[3]](diffhunk://#diff-51f81c19d09471e840cc4cb16564db484a7c9d3c68d2adf470a20d1a0826ba52R7) [[4]](diffhunk://#diff-51f81c19d09471e840cc4cb16564db484a7c9d3c68d2adf470a20d1a0826ba52R43-R49) [[5]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR11-R13) [[6]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR29-R31) [[7]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR42-R83)
## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes _link to [21800](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21800)

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

Run unit tests
check local and tugboat

## QA steps

Visual inspection on tugboat

## Screenshots

<img width="993" height="676" alt="image" src="https://github.com/user-attachments/assets/0285bb86-e6f8-461c-9cb8-109b503e7440" />
<img width="910" height="794" alt="image" src="https://github.com/user-attachments/assets/13beb7be-12e7-42eb-a0ca-cce4e542001e" />

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```
