### PR TITLE
VACMS: 21867 - Health Listings sidebar logic and tests

### DIFF
--- a/src/data/queries/tests/__snapshots__/vamcHealthServicesListing.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/vamcHealthServicesListing.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DrupalJsonApiParams configuration params function sets the correct include fields 1`] = `"include=field_administration,field_office&fields[node--health_care_region_page]=field_vamc_ehr_system,field_system_menu"`;
+
 exports[`VamcHealthServicesListing formatData outputs formatted data 1`] = `
 {
   "administration": {
@@ -35,6 +37,10 @@ exports[`VamcHealthServicesListing formatData outputs formatted data 1`] = `
   "lastUpdated": "2022-02-09T19:01:21+00:00",
   "lovellSwitchPath": null,
   "lovellVariant": null,
+  "menu": {
+    "data": null,
+    "rootPath": "/north-texas-health-care/health-services/",
+  },
   "metatags": [
     {
       "attributes": {

--- a/src/data/queries/tests/__snapshots__/vamcHealthServicesListing.test.tsx.snap
+++ b/src/data/queries/tests/__snapshots__/vamcHealthServicesListing.test.tsx.snap
@@ -38,7 +38,22 @@ exports[`VamcHealthServicesListing formatData outputs formatted data 1`] = `
   "lovellSwitchPath": null,
   "lovellVariant": null,
   "menu": {
-    "data": null,
+    "data": {
+      "description": "Test description",
+      "links": [
+        {
+          "description": "Test description",
+          "expanded": false,
+          "label": "Test Menu Item",
+          "links": [],
+          "lovellSection": null,
+          "url": {
+            "path": "/test-facility/test-service",
+          },
+        },
+      ],
+      "name": "Test Menu Item",
+    },
     "rootPath": "/north-texas-health-care/health-services/",
   },
   "metatags": [

--- a/src/data/queries/tests/vamcHealthServicesListing.test.tsx
+++ b/src/data/queries/tests/vamcHealthServicesListing.test.tsx
@@ -4,20 +4,33 @@
 
 import { NodeVamcHealthServicesListing } from '@/types/drupal/node'
 import { queries } from '@/data/queries'
-import { formatter } from '@/data/queries/vamcHealthServicesListing'
+import { formatter, params } from '@/data/queries/vamcHealthServicesListing'
 import mockData from '@/mocks/vamcHealthServicesListing.mock.json'
 
 const VamcHealthServicesListingMock: NodeVamcHealthServicesListing = mockData[0]
 
+// Mock menu data for testing
+const mockMenu = {
+  items: [],
+  tree: [],
+}
+
 const mockDataWrapper = {
   entity: VamcHealthServicesListingMock,
+  menu: mockMenu,
   lovell: undefined,
 }
 
 // remove if this component does not have a data fetch
 describe('DrupalJsonApiParams configuration', () => {
   test('params function sets the correct include fields', () => {
-    // TODO
+    const paramsInstance = params()
+    const queryString = decodeURIComponent(paramsInstance.getQueryString())
+    expect(queryString).toMatch(/include=field_administration,field_office/)
+    expect(queryString).toMatch(
+      /fields\[node--health_care_region_page\]=field_vamc_ehr_system,field_system_menu/
+    )
+    expect(queryString).toMatchSnapshot()
   })
 })
 
@@ -37,6 +50,7 @@ describe('VamcHealthServicesListing formatData', () => {
 
     const mockDataWrapperWithEmptyDescription = {
       entity: mockWithEmptyDescription,
+      menu: mockMenu,
       lovell: undefined,
     }
 
@@ -49,7 +63,10 @@ describe('VamcHealthServicesListing formatData', () => {
   })
 
   test('includes path, administration, and vamcEhrSystem fields', () => {
-    const result = formatter({ entity: VamcHealthServicesListingMock })
+    const result = formatter({
+      entity: VamcHealthServicesListingMock,
+      menu: mockMenu,
+    })
     expect(result.path).toBeDefined()
     expect(result.administration).toBeDefined()
     expect(result.vamcEhrSystem).toBeDefined()

--- a/src/data/queries/tests/vamcHealthServicesListing.test.tsx
+++ b/src/data/queries/tests/vamcHealthServicesListing.test.tsx
@@ -6,13 +6,33 @@ import { NodeVamcHealthServicesListing } from '@/types/drupal/node'
 import { queries } from '@/data/queries'
 import { formatter, params } from '@/data/queries/vamcHealthServicesListing'
 import mockData from '@/mocks/vamcHealthServicesListing.mock.json'
+import { DrupalMenuLinkContent } from 'next-drupal'
 
-const VamcHealthServicesListingMock: NodeVamcHealthServicesListing = mockData[0]
+// Use type assertion to bypass strict type checking for test data
+const VamcHealthServicesListingMock =
+  mockData[0] as NodeVamcHealthServicesListing
 
-// Mock menu data for testing
+// Mock menu data for testing - providing realistic structure
+const menuItem: DrupalMenuLinkContent = {
+  title: 'Test Menu Item',
+  type: 'menu_link_content',
+  url: '/test-facility/test-service',
+  id: 'test-menu-item',
+  description: 'Test description',
+  enabled: true,
+  expanded: false,
+  menu_name: 'test-menu',
+  meta: {},
+  options: {},
+  parent: null,
+  provider: null,
+  route: null,
+  weight: '0',
+}
+
 const mockMenu = {
-  items: [],
-  tree: [],
+  items: [menuItem],
+  tree: [menuItem],
 }
 
 const mockDataWrapper = {
@@ -70,5 +90,24 @@ describe('VamcHealthServicesListing formatData', () => {
     expect(result.path).toBeDefined()
     expect(result.administration).toBeDefined()
     expect(result.vamcEhrSystem).toBeDefined()
+  })
+
+  test('correctly formats menu data', () => {
+    const result = formatter({
+      entity: VamcHealthServicesListingMock,
+      menu: mockMenu,
+    })
+    expect(result.menu).toBeDefined()
+    expect(result.menu).toHaveProperty('rootPath')
+    expect(result.menu).toHaveProperty('data')
+  })
+
+  test('handles null menu gracefully', () => {
+    const result = formatter({
+      entity: VamcHealthServicesListingMock,
+      menu: null,
+    })
+
+    expect(result.menu).toBeNull()
   })
 })

--- a/src/data/queries/vamcHealthServicesListing.ts
+++ b/src/data/queries/vamcHealthServicesListing.ts
@@ -7,6 +7,7 @@ import { ExpandedStaticPropsContext } from '@/lib/drupal/staticProps'
 import {
   entityBaseFields,
   fetchSingleEntityOrPreview,
+  getMenu,
 } from '@/lib/drupal/query'
 import {
   getLovellVariantOfUrl,
@@ -14,12 +15,17 @@ import {
   getLovellVariantOfBreadcrumbs,
 } from '@/lib/drupal/lovell/utils'
 import { formatter as formatAdministration } from '@/data/queries/administration'
+import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
+import { Menu } from '@/types/drupal/menu'
 
 // Define the query params for fetching node--health_services_listing.
 export const params: QueryParams<null> = () => {
   return new DrupalJsonApiParams()
     .addInclude(['field_administration', 'field_office'])
-    .addFields('node--health_care_region_page', ['field_vamc_ehr_system'])
+    .addFields('node--health_care_region_page', [
+      'field_vamc_ehr_system',
+      'field_system_menu',
+    ])
 }
 
 // Define the option types for the data loader.
@@ -30,6 +36,7 @@ export type VamcHealthServicesListingDataOpts = {
 
 type VamcHealthServicesListingData = {
   entity: NodeVamcHealthServicesListing
+  menu: Menu | null
   lovell?: ExpandedStaticPropsContext['lovell']
 }
 
@@ -43,9 +50,16 @@ export const data: QueryData<
     RESOURCE_TYPES.VAMC_HEALTH_SERVICES_LISTING,
     params
   )) as NodeVamcHealthServicesListing
+  const menu = entity.field_office?.field_system_menu
+    ? await getMenu(
+        entity.field_office.field_system_menu.resourceIdObjMeta
+          .drupal_internal__target_id
+      )
+    : null
 
   return {
     entity,
+    menu,
     lovell: opts.context?.lovell,
   }
 }
@@ -53,11 +67,16 @@ export const data: QueryData<
 export const formatter: QueryFormatter<
   VamcHealthServicesListingData,
   VamcHealthServicesListing
-> = ({ entity, lovell }) => {
+> = ({ entity, menu, lovell }) => {
   let { breadcrumbs } = entity
   if (lovell?.isLovellVariantPage) {
     breadcrumbs = getLovellVariantOfBreadcrumbs(breadcrumbs, lovell.variant)
   }
+
+  const formattedMenu =
+    menu !== null
+      ? buildSideNavDataFromMenu(entity.path?.alias || '', menu)
+      : null
 
   return {
     ...entityBaseFields(entity),
@@ -74,5 +93,6 @@ export const formatter: QueryFormatter<
     path: entity.path?.alias || null,
     administration: formatAdministration(entity.field_administration),
     vamcEhrSystem: entity.field_office?.field_vamc_ehr_system || null,
+    menu: formattedMenu,
   }
 }

--- a/src/templates/layouts/vamcHealthServicesListing/index.test.tsx
+++ b/src/templates/layouts/vamcHealthServicesListing/index.test.tsx
@@ -2,6 +2,16 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { VamcHealthServicesListing } from './index'
 
+// Mock menu data for testing
+const mockMenu = {
+  rootPath: '/test-facility/',
+  data: {
+    name: 'Test Facility',
+    description: '',
+    links: [],
+  },
+}
+
 describe('VamcHealthServicesListing with valid data', () => {
   test('renders VamcHealthServicesListing component', () => {
     render(
@@ -11,6 +21,7 @@ describe('VamcHealthServicesListing with valid data', () => {
         path={'/test-facility/health-services'}
         administration={null}
         vamcEhrSystem={null}
+        menu={mockMenu}
         id={'test-id'}
         type={'node--health_services_listing'}
         published={true}
@@ -29,6 +40,7 @@ describe('VamcHealthServicesListing with valid data', () => {
         path={'/test-facility/health-services'}
         administration={null}
         vamcEhrSystem={null}
+        menu={mockMenu}
         id={'test-id'}
         type={'node--health_services_listing'}
         published={true}
@@ -47,6 +59,7 @@ describe('VamcHealthServicesListing with valid data', () => {
         path={'/boston-health-care/health-services'}
         administration={null}
         vamcEhrSystem={null}
+        menu={mockMenu}
         id={'test-id'}
         type={'node--health_services_listing'}
         published={true}
@@ -81,6 +94,7 @@ describe('VamcHealthServicesListing with valid data', () => {
         path={'/test-facility/health-services'}
         administration={null}
         vamcEhrSystem={null}
+        menu={mockMenu}
         id={'test-id'}
         type={'node--health_services_listing'}
         published={true}
@@ -104,6 +118,7 @@ describe('VamcHealthServicesListing with valid data', () => {
         path={'/test-facility/health-services'}
         administration={null}
         vamcEhrSystem={null}
+        menu={mockMenu}
         id={'test-id'}
         type={'node--health_services_listing'}
         published={true}
@@ -115,5 +130,25 @@ describe('VamcHealthServicesListing with valid data', () => {
     expect(
       screen.getByText('You are viewing this page as a VA beneficiary.')
     ).toBeInTheDocument()
+  })
+
+  test('renders the sidebar nav with correct attributes', () => {
+    render(
+      <VamcHealthServicesListing
+        title={'Health Services'}
+        introText={'This is intro text'}
+        path={'/test-facility/health-services'}
+        administration={null}
+        vamcEhrSystem={null}
+        menu={mockMenu}
+        id={'test-id'}
+        type={'node--health_services_listing'}
+        published={true}
+        lastUpdated={'2023-01-01'}
+      />
+    )
+    const nav = screen.getByLabelText('secondary')
+    expect(nav).toBeInTheDocument()
+    expect(nav).toHaveAttribute('data-widget-type', 'side-nav')
   })
 })

--- a/src/templates/layouts/vamcHealthServicesListing/index.tsx
+++ b/src/templates/layouts/vamcHealthServicesListing/index.tsx
@@ -1,6 +1,14 @@
 import { VamcHealthServicesListing as FormattedVamcHealthServicesListing } from '@/types/formatted/vamcHealthServicesListing'
 import { LovellSwitcher } from '@/templates/components/lovellSwitcher'
 import { FacilityTopTasks } from '@/templates/components/topTasks'
+import { useEffect } from 'react'
+import { SideNavMenu } from '@/types/formatted/sideNav'
+
+// Allows additions to window object without overwriting global type
+interface customWindow extends Window {
+  sideNav?: SideNavMenu
+}
+declare const window: customWindow
 
 export function VamcHealthServicesListing({
   title,
@@ -10,20 +18,20 @@ export function VamcHealthServicesListing({
   path,
   administration,
   vamcEhrSystem,
+  menu,
 }: FormattedVamcHealthServicesListing) {
   // Extract the region base path from the full path (same as healthCareLocalFacility)
   const regionBasePath = path ? path.split('/')[1] : ''
+  // Note: The side nav widget is in a vets-website
+  useEffect(() => {
+    window.sideNav = menu
+  }, [menu])
 
   return (
     <main className="va-l-detail-page va-facility-page">
       <div className="usa-grid usa-grid-full">
-        {/* TODO: Replace with actual FacilitySidebarNav component */}
-        <div className="usa-width-one-fourth">
-          <div className="facility-sidebar-nav">
-            <p>TODO: Add Sidebar </p>
-          </div>
-        </div>
-
+        {/* Nav data filled in by a separate script from `window.sideNav` */}
+        <nav aria-label="secondary" data-widget-type="side-nav" />
         <div className="usa-width-three-fourths">
           <article className="usa-content">
             <LovellSwitcher

--- a/src/types/formatted/vamcHealthServicesListing.ts
+++ b/src/types/formatted/vamcHealthServicesListing.ts
@@ -2,6 +2,7 @@ import { PublishedEntity } from './publishedEntity'
 import { LovellChildVariant } from '@/lib/drupal/lovell/types'
 import { Administration } from './administration'
 import { VamcEhrSystem } from '@/types/drupal/vamcEhr'
+import { SideNavMenu } from '@/types/formatted/sideNav'
 
 export type VamcHealthServicesListing = PublishedEntity & {
   title: string
@@ -11,4 +12,5 @@ export type VamcHealthServicesListing = PublishedEntity & {
   path: string
   administration?: Administration
   vamcEhrSystem: VamcEhrSystem
+  menu: SideNavMenu | null
 }


### PR DESCRIPTION
# Description
Adding the sidebar to this new template - health listings.

This pull request enhances the VAMC Health Services Listing page by integrating a sidebar navigation menu, updating data fetching and formatting logic, and improving test coverage for the new sidebar feature. The changes ensure that menu data is fetched, formatted, and injected into the page for use by a client-side widget.

**Sidebar Navigation Integration and Data Flow Updates:**

* Updated the data query (`vamcHealthServicesListing.ts`) to fetch the related menu via `getMenu` when available, and to include menu data in the returned result. The query params were also updated to include `field_system_menu` in the API request. [[1]](diffhunk://#diff-cd59258596d07741f82789df6648b29400e5efbfb4a2decd44d40dce8d4e6c83R10-R28) [[2]](diffhunk://#diff-cd59258596d07741f82789df6648b29400e5efbfb4a2decd44d40dce8d4e6c83R39) [[3]](diffhunk://#diff-cd59258596d07741f82789df6648b29400e5efbfb4a2decd44d40dce8d4e6c83R53-R80)
* Modified the formatter to accept the new `menu` data, process it with `buildSideNavDataFromMenu`, and include the formatted menu in the output. [[1]](diffhunk://#diff-cd59258596d07741f82789df6648b29400e5efbfb4a2decd44d40dce8d4e6c83R53-R80) [[2]](diffhunk://#diff-cd59258596d07741f82789df6648b29400e5efbfb4a2decd44d40dce8d4e6c83R96)
* Extended the formatted type definition (`vamcHealthServicesListing.ts`) to include a `menu` property, ensuring type safety throughout the app. [[1]](diffhunk://#diff-de56b8cb9d3c915f549b731db00eac3c4e084893b31c7356ace6e1bbebc53908R5) [[2]](diffhunk://#diff-de56b8cb9d3c915f549b731db00eac3c4e084893b31c7356ace6e1bbebc53908R15)

**Component and Rendering Changes:**

* Updated the VamcHealthServicesListing React component to accept the `menu` prop, set `window.sideNav` for the client-side widget, and render a `<nav>` element with the correct ARIA and data attributes for the sidebar navigation. [[1]](diffhunk://#diff-6ed8c5a84f3f075292fddc82f804d777bdadd6bf56671a4d737fd655ce98f6efR4-R11) [[2]](diffhunk://#diff-6ed8c5a84f3f075292fddc82f804d777bdadd6bf56671a4d737fd655ce98f6efR21-R34)

**Test Suite Enhancements:**

* Added and updated tests for the new menu functionality, including passing mock menu data, verifying the sidebar nav is rendered with correct attributes, and updating snapshots and test cases to reflect the new data structure. [[1]](diffhunk://#diff-51f81c19d09471e840cc4cb16564db484a7c9d3c68d2adf470a20d1a0826ba52L7-R33) [[2]](diffhunk://#diff-51f81c19d09471e840cc4cb16564db484a7c9d3c68d2adf470a20d1a0826ba52R53) [[3]](diffhunk://#diff-51f81c19d09471e840cc4cb16564db484a7c9d3c68d2adf470a20d1a0826ba52L52-R69) [[4]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR5-R14) [[5]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR24) [[6]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR43) [[7]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR62) [[8]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR97) [[9]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR121) [[10]](diffhunk://#diff-d82c687e5f43846a700908797e04638d4b7006e4fb9bbcf80aa9845c7188841aR134-R153) [[11]](diffhunk://#diff-e852a91a79a2e5813be8aeedc9e7c92544f62c32f169b842099046a5bf57b397R3-R4) [[12]](diffhunk://#diff-e852a91a79a2e5813be8aeedc9e7c92544f62c32f169b842099046a5bf57b397R40-R43)
## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes  [21867](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21867)

## Developer Task

```md
- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)
```

## Testing Steps

Test on tugboat
Manual QA
Run unit tests

## QA steps
Compare sidebar in tugboat to prod

## Screenshots

<img width="1098" height="838" alt="image" src="https://github.com/user-attachments/assets/4ad30350-8fd0-47e5-a2d5-16fc40b6b9e4" />
<img width="1200" height="804" alt="image" src="https://github.com/user-attachments/assets/2b743c49-25d4-4202-aa26-bd12f0a6f15c" />

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

```md
- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM
```