### PR TITLE
Adjust spacing for VAMC health services "top tasks"

### DIFF
--- a/src/components/topTasks/template.tsx
+++ b/src/components/topTasks/template.tsx
@@ -6,6 +6,7 @@ type TopTasksProps = {
   path: string
   vamcEhrSystem: VamcEhrSystem
   administration?: Administration
+  className?: string
 }
 
 /**
@@ -17,6 +18,7 @@ export const FacilityTopTasks = ({
   path,
   administration,
   vamcEhrSystem,
+  className = 'vads-u-margin-bottom--6',
 }: TopTasksProps) => {
   path = normalizePath(path)
 
@@ -28,27 +30,29 @@ export const FacilityTopTasks = ({
   })
 
   return (
-    <div data-testid="facility-top-tasks" className="vads-u-margin-bottom--6">
-      <div data-template="facilities/facilities_health_services_buttons">
-        <va-link-action
-          class="vads-u-display--block"
-          href={`${topTask.url}`}
-          text={`${topTask.text}`}
-          type="secondary"
-        ></va-link-action>
-        <va-link-action
-          class="vads-u-display--block"
-          href={`${path}/register-for-care`}
-          text="Register for care"
-          type="secondary"
-        ></va-link-action>
-        <va-link-action
-          class="vads-u-display--block"
-          href={`${path}/pharmacy`}
-          text="Learn about pharmacy services"
-          type="secondary"
-        ></va-link-action>
-      </div>
+    <div
+      data-template="facilities/facilities_health_services_buttons"
+      data-testid="facility-top-tasks"
+      className={className}
+    >
+      <va-link-action
+        class="vads-u-display--block"
+        href={`${topTask.url}`}
+        text={`${topTask.text}`}
+        type="secondary"
+      ></va-link-action>
+      <va-link-action
+        class="vads-u-display--block"
+        href={`${path}/register-for-care`}
+        text="Register for care"
+        type="secondary"
+      ></va-link-action>
+      <va-link-action
+        class="vads-u-display--block"
+        href={`${path}/pharmacy`}
+        text="Learn about pharmacy services"
+        type="secondary"
+      ></va-link-action>
     </div>
   )
 }

--- a/src/components/vamcHealthServicesListing/template.tsx
+++ b/src/components/vamcHealthServicesListing/template.tsx
@@ -40,13 +40,12 @@ export function VamcHealthServicesListing({
 
         {/* Top Task links */}
         {path && (
-          <div>
-            <FacilityTopTasks
-              path={regionBasePath}
-              administration={administration}
-              vamcEhrSystem={vamcEhrSystem}
-            />
-          </div>
+          <FacilityTopTasks
+            path={regionBasePath}
+            administration={administration}
+            vamcEhrSystem={vamcEhrSystem}
+            className="vads-u-margin-bottom--4"
+          />
         )}
 
         <va-on-this-page />


### PR DESCRIPTION
# Description

Makes the spacing for the "top tasks" match prod better. Thought about making that outer div external to the TopTasks component, but I liked how clean it was in the other components. Decided to make it a `className` override instead.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21806

## Testing Steps

Compare http://localhost:3999/boston-health-care/health-services/ with https://www.va.gov/boston-health-care/health-services/

## Screenshots

Before:

<img width="1624" height="1056" alt="screenshot showing the top tasks with more bottom margin" src="https://github.com/user-attachments/assets/54d06b1c-a102-4874-9db6-045d6d65c085" />

After:

<img width="1624" height="1056" alt="screenshot showing the top tasks with less bottom margin" src="https://github.com/user-attachments/assets/45448de5-708a-4404-843d-10eab97c568f" />
