### PR TITLE
Rename the type `ParagraphCCVetCenterFaqs` to `ParagraphCCQaSection`

### DIFF
--- a/src/data/queries/tests/__snapshots__/qaSection.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/qaSection.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`QaSection formatData outputs formatted data 1`] = `
     {
       "answers": [
         {
-          "html": "",
+          "html": "<p>asdfasdf</p>",
           "id": "f6dfd8da-877f-46bd-9707-28861c27003e",
           "type": "paragraph--wysiwyg",
         },
@@ -22,7 +22,7 @@ exports[`QaSection formatData outputs formatted data 1`] = `
     {
       "answers": [
         {
-          "html": "",
+          "html": "<p>asdfasdf</p>",
           "id": "004d4d31-9e5f-4dcd-ab19-1aef98daefd4",
           "type": "paragraph--wysiwyg",
         },

--- a/src/data/queries/vetCenter.ts
+++ b/src/data/queries/vetCenter.ts
@@ -24,7 +24,7 @@ import {
   formatParagraph,
 } from '@/lib/drupal/paragraphs'
 import {
-  ParagraphCCVetCenterFaqs,
+  ParagraphCCQaSection,
   ParagraphQaSection,
 } from '@/types/drupal/paragraph'
 import { QaSection } from '@/types/formatted/qaSection'
@@ -146,7 +146,7 @@ export const formatter: QueryFormatter<VetCenterData, FormattedVetCenter> = ({
     return formattedFeaturedContentArray
   }
   // Similarly, this formats centralized content FAQs to match what our QA components are expecting
-  const formatFaq = (faqs: ParagraphCCVetCenterFaqs) => {
+  const formatFaq = (faqs: ParagraphCCQaSection) => {
     const normalizedQaSection = entityFetchedParagraphsToNormalParagraphs({
       type: faqs.target_type,
       bundle: faqs.fetched_bundle,

--- a/src/mocks/qaSection.mock.json
+++ b/src/mocks/qaSection.mock.json
@@ -75,10 +75,39 @@
         {
           "type": "paragraph--wysiwyg",
           "id": "f6dfd8da-877f-46bd-9707-28861c27003e",
-          "resourceIdObjMeta": {
-            "target_revision_id": 3011,
-            "drupal_internal__target_id": 2754
-          }
+          "drupal_internal__id": 2754,
+          "drupal_internal__revision_id": 3011,
+          "langcode": "en",
+          "status": true,
+          "created": "2019-03-04T22:24:09+00:00",
+          "parent_id": "2755",
+          "parent_type": "paragraph",
+          "parent_field_name": "field_answer",
+          "behavior_settings": [],
+          "default_langcode": true,
+          "revision_translation_affected": true,
+          "breadcrumbs": [],
+          "content_translation_source": "und",
+          "content_translation_outdated": false,
+          "content_translation_changed": null,
+          "field_wysiwyg": {
+            "value": "<p>asdfasdf</p>\r\n",
+            "format": "rich_text",
+            "processed": "<p>asdfasdf</p>"
+          },
+          "links": {
+            "self": {
+              "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/wysiwyg/f6dfd8da-877f-46bd-9707-28861c27003e?resourceVersion=id%3A3011"
+            }
+          },
+          "paragraph_type": {
+            "type": "paragraphs_type--paragraphs_type",
+            "id": "885e4b61-cfd2-44b9-94ae-f068ba2b48b6",
+            "resourceIdObjMeta": {
+              "drupal_internal__target_id": "wysiwyg"
+            }
+          },
+          "relationshipNames": ["paragraph_type"]
         }
       ],
       "relationshipNames": ["paragraph_type", "field_answer"]
@@ -121,10 +150,39 @@
         {
           "type": "paragraph--wysiwyg",
           "id": "004d4d31-9e5f-4dcd-ab19-1aef98daefd4",
-          "resourceIdObjMeta": {
-            "target_revision_id": 3013,
-            "drupal_internal__target_id": 2756
-          }
+          "drupal_internal__id": 2756,
+          "drupal_internal__revision_id": 3013,
+          "langcode": "en",
+          "status": true,
+          "created": "2019-03-04T22:25:58+00:00",
+          "parent_id": "2757",
+          "parent_type": "paragraph",
+          "parent_field_name": "field_answer",
+          "behavior_settings": [],
+          "default_langcode": true,
+          "revision_translation_affected": true,
+          "breadcrumbs": [],
+          "content_translation_source": "und",
+          "content_translation_outdated": false,
+          "content_translation_changed": null,
+          "field_wysiwyg": {
+            "value": "<p>asdfasdf</p>\r\n",
+            "format": "rich_text",
+            "processed": "<p>asdfasdf</p>"
+          },
+          "links": {
+            "self": {
+              "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/wysiwyg/004d4d31-9e5f-4dcd-ab19-1aef98daefd4?resourceVersion=id%3A3013"
+            }
+          },
+          "paragraph_type": {
+            "type": "paragraphs_type--paragraphs_type",
+            "id": "885e4b61-cfd2-44b9-94ae-f068ba2b48b6",
+            "resourceIdObjMeta": {
+              "drupal_internal__target_id": "wysiwyg"
+            }
+          },
+          "relationshipNames": ["paragraph_type"]
         }
       ],
       "relationshipNames": ["paragraph_type", "field_answer"]

--- a/src/products/vamcSystemVaPolice/query.ts
+++ b/src/products/vamcSystemVaPolice/query.ts
@@ -14,7 +14,7 @@ import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
 import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
 import { getLovellVariantOfBreadcrumbs } from '@/lib/drupal/lovell/utils'
 import {
-  ParagraphCCVetCenterFaqs,
+  ParagraphCCQaSection,
   ParagraphQaSection,
 } from '@/types/drupal/paragraph'
 import {
@@ -73,7 +73,7 @@ export const data: QueryData<
 }
 
 // Similarly, this formats centralized content FAQs to match what our QA components are expecting
-const formatFaq = (faqs: ParagraphCCVetCenterFaqs) => {
+const formatFaq = (faqs: ParagraphCCQaSection) => {
   const normalizedQaSection = entityFetchedParagraphsToNormalParagraphs({
     type: faqs.target_type,
     bundle: faqs.fetched_bundle,

--- a/src/types/drupal/node.ts
+++ b/src/types/drupal/node.ts
@@ -40,7 +40,7 @@ import {
   ParagraphTable,
   ParagraphWysiwyg,
   ParagraphCCFeaturedContent,
-  ParagraphCCVetCenterFaqs,
+  ParagraphCCQaSection,
   ParagraphFeaturedContent,
   ParagraphListOfLinkTeasers,
 } from './paragraph'
@@ -421,7 +421,7 @@ export interface NodeVamcSystemVaPolice extends DrupalNode {
   field_administration: FieldAdministration
   field_cc_va_police_overview: FieldCCText
   field_phone_numbers_paragraph: ParagraphPhoneNumber[]
-  field_cc_faq: ParagraphCCVetCenterFaqs
+  field_cc_faq: ParagraphCCQaSection
 }
 
 export interface NodeLeadershipListing extends DrupalNode {
@@ -455,7 +455,7 @@ export interface CommonVetCenterFields {
 export interface NodeVetCenter extends CommonVetCenterFields, DrupalNode {
   field_cc_non_traditional_hours: FieldCCText
   field_cc_vet_center_call_center: FieldCCText
-  field_cc_vet_center_faqs: ParagraphCCVetCenterFaqs
+  field_cc_vet_center_faqs: ParagraphCCQaSection
   field_cc_vet_center_featured_con: ParagraphCCFeaturedContent
   field_intro_text: string
   field_mission_explainer: FieldMissionExplainer | null

--- a/src/types/drupal/paragraph.ts
+++ b/src/types/drupal/paragraph.ts
@@ -195,7 +195,7 @@ export interface ParagraphQaSection extends DrupalParagraph {
   field_section_header: string
   field_accordion_display: boolean
   field_section_intro: string
-  field_questions: DrupalParagraph[]
+  field_questions: ParagraphQA[]
 }
 
 export interface ParagraphReactWidget extends DrupalParagraph {

--- a/src/types/drupal/paragraph.ts
+++ b/src/types/drupal/paragraph.ts
@@ -121,7 +121,7 @@ export interface ParagraphCCFeaturedContent {
   }
 }
 
-export interface ParagraphCCVetCenterFaqs {
+export interface ParagraphCCQaSection {
   target_type: string
   fetched_bundle: string
   fetched: {


### PR DESCRIPTION
# Description

- Renames the _centralized content_ (CC) type `ParagraphCCVetCenterFaqs` to `ParagraphCCQaSection` since it is used by more than just the Vet Centers
- Makes the relationship between `ParagraphQaSection` and `ParagraphQA` clearer by actually using the `ParagraphQA` in `ParagraphQaSection`

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21861

## Testing Steps

If your editor supports it or you have some other TypeScript tools, follow the usage for some of these types to get a feel for how they're used. What's a little confusing but is at least consistent is that most of the `Paragraph*` types are the untransformed Drupal data structures, whereas when they get "formatted", the name changes from something like `ParagraphQA` to `QaParagraph`; essentially the type name is flipped.