### PR TITLE
Fix type error with mock data that is failing CI tests

### DIFF
--- a/src/components/vamcHealthServicesListing/query.test.ts
+++ b/src/components/vamcHealthServicesListing/query.test.ts
@@ -14,13 +14,13 @@ import { DrupalMenuLinkContent } from 'next-drupal'
 import { createMockServicesForGrouping } from './mockServiceDes'
 
 // Use type assertion to bypass strict type checking for test data
-const mockServicesListing: NodeVamcHealthServicesListing = {
+const mockServicesListing = {
   ...mockServicesListingPartial,
   field_office: {
     ...(mockSystem as unknown as NodeHealthCareRegionPage),
     field_system_menu: {},
   },
-}
+} as NodeVamcHealthServicesListing
 
 // Mock menu data for testing - providing realistic structure
 const menuItem: DrupalMenuLinkContent = {


### PR DESCRIPTION
# Description

This fixes a type-checking failure on the main branch.

I had merged my https://github.com/department-of-veterans-affairs/next-build/pull/1344 after https://github.com/department-of-veterans-affairs/next-build/pull/1343 was merged without having updated it from the main branch, so the CI tests never caught the new error.