### PR TITLE
VACMS-22408: process wysiwyg body content on banner.

### DIFF
--- a/src/components/banner/__snapshots__/query.test.ts.snap
+++ b/src/components/banner/__snapshots__/query.test.ts.snap
@@ -4,7 +4,8 @@ exports[`Banners return formatted data outputs formatted data for BASIC banner t
 [
   {
     "alertType": "information",
-    "body": "<p>this is a regular degular ol banner</p>",
+    "body": "<p>this is a regular degular ol banner</p>
+",
     "dismiss": true,
     "id": 65137,
     "title": "a banner",

--- a/src/components/banner/query.ts
+++ b/src/components/banner/query.ts
@@ -2,6 +2,7 @@ import { QueryData, QueryFormatter } from 'next-drupal-query'
 import { BANNER_RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
 import { BannersData } from './formatted-type'
 import { drupalClient } from '@/lib/drupal/drupalClient'
+import { getHtmlFromField } from '@/lib/utils/getHtmlFromField'
 
 export type BannerDataOpts = {
   itemPath?: string
@@ -35,7 +36,7 @@ export const formatter: QueryFormatter<any, BannersData> = (entities) => {
         return {
           id: banner.nid,
           title: banner.title,
-          body: banner.body.value,
+          body: getHtmlFromField(banner.body),
           alertType: banner.field_alert_type,
           dismiss,
           type: banner.type.target_id,


### PR DESCRIPTION
## Notice about main branch
Until further notice, the main branch of this repo is locked. Pull requests should be made against the [integration-202510](https://github.com/department-of-veterans-affairs/next-build/tree/integration-202510) branch. 

Merges to the main branch for critical bugs or security updates are allowed. Please contact CMS Team in the [#platform-cms-team](https://dsva.slack.com/archives/CT4GZBM8F) channel if you need assistance. 

## Description

Formats the banner body value from `processed` data rather than `value`.

This pull request updates the banner data formatting logic to ensure the banner body is consistently converted to HTML before being output, improving data integrity and display. The main changes focus on using a utility function for HTML conversion and updating related imports and test snapshots.

**Banner data formatting improvements:**

* Updated the `formatter` in `query.ts` to use the `getHtmlFromField` utility for converting the `banner.body` field to HTML, ensuring consistent formatting of banner bodies.
* Added the `getHtmlFromField` import to `query.ts` to support the new formatting logic.

**Test snapshot update:**

* Modified the test snapshot in `query.test.ts.snap` to reflect the new HTML output for banner bodies, including an extra newline after the paragraph.

## Ticket

Closes [22408](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22408)

## Developer Task

- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)

## Testing Steps

 - [ ] Banner body looks properly formatted with clickable links if they exist.

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.
