### PR TITLE
Use EKS instead of Drupal Tugboat for Next Build Tugboat Builds

### DIFF
--- a/envs/.env.tugboat
+++ b/envs/.env.tugboat
@@ -1,5 +1,6 @@
 # Domain for the CMS Content API.
-NEXT_PUBLIC_DRUPAL_BASE_URL=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
+# NEXT_PUBLIC_DRUPAL_BASE_URL=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov
+NEXT_PUBLIC_DRUPAL_BASE_URL=https://eks-dev.cms.va.gov/
 
 # Domain for retrieving CMS images; likely unused.
 NEXT_IMAGE_DOMAIN=https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov


### PR DESCRIPTION
# Description

This is an attempt to identify is the source of the 502 errors in the `next-build` static builds. The hypothesis is that during static site generation, the ELB is connecting to a lot of different "host" ports on the Drupal tugboat instance that all redirect to the same HTTPS port (443), and with enough requests coming in during SSG, we're overwhelming the port. We're not seeing any 502 logs in Tugboat, but if the connection pool is full, these errors maybe generated by the ELB because Tugboat is sending a TCP RST in response to the connection attempt. That probably isn't logged in Tugboat.

By pointing to EKS, we'll see if Tugboat's HTTPS connection pool capacity is the cause of the 502s.