### PR TITLE
Medical records page: Add the React widget

### DIFF
--- a/src/components/reactWidget/formatted-type.ts
+++ b/src/components/reactWidget/formatted-type.ts
@@ -2,7 +2,7 @@ import { PublishedParagraph } from '@/types/formatted/publishedEntity'
 
 export type ReactWidget = PublishedParagraph & {
   type: 'paragraph--react_widget'
-  entityId: number
+  entityId: number | null
   widgetType: string
   ctaWidget?: boolean
   loadingMessage?: string
@@ -12,6 +12,6 @@ export type ReactWidget = PublishedParagraph & {
   defaultLink?: {
     url: string
     title: string
-  }
+  } | null
   buttonFormat?: boolean
 }

--- a/src/components/reactWidget/query.ts
+++ b/src/components/reactWidget/query.ts
@@ -2,17 +2,32 @@ import { ParagraphReactWidget } from '@/types/drupal/paragraph'
 import { QueryFormatter } from 'next-drupal-query'
 import { ReactWidget } from '@/components/reactWidget/formatted-type'
 
+const parseBoolean = (value: string | boolean) => {
+  if (typeof value === 'string') {
+    return value === '1'
+  }
+  return value
+}
+
 export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
   entity: ParagraphReactWidget
 ) => {
   return {
     type: entity.type as ReactWidget['type'],
-    id: entity.id,
-    entityId: entity.drupal_internal__id,
+    id: entity.id ?? null,
+    entityId: entity.drupal_internal__id ?? null,
     widgetType: entity.field_widget_type,
-    ctaWidget: entity.field_cta_widget,
+    ctaWidget: parseBoolean(entity.field_cta_widget),
     loadingMessage: entity.field_loading_message,
-    timeout: entity.field_timeout,
+    // TODO: Until we come across an example of a react widget that isn't pulled in via
+    // entity_field_fetch, we won't know if the regular Drupal API parses these number
+    // and boolean values automatically or if we'll always need to parse them manually.
+    // For now, we'll just expect either type. This formatter was created before it was
+    // actually used.
+    timeout:
+      typeof entity.field_timeout === 'string'
+        ? parseInt(entity.field_timeout, 10)
+        : entity.field_timeout,
     errorMessage: entity.field_error_message.processed,
     defaultLink: entity.field_default_link
       ? {
@@ -20,6 +35,6 @@ export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
           title: entity.field_default_link.title,
         }
       : null,
-    buttonFormat: entity.field_button_format,
+    buttonFormat: parseBoolean(entity.field_button_format),
   }
 }

--- a/src/components/reactWidget/query.ts
+++ b/src/components/reactWidget/query.ts
@@ -2,7 +2,7 @@ import { ParagraphReactWidget } from '@/types/drupal/paragraph'
 import { QueryFormatter } from 'next-drupal-query'
 import { ReactWidget } from '@/components/reactWidget/formatted-type'
 
-const parseBoolean = (value: string | boolean) => {
+const toBoolean = (value: string | boolean) => {
   if (typeof value === 'string') {
     return value === '1'
   }
@@ -17,7 +17,7 @@ export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
     id: entity.id ?? null,
     entityId: entity.drupal_internal__id ?? null,
     widgetType: entity.field_widget_type,
-    ctaWidget: parseBoolean(entity.field_cta_widget),
+    ctaWidget: toBoolean(entity.field_cta_widget),
     loadingMessage: entity.field_loading_message,
     // TODO: Until we come across an example of a react widget that isn't pulled in via
     // entity_field_fetch, we won't know if the regular Drupal API parses these number
@@ -35,6 +35,6 @@ export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
           title: entity.field_default_link.title,
         }
       : null,
-    buttonFormat: parseBoolean(entity.field_button_format),
+    buttonFormat: toBoolean(entity.field_button_format),
   }
 }

--- a/src/components/vamcSystemMedicalRecordsOffice/formatted-type.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/formatted-type.ts
@@ -6,6 +6,7 @@ import { ListOfLinkTeasers } from '../listOfLinkTeasers/formatted-type'
 import { ServiceLocation } from '../serviceLocation/formatted-type'
 import { FieldAddress } from '@/types/drupal/field_type'
 import { LovellChildVariant } from '@/lib/drupal/lovell/types'
+import { ReactWidget } from '../reactWidget/formatted-type'
 
 export interface VamcSystemMedicalRecordsOffice extends PublishedEntity {
   title: string
@@ -13,7 +14,7 @@ export interface VamcSystemMedicalRecordsOffice extends PublishedEntity {
   menu: SideNavMenu
   topOfPageContent: Wysiwyg
   getRecordsInPersonContent: Wysiwyg
-  bottomOfPageContent: Wysiwyg
+  reactWidget: ReactWidget
   relatedLinks: ListOfLinkTeasers
   services: Array<{
     id: string

--- a/src/components/vamcSystemMedicalRecordsOffice/mock.formatted.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/mock.formatted.ts
@@ -583,7 +583,19 @@ const mockData: VamcSystemMedicalRecordsOffice = {
     id: '82639',
     html: '<h2 id="get-your-records-in-person">Get your records in person</h2><p>We can help you get copies of your VA medical records. We can also help you update your records. Call or visit one of our release of information offices.</p><p><strong>What to bring</strong></p><ul><li>A signed written request for a copy of your records to be provided to you. For your convenience you may download and complete the “Individuals’ Request For a Copy of Their Own Health Information” (VA Form 10-5345a).  <a href="https://www.va.gov/vaforms/medical/pdf/VHA%20Form%2010-5345a%20Fill-revision.pdf" hreflang="en">Download VA Form 10-5345a (PDF)</a></li><li>Your Veteran Health Identification Card (VHIC)</li></ul>',
   },
-  bottomOfPageContent: null,
+  reactWidget: {
+    type: 'paragraph--react_widget',
+    id: '82635',
+    entityId: null,
+    widgetType: 'modern-get-medical-records-page',
+    ctaWidget: true,
+    loadingMessage: null,
+    timeout: 20,
+    errorMessage:
+      '<strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.',
+    defaultLink: null,
+    buttonFormat: false,
+  },
   relatedLinks: {
     type: 'paragraph--list_of_link_teasers',
     id: '82659',

--- a/src/components/vamcSystemMedicalRecordsOffice/query.test.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/query.test.ts
@@ -46,12 +46,6 @@ describe('VamcSystemMedicalRecordsOffice formatter', () => {
     )
   })
 
-  it('formats bottomOfPageContent field correctly', () => {
-    const result = formatter(defaultData)
-
-    expect(result.bottomOfPageContent).toBeNull()
-  })
-
   it('formats relatedLinks field correctly', () => {
     const result = formatter(defaultData)
 
@@ -216,6 +210,15 @@ describe('VamcSystemMedicalRecordsOffice formatter', () => {
       expect(result.breadcrumbs).toEqual(lovellBreadcrumbs)
       expect(result.lovellVariant).toBeNull()
       expect(result.lovellSwitchPath).toBeNull()
+    })
+
+    it('formats reactWidget field correctly', () => {
+      const result = formatter(defaultData)
+
+      expect(result.reactWidget).toBeDefined()
+      expect(result.reactWidget.widgetType).toBe(
+        'modern-get-medical-records-page'
+      )
     })
   })
 })

--- a/src/components/vamcSystemMedicalRecordsOffice/query.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/query.ts
@@ -34,6 +34,7 @@ import {
   getLovellVariantOfUrl,
   getOppositeChildVariant,
 } from '@/lib/drupal/lovell/utils'
+import { formatter as formatReactWidget } from '@/components/reactWidget/query'
 
 // Define the query params for fetching node--vamc_system_medical_records_office.
 export const params: QueryParams<null> = () => {
@@ -156,8 +157,8 @@ export const formatter: QueryFormatter<
     getRecordsInPersonContent: formatCcWysiwyg(
       entity.field_cc_get_records_in_person
     ),
-    bottomOfPageContent: formatCcWysiwyg(
-      entity.field_cc_bottom_of_page_content
+    reactWidget: formatReactWidget(
+      normalizeEntityFetchedParagraphs(entity.field_cc_react_widget)
     ),
     relatedLinks: formatListOfLinkTeasers(
       normalizeEntityFetchedParagraphs(entity.field_cc_related_links)

--- a/src/components/vamcSystemMedicalRecordsOffice/template.test.tsx
+++ b/src/components/vamcSystemMedicalRecordsOffice/template.test.tsx
@@ -58,4 +58,12 @@ describe('VamcSystemMedicalRecordsOffice', () => {
     )
     expect(paragraphContent).toBeInTheDocument()
   })
+
+  it('renders the reactWidget', () => {
+    render(<VamcSystemMedicalRecordsOffice {...mockData} />)
+    const reactWidget = document.querySelector(
+      '[data-template="paragraphs/react_widget"]'
+    )
+    expect(reactWidget).toBeInTheDocument()
+  })
 })

--- a/src/components/vamcSystemMedicalRecordsOffice/template.tsx
+++ b/src/components/vamcSystemMedicalRecordsOffice/template.tsx
@@ -1,15 +1,16 @@
 import { Fragment } from 'react'
 import { VamcSystemMedicalRecordsOffice as FormattedVamcSystemMedicalRecordsOffice } from './formatted-type'
-import { ContentFooter } from '../contentFooter/template'
-import { Wysiwyg } from '../wysiwyg/template'
-import { ListOfLinkTeasers } from '../listOfLinkTeasers/template'
+import { ContentFooter } from '@/components/contentFooter/template'
+import { Wysiwyg } from '@/components/wysiwyg/template'
+import { ListOfLinkTeasers } from '@/components/listOfLinkTeasers/template'
 import {
   ServiceLocation,
   ServiceLocationType,
-} from '../serviceLocation/template'
+} from '@/components/serviceLocation/template'
 import { Address } from '@/components/address/template'
 import { LovellSwitcher } from '@/components/lovellSwitcher/template'
 import { SideNavLayout } from '@/components/sideNavLayout/template'
+import { ReactWidget } from '@/components/reactWidget/template'
 
 export const VamcSystemMedicalRecordsOffice = ({
   title,
@@ -18,7 +19,7 @@ export const VamcSystemMedicalRecordsOffice = ({
   menu,
   topOfPageContent,
   getRecordsInPersonContent,
-  bottomOfPageContent,
+  reactWidget,
   relatedLinks,
   services,
   lovellVariant,
@@ -48,6 +49,8 @@ export const VamcSystemMedicalRecordsOffice = ({
         <div className="usa-content">
           <Wysiwyg {...topOfPageContent} />
         </div>
+
+        <ReactWidget {...reactWidget} />
 
         <div className="usa-content">
           <Wysiwyg {...getRecordsInPersonContent} />
@@ -89,9 +92,6 @@ export const VamcSystemMedicalRecordsOffice = ({
               - fieldFaxNumber (fax number)
             */}
 
-        <Wysiwyg {...bottomOfPageContent} />
-
-        {/* TODO: Related links */}
         <div className="va-nav-linkslist va-nav-linkslist--related">
           <ListOfLinkTeasers {...relatedLinks} />
         </div>

--- a/src/lib/drupal/paragraphs.ts
+++ b/src/lib/drupal/paragraphs.ts
@@ -93,6 +93,10 @@ function isEntityFetchedRoot(root: unknown): root is EntityFetchedRoot {
   )
 }
 
+/**
+ * These are fields that we expect to be actual arrays, so we don't want to convert them
+ * to single values.
+ */
 const EXPECTED_ARRAY_FIELDS = [
   'field_links',
   'field_audience_beneficiares',
@@ -100,7 +104,15 @@ const EXPECTED_ARRAY_FIELDS = [
   'field_topics',
 ]
 
-const POSSIBLY_EMPTY_FIELDS = ['field_alert_block_reference']
+/**
+ * These are fields that could be null, so if we are converting from an array to a single
+ * value and get an empty array, we want to convert it back to null.
+ */
+const POSSIBLY_EMPTY_FIELDS = [
+  'field_alert_block_reference',
+  'field_default_link',
+  'field_loading_message',
+]
 
 /**
  * Recursively converts a paragraph that was fetched using [entity_field_fetch](https://www.drupal.org/project/entity_field_fetch)

--- a/src/types/drupal/field_type.d.ts
+++ b/src/types/drupal/field_type.d.ts
@@ -1,4 +1,6 @@
 import { TaxonomyTermHealthCareServiceTaxonomy } from './taxonomy_term'
+import { ParagraphReactWidget } from './paragraph'
+import { DrupalParagraph } from 'next-drupal'
 
 export interface FieldAddress {
   langcode: string
@@ -172,6 +174,22 @@ export type FieldNestedButton = {
   field_button_label: FieldNestedText[]
   field_button_link: FieldCCNestedLink[]
 }
+
+export type EntityFieldFetched<FetchedType extends object> = {
+  target_type: string
+  target_id: string
+  fetched_bundle: string
+  fetched: {
+    // [key in keyof FetchedType]: Array<FetchedType[key]>
+    [key in Exclude<keyof FetchedType, keyof DrupalParagraph>]: Array<
+      FetchedType[key]
+    >
+    // [key in keyof FetchedType]: key extends keyof DrupalParagraph
+    //   ? Array<FetchedType[key]> | undefined
+    //   : Array<FetchedType[key]>
+  }
+}
+
 export interface FieldCCText {
   target_type: string
   target_id: string
@@ -180,6 +198,7 @@ export interface FieldCCText {
     field_wysiwyg: FieldFormattedText[]
   }
 }
+
 export interface FieldCCPhone {
   target_type: string
   target_id: string
@@ -226,6 +245,15 @@ export interface FieldCCListOfLinkTeasers {
     field_va_paragraphs: FieldCCNestedLinkTeaser[]
   }
 }
+
+export type FieldCCReactWidget = EntityFieldFetched<ParagraphReactWidget>
+// export type FieldCCReactWidget = EntityFieldFetched<Pick<ParagraphReactWidget, 'field_cta_widget'
+// | 'field_default_link'
+// | 'field_button_format'
+// | 'field_error_message'
+// | 'field_loading_message'
+// | 'field_timeout'
+// | 'field_widget_type'>>
 
 export interface FieldMissionExplainer {
   target_id: string

--- a/src/types/drupal/field_type.d.ts
+++ b/src/types/drupal/field_type.d.ts
@@ -175,18 +175,14 @@ export type FieldNestedButton = {
   field_button_link: FieldCCNestedLink[]
 }
 
-export type EntityFieldFetched<FetchedType extends object> = {
+export type EntityFieldFetched<FetchedType extends DrupalParagraph> = {
   target_type: string
   target_id: string
   fetched_bundle: string
   fetched: {
-    // [key in keyof FetchedType]: Array<FetchedType[key]>
     [key in Exclude<keyof FetchedType, keyof DrupalParagraph>]: Array<
       FetchedType[key]
     >
-    // [key in keyof FetchedType]: key extends keyof DrupalParagraph
-    //   ? Array<FetchedType[key]> | undefined
-    //   : Array<FetchedType[key]>
   }
 }
 
@@ -247,13 +243,6 @@ export interface FieldCCListOfLinkTeasers {
 }
 
 export type FieldCCReactWidget = EntityFieldFetched<ParagraphReactWidget>
-// export type FieldCCReactWidget = EntityFieldFetched<Pick<ParagraphReactWidget, 'field_cta_widget'
-// | 'field_default_link'
-// | 'field_button_format'
-// | 'field_error_message'
-// | 'field_loading_message'
-// | 'field_timeout'
-// | 'field_widget_type'>>
 
 export interface FieldMissionExplainer {
   target_id: string

--- a/src/types/drupal/node.ts
+++ b/src/types/drupal/node.ts
@@ -23,6 +23,7 @@ import {
   FieldVetCenterBannerImage,
   FieldCCListOfLinkTeasers,
   FieldContentBlock,
+  FieldCCReactWidget,
 } from './field_type'
 import { DrupalMediaDocument, DrupalMediaImage } from './media'
 import {
@@ -478,16 +479,14 @@ export interface NodeVamcSystemMedicalRecordsOffice extends DrupalNode {
     NodeHealthCareRegionPage,
     'id' | 'title' | 'field_system_menu'
   >
-  field_cc_top_of_page_content?: FieldCCText
-  field_cc_bottom_of_page_content?: FieldCCText
-  field_cc_related_links?: FieldCCListOfLinkTeasers
-  // TODO: Add additional centralized content fields from medical records template
-  // field_cc_react_widget?: FieldCCText
+  field_cc_top_of_page_content: FieldCCText
+  field_cc_related_links: FieldCCListOfLinkTeasers
+  field_cc_react_widget: FieldCCReactWidget
+
   // field_cc_get_records_in_person?: FieldCCText
   // field_cc_get_records_mail_or_fax?: FieldCCText
   // field_cc_how_we_share_records?: FieldCCText
   // field_cc_faqs?: FieldCCText
-  // TODO: Add individual node fields from medical records template
   // field_vamc_med_records_mailing?: FieldAddress
   // field_fax_number?: string
 }


### PR DESCRIPTION
## Notice about main branch
Until further notice, the main branch of this repo is locked. Pull requests should be made against the [integration-202510](https://github.com/department-of-veterans-affairs/next-build/tree/integration-202510) branch. 

Merges to the main branch for critical bugs or security updates are allowed. Please contact CMS Team in the [#platform-cms-team](https://dsva.slack.com/archives/CT4GZBM8F) channel if you need assistance. 

## Description

We already had a component for rendering a`ReactWidget`, but as far as I can tell we've never used them until now. I had to make some adjustments, but it works now.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21978

## Testing Steps

http://localhost:3999/boston-health-care/medical-records-office

## Screenshots

<img width="1624" height="1056" alt="Screenshot 2025-10-01 at 12 45 10 PM" src="https://github.com/user-attachments/assets/71f13b90-9ba0-45ac-b596-4396dd62172f" />
