### PR TITLE
VAMC register for care: Top of page content

### DIFF
--- a/src/components/vamcSystemRegisterForCare/formatted-type.ts
+++ b/src/components/vamcSystemRegisterForCare/formatted-type.ts
@@ -1,9 +1,11 @@
 import { PublishedEntity } from '@/types/formatted/publishedEntity'
 import { VamcSystem } from '../vamcSystem/formatted-type'
 import { SideNavMenu } from '@/types/formatted/sideNav'
+import { Wysiwyg } from '../wysiwyg/formatted-type'
 
 export interface VamcSystemRegisterForCare extends PublishedEntity {
   title: string
   vamcSystem: Pick<VamcSystem, 'id' | 'title'>
   menu: SideNavMenu
+  topOfPageContent: Wysiwyg
 }

--- a/src/components/vamcSystemRegisterForCare/mock.formatted.ts
+++ b/src/components/vamcSystemRegisterForCare/mock.formatted.ts
@@ -1,0 +1,90 @@
+import { VamcSystemRegisterForCare } from './formatted-type'
+
+const mockData: VamcSystemRegisterForCare = {
+  breadcrumbs: [
+    {
+      options: [],
+      title: 'Home',
+      uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/',
+    },
+    {
+      options: [],
+      title: 'VA Richmond health care',
+      uri: 'https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/richmond-health-care',
+    },
+    {
+      options: [],
+      title: 'Register for care',
+      uri: 'internal:#',
+    },
+  ],
+  entityId: 44606,
+  entityPath: '/richmond-health-care/register-for-care',
+  id: '116e00eb-8208-4bdc-8952-e3c9bc509327',
+  lastUpdated: '2022-05-06T15:10:15+00:00',
+  menu: {
+    data: {
+      description: null,
+      links: [
+        {
+          description: null,
+          expanded: false,
+          label: 'VA Richmond health care',
+          links: [
+            {
+              description: null,
+              expanded: false,
+              label: 'SERVICES AND LOCATIONS',
+              links: [],
+              lovellSection: null,
+              url: {
+                path: '',
+              },
+            },
+            {
+              description: null,
+              expanded: false,
+              label: 'NEWS AND EVENTS',
+              links: [],
+              lovellSection: null,
+              url: {
+                path: '',
+              },
+            },
+            {
+              description: null,
+              expanded: false,
+              label: 'ABOUT VA RICHMOND',
+              links: [],
+              lovellSection: null,
+              url: {
+                path: '',
+              },
+            },
+          ],
+          lovellSection: null,
+          url: {
+            path: '/richmond-health-care',
+          },
+        },
+      ],
+      name: 'VA Richmond health care',
+    },
+    rootPath: '/richmond-health-care/register-for-care/',
+  },
+  metatags: [],
+  moderationState: 'published',
+  published: true,
+  title: 'Register for care',
+  topOfPageContent: {
+    html: '<h2 id="patient-registration-admission">Patient registration (admissions)</h2><p>Whether you moved and need to change your medical center or need a primary care provider in the area, we can help. Call us or visit one of our patient registration offices to get started.</p>',
+    id: null,
+    type: 'paragraph--wysiwyg',
+  },
+  type: 'node--vamc_system_register_for_care',
+  vamcSystem: {
+    id: '9aafd9b9-3676-4167-aeb7-0bde3c1ec1d6',
+    title: 'VA Richmond health care',
+  },
+}
+export default mockData

--- a/src/components/vamcSystemRegisterForCare/query.test.ts
+++ b/src/components/vamcSystemRegisterForCare/query.test.ts
@@ -1,3 +1,10 @@
+/**
+ * @jest-environment node
+ *
+ * If we don't have this, next-drupal-query will complain, thinking that it's running on
+ * the client: "You should not call getQueryData on the client."
+ */
+
 import { formatter } from './query'
 import mockData from './mock.json'
 import mockMenu from './mock.menu.json'
@@ -20,10 +27,21 @@ describe('VamcSystemRegisterForCare formatter', () => {
     )
   })
 
+  it('formats topOfPageContent field correctly', () => {
+    const result = formatter({
+      entity: mockData,
+      menu: mockMenu as unknown as Menu,
+    })
+
+    expect(result.topOfPageContent).toBeDefined()
+    expect(result.topOfPageContent.html).toBe(
+      '<h2 id="patient-registration-admission">Patient registration (admissions)</h2>\n\n<p>Whether you moved and need to change your medical center or need a primary care provider in the area, we can help. Call us or visit one of our patient registration offices to get started.</p>'
+    )
+  })
+
   // it('formats centralized content fields', () => {
   //   const result = formatter({ entity: mockData })
 
-  //   expect(result.topOfPageContent).toBeDefined()
   //   expect(result.bottomOfPageContent).toBeDefined()
   //   expect(result.relatedLinks).toBeDefined()
   // })

--- a/src/components/vamcSystemRegisterForCare/query.ts
+++ b/src/components/vamcSystemRegisterForCare/query.ts
@@ -11,6 +11,12 @@ import {
 } from '@/lib/drupal/query'
 import { Menu } from '@/types/drupal/menu'
 import { buildSideNavDataFromMenu } from '@/lib/drupal/facilitySideNav'
+import {
+  entityFetchedParagraphsToNormalParagraphs,
+  formatParagraph,
+} from '@/lib/drupal/paragraphs'
+import { ParagraphWysiwyg } from '@/types/drupal/paragraph'
+import { Wysiwyg } from '../wysiwyg/formatted-type'
 
 // Define the query params for fetching node--vamc_system_register_for_care.
 export const params: QueryParams<null> = () => {
@@ -73,5 +79,12 @@ export const formatter: QueryFormatter<
       title: entity.field_office.title,
     },
     menu: buildSideNavDataFromMenu(entity.path.alias, menu),
+    topOfPageContent: formatParagraph(
+      entityFetchedParagraphsToNormalParagraphs({
+        type: entity.field_cc_top_of_page_content.target_type,
+        bundle: entity.field_cc_top_of_page_content.fetched_bundle,
+        ...entity.field_cc_top_of_page_content.fetched,
+      }) as ParagraphWysiwyg
+    ) as Wysiwyg,
   }
 }

--- a/src/components/vamcSystemRegisterForCare/template.test.tsx
+++ b/src/components/vamcSystemRegisterForCare/template.test.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import VamcSystemRegisterForCare from './template'
-import mockDrupalData from './mock.json'
+// import mockDrupalData from './mock.json'
 import { formatter } from './query'
-import mockMenu from './mock.menu.json'
+// import mockMenu from './mock.menu.json'
 import { Menu } from '@/types/drupal/menu'
+import mockData from './mock.formatted'
 
-const mockData = formatter({
-  entity: mockDrupalData,
-  menu: mockMenu as unknown as Menu,
-})
+// const mockData = formatter({
+//   entity: mockDrupalData,
+//   menu: mockMenu as unknown as Menu,
+// })
 
 describe('VamcSystemRegisterForCare', () => {
   it('renders the title', () => {
@@ -36,5 +37,24 @@ describe('VamcSystemRegisterForCare', () => {
     // @ts-expect-error - window.sideNav is not a default window property, but
     // we're adding it
     expect(window.sideNav).toEqual(mockData.menu)
+  })
+
+  it('renders topOfPageContent in the correct location', () => {
+    render(<VamcSystemRegisterForCare {...mockData} />)
+
+    // Check that the topOfPageContent HTML is rendered
+    const contentSection = screen.getByText('Patient registration (admissions)')
+    expect(contentSection).toBeInTheDocument()
+    expect(contentSection.tagName).toBe('H2')
+    expect(contentSection).toHaveAttribute(
+      'id',
+      'patient-registration-admission'
+    )
+
+    // Check that the paragraph content is also rendered
+    const paragraphContent = screen.getByText(
+      /Whether you moved and need to change your medical center/
+    )
+    expect(paragraphContent).toBeInTheDocument()
   })
 })

--- a/src/components/vamcSystemRegisterForCare/template.test.tsx
+++ b/src/components/vamcSystemRegisterForCare/template.test.tsx
@@ -1,16 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import VamcSystemRegisterForCare from './template'
-// import mockDrupalData from './mock.json'
-import { formatter } from './query'
-// import mockMenu from './mock.menu.json'
-import { Menu } from '@/types/drupal/menu'
 import mockData from './mock.formatted'
-
-// const mockData = formatter({
-//   entity: mockDrupalData,
-//   menu: mockMenu as unknown as Menu,
-// })
 
 describe('VamcSystemRegisterForCare', () => {
   it('renders the title', () => {

--- a/src/components/vamcSystemRegisterForCare/template.tsx
+++ b/src/components/vamcSystemRegisterForCare/template.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { VamcSystemRegisterForCare as FormattedVamcSystemRegisterForCare } from './formatted-type'
 import { ContentFooter } from '../contentFooter/template'
 import { SideNavMenu } from '@/types/formatted/sideNav'
+import { Wysiwyg } from '../wysiwyg/template'
 
 // Allows additions to window object without overwriting global type
 interface customWindow extends Window {
@@ -14,6 +15,7 @@ export const VamcSystemRegisterForCare = ({
   vamcSystem,
   lastUpdated,
   menu,
+  topOfPageContent,
 }: FormattedVamcSystemRegisterForCare) => {
   // Populate the side nav data for the side nav widget to fill in
   // Note: The side nav widget is in a separate app in the static-pages bundle
@@ -49,12 +51,10 @@ export const VamcSystemRegisterForCare = ({
                 </p>
               </div>
 
-              {/* TODO: On this page navigation */}
-              <div>TODO: On this page navigation</div>
+              <va-on-this-page></va-on-this-page>
 
-              {/* TODO: Centralized content - top of page */}
               <div className="usa-content">
-                <div>TODO: Centralized content - top of page</div>
+                <Wysiwyg {...topOfPageContent} />
               </div>
 
               {/* TODO: Facilities offering non-clinical service */}

--- a/src/types/drupal/field_type.d.ts
+++ b/src/types/drupal/field_type.d.ts
@@ -170,6 +170,7 @@ export type FieldNestedButton = {
   field_button_link: FieldCCNestedLink[]
 }
 export interface FieldCCText {
+  target_type: string
   target_id?: string
   fetched_bundle: string
   fetched: {


### PR DESCRIPTION
# Description

Adds the top-of-page CC content for the "Register for care" page.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21898

## Testing Steps

http://localhost:3999/richmond-health-care/register-for-care/

## Screenshots

<img width="1037" height="761" alt="Screenshot 2025-09-01 at 8 43 51 PM" src="https://github.com/user-attachments/assets/87f85134-159b-49fd-8b65-70ce91775122" />

