### PR TITLE
Remove --turbopack from the start command

### DIFF
--- a/scripts/yarn/start.js
+++ b/scripts/yarn/start.js
@@ -1,3 +1,3 @@
 import { processEnv } from 'env-loader'
 
-processEnv('next start --turbopack')
+processEnv('next start')


### PR DESCRIPTION
This is because we're not actually _compiling_ anything with this command, turns out. 🫠 