### PR TITLE
Give API explorer tabs in the browser a real title

### DIFF
--- a/src/pages/_playground/api-explorer.tsx
+++ b/src/pages/_playground/api-explorer.tsx
@@ -185,6 +185,11 @@ export default function ApiExplorer() {
     }))
   }, []) // Only run once on mount
 
+  // Update document title when queryState changes
+  useEffect(() => {
+    document.title = `API Explorer - ${queryState.resourceType}`
+  }, [queryState.resourceType])
+
   const handleResourceTypeChange = (
     e: React.ChangeEvent<HTMLSelectElement>
   ) => {


### PR DESCRIPTION
# Description

When I'm doing local development, I often have tabs open for the API Explorer next to my other testing tabs, and I have a hard time telling which ones are which. This is a quick solution to that by giving the tab a title.

## Ticket

No ticket

## Screenshots

![tabs](https://github.com/user-attachments/assets/2792aab5-011a-497a-8ca0-7d3d7cef857a)
