### PR TITLE
Fix the text for when there are no news releases

### DIFF
--- a/src/components/pressReleaseListing/template.test.tsx
+++ b/src/components/pressReleaseListing/template.test.tsx
@@ -69,7 +69,7 @@ describe('PressReleaseListing component renders', () => {
       <PressReleaseListing {...pressReleaseListingProps} news-releases={[]} />
     )
     expect(screen.queryByText(/News releases/)).toBeInTheDocument()
-    const element = screen.getByText('No stories at this time.')
+    const element = screen.getByText('No news releases at this time.')
     expect(element).toBeInTheDocument()
   })
 })

--- a/src/components/pressReleaseListing/template.tsx
+++ b/src/components/pressReleaseListing/template.tsx
@@ -54,7 +54,7 @@ export function PressReleaseListing(
         </li>
       ))
     ) : (
-      <div className="clearfix-text">No stories at this time.</div>
+      <div className="clearfix-text">No news releases at this time.</div>
     )
 
   return (


### PR DESCRIPTION
# Description

Fixed the wrong text being used for when there are no press releases.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22104

## Testing Steps

http://localhost:3999/central-western-massachusetts-health-care/news-releases/

## Screenshots

<img width="1624" height="1056" alt="Screenshot 2025-09-02 at 7 55 30 AM" src="https://github.com/user-attachments/assets/f3456ce2-3061-4bea-88dd-af441fa9baa2" />
