### PR TITLE
Medical records page: Add FAQ section

### DIFF
--- a/src/components/reactWidget/query.ts
+++ b/src/components/reactWidget/query.ts
@@ -2,13 +2,6 @@ import { ParagraphReactWidget } from '@/types/drupal/paragraph'
 import { QueryFormatter } from 'next-drupal-query'
 import { ReactWidget } from '@/components/reactWidget/formatted-type'
 
-const toBoolean = (value: string | boolean) => {
-  if (typeof value === 'string') {
-    return value === '1'
-  }
-  return value
-}
-
 export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
   entity: ParagraphReactWidget
 ) => {
@@ -17,17 +10,9 @@ export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
     id: entity.id ?? null,
     entityId: entity.drupal_internal__id ?? null,
     widgetType: entity.field_widget_type,
-    ctaWidget: toBoolean(entity.field_cta_widget),
+    ctaWidget: entity.field_cta_widget,
     loadingMessage: entity.field_loading_message,
-    // TODO: Until we come across an example of a react widget that isn't pulled in via
-    // entity_field_fetch, we won't know if the regular Drupal API parses these number
-    // and boolean values automatically or if we'll always need to parse them manually.
-    // For now, we'll just expect either type. This formatter was created before it was
-    // actually used.
-    timeout:
-      typeof entity.field_timeout === 'string'
-        ? parseInt(entity.field_timeout, 10)
-        : entity.field_timeout,
+    timeout: entity.field_timeout,
     errorMessage: entity.field_error_message.processed,
     defaultLink: entity.field_default_link
       ? {
@@ -35,6 +20,6 @@ export const formatter: QueryFormatter<ParagraphReactWidget, ReactWidget> = (
           title: entity.field_default_link.title,
         }
       : null,
-    buttonFormat: toBoolean(entity.field_button_format),
+    buttonFormat: entity.field_button_format,
   }
 }

--- a/src/components/vamcSystemMedicalRecordsOffice/__snapshots__/query.test.ts.snap
+++ b/src/components/vamcSystemMedicalRecordsOffice/__snapshots__/query.test.ts.snap
@@ -1,0 +1,381 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`VamcSystemMedicalRecordsOffice formatter outputs formatted data 1`] = `
+{
+  "breadcrumbs": [
+    {
+      "options": [],
+      "title": "Home",
+      "uri": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/",
+    },
+    {
+      "options": [],
+      "title": "VA Beckley health care",
+      "uri": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/beckley-health-care",
+    },
+    {
+      "options": [],
+      "title": "Medical records office",
+      "uri": "internal:#",
+    },
+  ],
+  "entityId": 45806,
+  "entityPath": "/beckley-health-care/medical-records-office",
+  "faqsContent": {
+    "displayAccordion": true,
+    "header": "Questions about medical records",
+    "id": "82653",
+    "intro": null,
+    "questions": [
+      {
+        "answers": [
+          {
+            "html": "<p>You can get another person's medical records if you’re listed as having Power of Attorney (POA) or you’re the patient’s next of kin.</p>",
+            "id": "82643",
+            "type": "paragraph--wysiwyg",
+          },
+        ],
+        "id": "82644",
+        "question": "Can I get someone else's medical records?",
+        "type": "paragraph--q_a",
+      },
+      {
+        "answers": [
+          {
+            "html": "<p>You can get the records of a deceased patient if you have:</p>
+
+<ul>
+	<li>A copy of their death certificate</li>
+	<li>A valid photo ID for yourself</li>
+	<li>Any POA paperwork or will showing you have a legal right to their record</li>
+</ul>",
+            "id": "82645",
+            "type": "paragraph--wysiwyg",
+          },
+        ],
+        "id": "82646",
+        "question": "Can I get records of a deceased patient?",
+        "type": "paragraph--q_a",
+      },
+      {
+        "answers": [
+          {
+            "html": "<p>Yes. If you’re making the request in person, you can tell us what format you would like. If you’re using <a href="https://www.va.gov/vaforms/medical/pdf/VHA%20Form%2010-5345a%20Fill-revision.pdf" hreflang="en">VA Form 10-5345a</a>, check the “CD-ROM” or “Other” box (and write in DVD).</p>",
+            "id": "82647",
+            "type": "paragraph--wysiwyg",
+          },
+        ],
+        "id": "82648",
+        "question": "Can I get records on a CD or DVD?",
+        "type": "paragraph--q_a",
+      },
+      {
+        "answers": [
+          {
+            "html": "<p>Yes, we provide all available images on DVD.</p>
+
+<p>If you have a <a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/home" hreflang="en" target="_blank">My HealtheVet Premium account</a>, you can also view or download many kinds of radiology images online. A Premium account is one where you’ve gone through extra identity authentication. </p>",
+            "id": "82649",
+            "type": "paragraph--wysiwyg",
+          },
+        ],
+        "id": "82650",
+        "question": "Can I get radiology images and X-rays?",
+        "type": "paragraph--q_a",
+      },
+      {
+        "answers": [
+          {
+            "html": "<p>Please ask at the Register for care office, and they will provide you documentation of your VA coverage.</p>",
+            "id": "82651",
+            "type": "paragraph--wysiwyg",
+          },
+        ],
+        "id": "82652",
+        "question": "Can I get a proof of health insurance document?",
+        "type": "paragraph--q_a",
+      },
+    ],
+    "type": "paragraph--q_a_section",
+  },
+  "getRecordsInPersonContent": {
+    "html": "<h2 id="get-your-records-in-person">Get your records in person</h2><p>We can help you get copies of your VA medical records. We can also help you update your records. Call or visit one of our release of information offices.</p><p><strong>What to bring</strong></p><ul><li>A signed written request for a copy of your records to be provided to you. For your convenience you may download and complete the “Individuals’ Request For a Copy of Their Own Health Information” (VA Form 10-5345a).  <a href="https://www.va.gov/vaforms/medical/pdf/VHA%20Form%2010-5345a%20Fill-revision.pdf" hreflang="en">Download VA Form 10-5345a (PDF)</a></li><li>Your Veteran Health Identification Card (VHIC)</li></ul>",
+    "id": "82639",
+    "type": "paragraph--wysiwyg",
+  },
+  "howWeShareRecordsContent": {
+    "html": "<p>Per VHA Directives, we have 20 business days to process all requests. Requests are accepted in-person, through My HealtheVet, mail, and fax. Please contact the facility to verify if submission by email is available.</p><p> </p><h2 id="how-we-share-your-records-with">How we share your records with providers outside VA</h2><p>The Veterans Health Information Exchange (VHIE) program lets us electronically share your health information with health care providers who treat you, including <a href="https://www.va.gov/vhie/" hreflang="en">participating non-VA providers</a> if you receive care outside of VA.</p><p>This program is voluntary, and you can choose not to share your information (opt out of sharing).</p><p><a href="https://www.va.gov/health-care/get-medical-records/#the-veterans-health-informatio">Learn more about VHIE</a></p><h3 id="to-opt-out-of-sharing">To opt out of sharing</h3><p>Fill out, sign, and date VA Form 10-10164 (Opt Out of Sharing Protected Health Information).</p><p>Mail the signed, completed form to our ROI office. You can also bring it with you or ask for this form when you visit us.</p><p><a href="https://www.va.gov/vaforms/medical/pdf/10-10164-fill.pdf" hreflang="en">Download VA Form 10-10164 (PDF)</a></p><p><strong>Note: </strong>If you had revoked your permission to share, before September 30, 2019, your opt out status will stay active. You don’t need to submit form 10-10164.</p><h3 id="to-allow-sharing-after-opting-">To allow sharing after opting out</h3><p>If you change your mind and want to share your health information, you’ll need to submit VA Form 10-10163 (Request for and Permission to Participate in Sharing Protected Health Information).</p><p>Mail the signed, completed form to our ROI office. You can also bring it with you or ask for this form when you visit us.</p><p><a href="https://www.va.gov/vaforms/medical/pdf/10-10163-fill.pdf" hreflang="en">Download VA Form 10-10163 (PDF)</a></p>",
+    "id": "82641",
+    "type": "paragraph--wysiwyg",
+  },
+  "id": "a2123e95-9605-4988-af58-5946129b0e5d",
+  "lastUpdated": "2022-05-26T16:02:50+00:00",
+  "lovellSwitchPath": null,
+  "lovellVariant": null,
+  "menu": {
+    "data": {
+      "description": null,
+      "links": [
+        {
+          "description": null,
+          "expanded": false,
+          "label": "VA Richmond health care",
+          "links": [
+            {
+              "description": null,
+              "expanded": false,
+              "label": "SERVICES AND LOCATIONS",
+              "links": [],
+              "lovellSection": null,
+              "url": {
+                "path": "",
+              },
+            },
+            {
+              "description": null,
+              "expanded": false,
+              "label": "NEWS AND EVENTS",
+              "links": [],
+              "lovellSection": null,
+              "url": {
+                "path": "",
+              },
+            },
+            {
+              "description": null,
+              "expanded": false,
+              "label": "ABOUT VA RICHMOND",
+              "links": [],
+              "lovellSection": null,
+              "url": {
+                "path": "",
+              },
+            },
+          ],
+          "lovellSection": null,
+          "url": {
+            "path": "/richmond-health-care",
+          },
+        },
+      ],
+      "name": "VA Richmond health care",
+    },
+    "rootPath": "/beckley-health-care/medical-records-office/",
+  },
+  "metatags": [],
+  "moderationState": "published",
+  "published": true,
+  "reactWidget": {
+    "buttonFormat": false,
+    "ctaWidget": true,
+    "defaultLink": null,
+    "entityId": null,
+    "errorMessage": "<strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.",
+    "id": "82635",
+    "loadingMessage": null,
+    "timeout": 20,
+    "type": "paragraph--react_widget",
+    "widgetType": "modern-get-medical-records-page",
+  },
+  "relatedLinks": {
+    "entityId": null,
+    "id": "82659",
+    "linkTeasers": [
+      {
+        "componentParams": {
+          "sectionHeader": "",
+        },
+        "entityId": null,
+        "id": "82655",
+        "options": {
+          "data-entity-substitution": "canonical",
+          "data-entity-type": "node",
+          "data-entity-uuid": "5f539c97-cfe7-4496-9dd5-a9b4d01f592d",
+          "href": "entity:node/8473",
+        },
+        "parentField": null,
+        "summary": "Find out how to change your address and other information in your VA.gov profile. This will update your information across several VA benefits and services.",
+        "title": "Change your address on file with VA",
+        "type": "paragraph--link_teaser",
+        "uri": "/test-translated-path",
+      },
+      {
+        "componentParams": {
+          "sectionHeader": "",
+        },
+        "entityId": null,
+        "id": "82656",
+        "options": {
+          "data-entity-substitution": "canonical",
+          "data-entity-type": "node",
+          "data-entity-uuid": "bcca7668-9a43-47ec-b029-e3563dc836f4",
+          "href": "entity:node/39",
+        },
+        "parentField": null,
+        "summary": "Update your personal, financial, or insurance information with VA Form 10-10EZR.",
+        "title": "Update your VA health benefits information",
+        "type": "paragraph--link_teaser",
+        "uri": "/test-translated-path",
+      },
+      {
+        "componentParams": {
+          "sectionHeader": "",
+        },
+        "entityId": null,
+        "id": "82657",
+        "options": {
+          "data-entity-substitution": "canonical",
+          "data-entity-type": "node",
+          "data-entity-uuid": "be5ce8bb-48af-4ac0-bf45-124081bb3dcb",
+          "href": "entity:node/79",
+        },
+        "parentField": null,
+        "summary": "Apply for a printed Veteran ID card, get your VA benefit letters and military service records, and learn how to apply for a discharge upgrade.",
+        "title": "Access and manage your records",
+        "type": "paragraph--link_teaser",
+        "uri": "/test-translated-path",
+      },
+      {
+        "componentParams": {
+          "sectionHeader": "",
+        },
+        "entityId": null,
+        "id": "82658",
+        "options": {
+          "data-entity-substitution": "",
+          "data-entity-type": "",
+          "data-entity-uuid": "",
+          "href": "https://www.choose.va.gov/",
+        },
+        "parentField": null,
+        "summary": "Learn how we're making it easier for you to get health care through VA facilities, mobile health clinics, virtual telehealth, and community care providers.",
+        "title": "MISSION Act and VA health care",
+        "type": "paragraph--link_teaser",
+        "uri": "https://www.choose.va.gov/",
+      },
+    ],
+    "title": "More information",
+    "type": "paragraph--list_of_link_teasers",
+  },
+  "services": [
+    {
+      "address": {
+        "additional_name": null,
+        "address_line1": "1200 South Detroit Avenue",
+        "administrative_area": "OH",
+        "country_code": "US",
+        "dependent_locality": null,
+        "langcode": null,
+        "locality": "Toledo",
+        "postal_code": "43614-5903",
+      },
+      "id": "209b73cd-22e9-4cd4-901f-99e1b3c9fff0",
+      "path": "/ann-arbor-health-care/locations/toledo-va-clinic",
+      "phoneNumber": "419-259-2000",
+      "serviceLocations": [
+        {
+          "additionalHoursInfo": null,
+          "appointmentPhoneNumbers": [],
+          "apptIntroTextCustom": null,
+          "apptIntroTextType": null,
+          "contactInfoPhoneNumbers": [
+            {
+              "entityId": 109229,
+              "extension": "37523",
+              "id": "1adcb239-8634-45be-b7e5-15ca21c7a3f8",
+              "label": "Release of Information Office",
+              "number": "419-259-2000",
+              "phoneType": "tel",
+              "type": "paragraph--phone_number",
+            },
+            {
+              "entityId": 109230,
+              "extension": null,
+              "id": "082bb7b8-cc39-4544-b5e1-495dc50a0a75",
+              "label": "Release of Information",
+              "number": "419-213-7635",
+              "phoneType": "fax",
+              "type": "paragraph--phone_number",
+            },
+          ],
+          "emailContacts": [],
+          "hours": "0",
+          "id": "034314d2-4ee2-4b7b-9dc6-7e309036b72a",
+          "officeHours": [],
+          "officeVisits": null,
+          "onlineSchedulingAvail": null,
+          "serviceLocationAddress": {
+            "behavior_settings": [],
+            "breadcrumbs": [],
+            "content_translation_changed": null,
+            "content_translation_outdated": false,
+            "content_translation_source": "und",
+            "created": "2022-05-18T14:35:53+00:00",
+            "default_langcode": true,
+            "drupal_internal__id": 109231,
+            "drupal_internal__revision_id": 648810,
+            "field_address": {
+              "address_line1": "",
+              "address_line2": "",
+              "administrative_area": "",
+              "country_code": "US",
+              "dependent_locality": null,
+              "langcode": null,
+              "locality": "",
+              "postal_code": "",
+              "sorting_code": null,
+            },
+            "field_building_name_number": null,
+            "field_clinic_name": "Release of Information Office",
+            "field_use_facility_address": true,
+            "field_wing_floor_or_room_number": "1st Floor - Room 1-006",
+            "id": "26310f89-4b9d-4de0-b063-8fd52fbdf8cb",
+            "langcode": "en",
+            "links": {
+              "self": {
+                "href": "https://content-build-medc0xjkxm4jmpzxl3tfbcs7qcddsivh.ci.cms.va.gov/jsonapi/paragraph/service_location_address/26310f89-4b9d-4de0-b063-8fd52fbdf8cb?resourceVersion=id%3A648810",
+              },
+            },
+            "paragraph_type": {
+              "id": "bd794386-a382-48d0-84fb-47290c3c1176",
+              "resourceIdObjMeta": {
+                "drupal_internal__target_id": "service_location_address",
+              },
+              "type": "paragraphs_type--paragraphs_type",
+            },
+            "parent_field_name": "field_service_location_address",
+            "parent_id": "109232",
+            "parent_type": "paragraph",
+            "relationshipNames": [
+              "paragraph_type",
+            ],
+            "resourceIdObjMeta": {
+              "drupal_internal__target_id": 109231,
+              "target_revision_id": 648810,
+            },
+            "revision_translation_affected": true,
+            "status": true,
+            "type": "paragraph--service_location_address",
+          },
+          "type": "paragraph--service_location",
+          "useFacilityPhoneNumber": null,
+          "useMainFacilityPhone": false,
+          "virtualSupport": null,
+        },
+      ],
+      "title": "Toledo VA Clinic",
+    },
+  ],
+  "title": "Medical records office",
+  "topOfPageContent": {
+    "html": "<h2 id="get-your-records-online">Get your records online</h2><p>Access your VA medical records online. Sign in to view, organize, and share your VA medical records and other personal health information. We don't charge any fees to send copies directly to health care providers.</p>",
+    "id": "82634",
+    "type": "paragraph--wysiwyg",
+  },
+  "type": "node--vamc_system_medical_records_offi",
+  "vamcSystem": {
+    "id": "6e35d07b-6b55-4f0c-b92d-bfc6e4f46528",
+    "title": "VA Beckley health care",
+  },
+}
+`;

--- a/src/components/vamcSystemMedicalRecordsOffice/formatted-type.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/formatted-type.ts
@@ -7,6 +7,7 @@ import { ServiceLocation } from '../serviceLocation/formatted-type'
 import { FieldAddress } from '@/types/drupal/field_type'
 import { LovellChildVariant } from '@/lib/drupal/lovell/types'
 import { ReactWidget } from '../reactWidget/formatted-type'
+import { QaSection } from '../qaSection/formatted-type'
 
 export interface VamcSystemMedicalRecordsOffice extends PublishedEntity {
   title: string
@@ -15,6 +16,7 @@ export interface VamcSystemMedicalRecordsOffice extends PublishedEntity {
   topOfPageContent: Wysiwyg
   getRecordsInPersonContent: Wysiwyg
   howWeShareRecordsContent: Wysiwyg
+  faqsContent: QaSection
   reactWidget: ReactWidget
   relatedLinks: ListOfLinkTeasers
   services: Array<{

--- a/src/components/vamcSystemMedicalRecordsOffice/mock.formatted.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/mock.formatted.ts
@@ -588,6 +588,85 @@ const mockData: VamcSystemMedicalRecordsOffice = {
     id: '82641',
     html: '<p>Per VHA Directives, we have 20 business days to process all requests. Requests are accepted in-person, through My HealtheVet, mail, and fax. Please contact the facility to verify if submission by email is available.</p><p>&nbsp;</p><h2 id="how-we-share-your-records-with">How we share your records with providers outside VA</h2><p>The Veterans Health Information Exchange (VHIE) program lets us electronically share your health information with health care providers who treat you, including&nbsp;<a href="https://www.va.gov/vhie/" hreflang="en">participating non-VA&nbsp;providers</a>&nbsp;if you receive care outside of VA.</p><p>This program is voluntary, and you can choose not to share your information (opt out of sharing).</p><p><a href="https://www.va.gov/health-care/get-medical-records/#the-veterans-health-informatio">Learn more about VHIE</a></p><h3 id="to-opt-out-of-sharing">To opt out of sharing</h3><p>Fill out, sign, and date VA Form 10-10164 (Opt Out of Sharing Protected Health Information).</p><p>Mail the signed, completed form to our ROI office. You can also bring it with you or ask for this form when you visit us.</p><p><a href="https://www.va.gov/vaforms/medical/pdf/10-10164-fill.pdf" hreflang="en">Download VA Form 10-10164 (PDF)</a></p><p><strong>Note:&nbsp;</strong>If you had revoked your permission to share, before September 30, 2019, your opt out status will stay active. You don’t need to submit form 10-10164.</p><h3 id="to-allow-sharing-after-opting-">To allow sharing after opting out</h3><p>If you change your mind and want to share your health information, you’ll need to submit VA Form 10-10163 (Request for and Permission to Participate in Sharing Protected Health Information).</p><p>Mail the signed, completed form to our ROI office. You can also bring it with you or ask for this form when you visit us.</p><p><a href="https://www.va.gov/vaforms/medical/pdf/10-10163-fill.pdf" hreflang="en">Download VA Form 10-10163 (PDF)</a></p>',
   },
+  faqsContent: {
+    header: 'Questions about medical records',
+    intro: null,
+    questions: [
+      {
+        type: 'paragraph--q_a',
+        question: "Can I get someone else's medical records?",
+        answers: [
+          {
+            type: 'paragraph--wysiwyg',
+            id: '82643',
+            html: "<p>You can get another person's medical records if you’re listed as having Power of Attorney (POA) or you’re the patient’s next of kin.</p>",
+          },
+        ],
+        id: '82644',
+      },
+      {
+        type: 'paragraph--q_a',
+        question: 'Can I get records of a deceased patient?',
+        answers: [
+          {
+            type: 'paragraph--wysiwyg',
+            id: '82645',
+            html:
+              '<p>You can get the records of a deceased patient if you have:</p>\n' +
+              '\n' +
+              '<ul>\n' +
+              '\t<li>A copy of their death certificate</li>\n' +
+              '\t<li>A valid photo ID for yourself</li>\n' +
+              '\t<li>Any POA paperwork or will showing you have a legal right to their record</li>\n' +
+              '</ul>',
+          },
+        ],
+        id: '82646',
+      },
+      {
+        type: 'paragraph--q_a',
+        question: 'Can I get records on a CD or DVD?',
+        answers: [
+          {
+            type: 'paragraph--wysiwyg',
+            id: '82647',
+            html: '<p>Yes. If you’re making the request in person, you can tell us what format you would like. If you’re using&nbsp;<a href="https://www.va.gov/vaforms/medical/pdf/VHA%20Form%2010-5345a%20Fill-revision.pdf" hreflang="en">VA Form 10-5345a</a>, check the “CD-ROM” or “Other” box (and write in DVD).</p>',
+          },
+        ],
+        id: '82648',
+      },
+      {
+        type: 'paragraph--q_a',
+        question: 'Can I get radiology images and X-rays?',
+        answers: [
+          {
+            type: 'paragraph--wysiwyg',
+            id: '82649',
+            html:
+              '<p>Yes, we provide all available images on DVD.</p>\n' +
+              '\n' +
+              '<p>If you have a&nbsp;<a href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/home" hreflang="en" target="_blank">My HealtheVet Premium account</a>, you can also view or download many kinds of radiology images online. A Premium account is one where you’ve gone through extra identity authentication.&nbsp;</p>',
+          },
+        ],
+        id: '82650',
+      },
+      {
+        type: 'paragraph--q_a',
+        question: 'Can I get a proof of health insurance document?',
+        answers: [
+          {
+            type: 'paragraph--wysiwyg',
+            id: '82651',
+            html: '<p>Please ask at the Register for care office, and they will provide you documentation of your VA coverage.</p>',
+          },
+        ],
+        id: '82652',
+      },
+    ],
+    displayAccordion: true,
+    type: 'paragraph--q_a_section',
+    id: '82653',
+  },
   reactWidget: {
     type: 'paragraph--react_widget',
     id: '82635',

--- a/src/components/vamcSystemMedicalRecordsOffice/mock.json
+++ b/src/components/vamcSystemMedicalRecordsOffice/mock.json
@@ -75,7 +75,7 @@
     "fetched": {
       "field_accordion_display": [
         {
-          "value": "0"
+          "value": "1"
         }
       ],
       "field_questions": [

--- a/src/components/vamcSystemMedicalRecordsOffice/query.test.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/query.test.ts
@@ -55,6 +55,16 @@ describe('VamcSystemMedicalRecordsOffice formatter', () => {
     )
   })
 
+  it('formats faqsContent field correctly', () => {
+    const result = formatter(defaultData)
+
+    expect(result.faqsContent).toBeDefined()
+    expect(result.faqsContent.header).toContain(
+      'Questions about medical records'
+    )
+    expect(result.faqsContent.displayAccordion).toBe(true)
+  })
+
   it('formats relatedLinks field correctly', () => {
     const result = formatter(defaultData)
 

--- a/src/components/vamcSystemMedicalRecordsOffice/query.test.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/query.test.ts
@@ -5,82 +5,80 @@
  * the client: "You should not call getQueryData on the client."
  */
 
-import { formatter } from './query'
-import mockData from './mock.json'
+import mockPage from './mock.json'
 import mockMenu from './mock.menu.json'
 import mockServices from './mock.services.json'
-import { Menu } from '@/types/drupal/menu'
-import { VamcSystemMedicalRecordsOfficeData } from './query'
-import { NodeVhaFacilityNonclinicalService } from '@/types/drupal/node'
+import {
+  NodeVamcSystemMedicalRecordsOffice,
+  NodeVhaFacilityNonclinicalService,
+} from '@/types/drupal/node'
+import { RESOURCE_TYPES } from '@/lib/constants/resourceTypes'
+import { queries } from '@/lib/drupal/queries'
+import { LovellStaticPropsContextProps } from '@/lib/drupal/lovell/types'
 
-const defaultData: VamcSystemMedicalRecordsOfficeData = {
-  entity: mockData,
-  // @ts-expect-error - the `options` type of this real data is not compatible with that
-  // of the `DrupalMenuLinkContent` definition from `next-drupal`
-  menu: mockMenu as Menu,
-  services: mockServices as NodeVhaFacilityNonclinicalService[],
+const mockPageQuery = jest.fn(
+  () => mockPage as NodeVamcSystemMedicalRecordsOffice
+)
+const mockServicesQuery = jest.fn(
+  () => mockServices as NodeVhaFacilityNonclinicalService[]
+)
+
+jest.mock('@/lib/drupal/query', () => ({
+  ...jest.requireActual('@/lib/drupal/query'),
+  fetchSingleEntityOrPreview: () => mockPageQuery(),
+  fetchAndConcatAllResourceCollectionPages: () => ({
+    data: mockServicesQuery(),
+  }),
+  getMenu: () => mockMenu,
+}))
+
+jest.mock('@/lib/drupal/drupalClient', () => ({
+  drupalClient: {
+    translatePath: jest.fn().mockResolvedValue({
+      entity: {
+        path: '/test-translated-path',
+      },
+    }),
+  },
+}))
+
+function runQuery(lovell: Partial<LovellStaticPropsContextProps> = {}) {
+  return queries.getData(RESOURCE_TYPES.VAMC_SYSTEM_MEDICAL_RECORDS_OFFICE, {
+    id: mockPage.id,
+    context: {
+      path: '/test-path',
+      drupalPath: '/test-drupal-path',
+      listing: {
+        isListingPage: false,
+        firstPagePath: '/test-first-page-path',
+        page: 1,
+      },
+      lovell: {
+        isLovellVariantPage: false,
+        variant: null,
+        ...lovell,
+      },
+    },
+  })
 }
 
 describe('VamcSystemMedicalRecordsOffice formatter', () => {
-  it('formats basic fields correctly', () => {
-    const result = formatter(defaultData)
-
-    expect(result.title).toBe('Medical records office')
-    expect(result.entityId).toBe(45806)
-    expect(result.entityPath).toBe(
-      '/beckley-health-care/medical-records-office'
+  beforeEach(() => {
+    // Reset to default mock data before each test
+    mockPageQuery.mockReturnValue(
+      mockPage as NodeVamcSystemMedicalRecordsOffice
     )
-    expect(result.vamcSystem.title).toBe('VA Beckley health care')
-    expect(result.menu).toBeDefined()
-    expect(result.menu.rootPath).toBe(
-      '/beckley-health-care/medical-records-office/'
+    mockServicesQuery.mockReturnValue(
+      mockServices as NodeVhaFacilityNonclinicalService[]
     )
   })
 
-  it('formats topOfPageContent field correctly', () => {
-    const result = formatter(defaultData)
-
-    expect(result.topOfPageContent).toBeDefined()
-    expect(result.topOfPageContent.html).toContain(
-      '<h2 id="get-your-records-online">Get your records online</h2>'
-    )
+  test('outputs formatted data', async () => {
+    expect(await runQuery()).toMatchSnapshot()
   })
 
-  it('formats howWeShareRecordsContent field correctly', () => {
-    const result = formatter(defaultData)
-
-    expect(result.howWeShareRecordsContent).toBeDefined()
-    expect(result.howWeShareRecordsContent.html).toContain(
-      '<p>Per VHA Directives, we have 20 business days to process all requests.'
-    )
-  })
-
-  it('formats faqsContent field correctly', () => {
-    const result = formatter(defaultData)
-
-    expect(result.faqsContent).toBeDefined()
-    expect(result.faqsContent.header).toContain(
-      'Questions about medical records'
-    )
-    expect(result.faqsContent.displayAccordion).toBe(true)
-  })
-
-  it('formats relatedLinks field correctly', () => {
-    const result = formatter(defaultData)
-
-    expect(result.relatedLinks).toBeDefined()
-    expect(result.relatedLinks.title).toBe('More information')
-    expect(result.relatedLinks.linkTeasers).toHaveLength(4)
-    expect(result.relatedLinks.linkTeasers[0].title).toBe(
-      'Change your address on file with VA'
-    )
-    expect(result.relatedLinks.linkTeasers[0].summary).toBe(
-      'Find out how to change your address and other information in your VA.gov profile. This will update your information across several VA benefits and services.'
-    )
-  })
-
-  it('formats services array correctly and sorts them alphabetically', () => {
-    const result = formatter(defaultData)
+  test('formats services array correctly and sorts them alphabetically', async () => {
+    const result = await runQuery()
 
     expect(result.services).toBeDefined()
     expect(result.services).toHaveLength(1)
@@ -106,7 +104,7 @@ describe('VamcSystemMedicalRecordsOffice formatter', () => {
     expect(service.serviceLocations[0]).toBeDefined()
   })
 
-  it('sorts services alphabetically by title', () => {
+  test('sorts services alphabetically by title', async () => {
     const unsortedServices = [
       {
         ...mockServices[0],
@@ -124,10 +122,11 @@ describe('VamcSystemMedicalRecordsOffice formatter', () => {
       },
     ]
 
-    const result = formatter({
-      ...defaultData,
-      services: unsortedServices as NodeVhaFacilityNonclinicalService[],
-    })
+    mockServicesQuery.mockReturnValue(
+      unsortedServices as NodeVhaFacilityNonclinicalService[]
+    )
+
+    const result = await runQuery()
 
     expect(result.services).toHaveLength(2)
     expect(result.services[0].title).toBe('Alpha Medical Center')
@@ -158,17 +157,15 @@ describe('VamcSystemMedicalRecordsOffice formatter', () => {
       },
     ]
 
-    it('outputs formatted data with Lovell variant', () => {
-      const result = formatter({
-        ...defaultData,
-        entity: {
-          ...mockData,
-          path: lovellPath,
-        },
-        lovell: {
-          isLovellVariantPage: true,
-          variant: 'tricare',
-        },
+    test('outputs formatted data with Lovell variant', async () => {
+      mockPageQuery.mockReturnValue({
+        ...mockPage,
+        path: lovellPath,
+      } as NodeVamcSystemMedicalRecordsOffice)
+
+      const result = await runQuery({
+        isLovellVariantPage: true,
+        variant: 'tricare',
       })
 
       expect(result.lovellVariant).toBe('tricare')
@@ -177,18 +174,16 @@ describe('VamcSystemMedicalRecordsOffice formatter', () => {
       )
     })
 
-    it('updates the breadcrumbs for Lovell variant', () => {
-      const result = formatter({
-        ...defaultData,
-        entity: {
-          ...mockData,
-          path: lovellPath,
-          breadcrumbs: lovellBreadcrumbs,
-        },
-        lovell: {
-          isLovellVariantPage: true,
-          variant: 'tricare',
-        },
+    test('updates the breadcrumbs for Lovell variant', async () => {
+      mockPageQuery.mockReturnValue({
+        ...mockPage,
+        path: lovellPath,
+        breadcrumbs: lovellBreadcrumbs,
+      } as NodeVamcSystemMedicalRecordsOffice)
+
+      const result = await runQuery({
+        isLovellVariantPage: true,
+        variant: 'tricare',
       })
 
       expect(result.breadcrumbs[1]).toEqual({
@@ -198,46 +193,19 @@ describe('VamcSystemMedicalRecordsOffice formatter', () => {
       })
     })
 
-    it('does not modify breadcrumbs when not a Lovell variant page', () => {
-      const result = formatter({
-        ...defaultData,
-        entity: {
-          ...mockData,
-          path: lovellPath,
-          breadcrumbs: lovellBreadcrumbs,
-        },
-        lovell: {
-          isLovellVariantPage: false,
-          variant: 'va',
-        },
+    test('does not modify breadcrumbs when not a Lovell variant page', async () => {
+      mockPageQuery.mockReturnValue({
+        ...mockPage,
+        path: lovellPath,
+        breadcrumbs: lovellBreadcrumbs,
+      } as NodeVamcSystemMedicalRecordsOffice)
+
+      const result = await runQuery({
+        isLovellVariantPage: false,
+        variant: 'va',
       })
 
       expect(result.breadcrumbs).toEqual(lovellBreadcrumbs)
-    })
-
-    it('handles null lovell context', () => {
-      const result = formatter({
-        ...defaultData,
-        entity: {
-          ...mockData,
-          path: lovellPath,
-          breadcrumbs: lovellBreadcrumbs,
-        },
-        lovell: null,
-      })
-
-      expect(result.breadcrumbs).toEqual(lovellBreadcrumbs)
-      expect(result.lovellVariant).toBeNull()
-      expect(result.lovellSwitchPath).toBeNull()
-    })
-
-    it('formats reactWidget field correctly', () => {
-      const result = formatter(defaultData)
-
-      expect(result.reactWidget).toBeDefined()
-      expect(result.reactWidget.widgetType).toBe(
-        'modern-get-medical-records-page'
-      )
     })
   })
 })

--- a/src/components/vamcSystemMedicalRecordsOffice/query.ts
+++ b/src/components/vamcSystemMedicalRecordsOffice/query.ts
@@ -35,6 +35,7 @@ import {
   getOppositeChildVariant,
 } from '@/lib/drupal/lovell/utils'
 import { formatter as formatReactWidget } from '@/components/reactWidget/query'
+import { formatter as formatQaSection } from '@/components/qaSection/query'
 
 // Define the query params for fetching node--vamc_system_medical_records_office.
 export const params: QueryParams<null> = () => {
@@ -159,6 +160,9 @@ export const formatter: QueryFormatter<
     ),
     howWeShareRecordsContent: formatCcWysiwyg(
       entity.field_cc_how_we_share_records
+    ),
+    faqsContent: formatQaSection(
+      normalizeEntityFetchedParagraphs(entity.field_cc_faqs)
     ),
     reactWidget: formatReactWidget(
       normalizeEntityFetchedParagraphs(entity.field_cc_react_widget)

--- a/src/components/vamcSystemMedicalRecordsOffice/template.test.tsx
+++ b/src/components/vamcSystemMedicalRecordsOffice/template.test.tsx
@@ -74,4 +74,18 @@ describe('VamcSystemMedicalRecordsOffice', () => {
     )
     expect(howWeShareRecordsContent).toBeInTheDocument()
   })
+
+  it('renders the faqsContent', () => {
+    const { container } = render(
+      <VamcSystemMedicalRecordsOffice {...mockData} />
+    )
+    const faqsContent = screen.getByText(/Questions about medical records/)
+    expect(faqsContent).toBeInTheDocument()
+
+    // console.log(container.innerHTML)
+    const accordionDiv = container.querySelector(
+      '[data-template="paragraphs/q_a.collapsible_panel"]'
+    )
+    expect(accordionDiv).toBeInTheDocument()
+  })
 })

--- a/src/components/vamcSystemMedicalRecordsOffice/template.tsx
+++ b/src/components/vamcSystemMedicalRecordsOffice/template.tsx
@@ -11,6 +11,7 @@ import { Address } from '@/components/address/template'
 import { LovellSwitcher } from '@/components/lovellSwitcher/template'
 import { SideNavLayout } from '@/components/sideNavLayout/template'
 import { ReactWidget } from '@/components/reactWidget/template'
+import { QaSection } from '../qaSection/template'
 
 export const VamcSystemMedicalRecordsOffice = ({
   title,
@@ -20,6 +21,7 @@ export const VamcSystemMedicalRecordsOffice = ({
   topOfPageContent,
   getRecordsInPersonContent,
   howWeShareRecordsContent,
+  faqsContent,
   reactWidget,
   relatedLinks,
   services,
@@ -84,9 +86,10 @@ export const VamcSystemMedicalRecordsOffice = ({
 
         <Wysiwyg {...howWeShareRecordsContent} />
 
+        <QaSection {...faqsContent} />
+
         {/* TODO: Add centralized content sections from medical records template
               - fieldCcGetRecordsMailOrFax
-              - fieldCcFaqs
             */}
 
         {/* TODO: Add individual node fields from medical records template

--- a/src/components/vamcSystemVaPolice/__snapshots__/query.test.ts.snap
+++ b/src/components/vamcSystemVaPolice/__snapshots__/query.test.ts.snap
@@ -27,10 +27,10 @@ exports[`VamcSystemVaPolice formatData outputs formatted data 1`] = `
   "entityId": 63857,
   "entityPath": "/central-arkansas-health-care/va-police",
   "faqs": {
-    "displayAccordion": "1",
+    "displayAccordion": true,
     "header": "Other questions you may have about VA police",
     "id": "141575",
-    "intro": [],
+    "intro": null,
     "questions": [
       {
         "answers": [

--- a/src/lib/drupal/paragraphs.ts
+++ b/src/lib/drupal/paragraphs.ts
@@ -93,6 +93,20 @@ function isEntityFetchedRoot(root: unknown): root is EntityFetchedRoot {
   )
 }
 
+const toBoolean = (value: string | boolean) => {
+  if (typeof value === 'string') {
+    return value === '1'
+  }
+  return value
+}
+
+const toNumber = (value: string | number) => {
+  if (typeof value === 'string') {
+    return parseInt(value, 10)
+  }
+  return value
+}
+
 /**
  * These are fields that we expect to be actual arrays, so we don't want to convert them
  * to single values.
@@ -104,6 +118,14 @@ const EXPECTED_ARRAY_FIELDS = [
   'field_topics',
 ]
 
+const EXPECTED_BOOLEAN_FIELDS = [
+  'field_accordion_display',
+  'field_cta_widget',
+  'field_button_format',
+]
+
+const EXPECTED_NUMBER_FIELDS = ['field_timeout']
+
 /**
  * These are fields that could be null, so if we are converting from an array to a single
  * value and get an empty array, we want to convert it back to null.
@@ -112,6 +134,7 @@ const POSSIBLY_EMPTY_FIELDS = [
   'field_alert_block_reference',
   'field_default_link',
   'field_loading_message',
+  'field_section_intro',
 ]
 
 /**
@@ -155,7 +178,14 @@ export function normalizeEntityFetchedParagraphs<T extends DrupalParagraph>(
           !('format' in firstItem) &&
           !('processed' in firstItem)
         ) {
-          return [key, firstItem.value]
+          let value = firstItem.value
+          if (EXPECTED_BOOLEAN_FIELDS.includes(key)) {
+            value = toBoolean(value)
+          }
+          if (EXPECTED_NUMBER_FIELDS.includes(key)) {
+            value = toNumber(value)
+          }
+          return [key, value]
         }
         return [key, firstItem]
       }

--- a/src/lib/drupal/paragraphs.ts
+++ b/src/lib/drupal/paragraphs.ts
@@ -118,12 +118,18 @@ const EXPECTED_ARRAY_FIELDS = [
   'field_topics',
 ]
 
+/**
+ * Automatically convert `"0"` and `"1"` to `false` and `true`.
+ */
 const EXPECTED_BOOLEAN_FIELDS = [
   'field_accordion_display',
   'field_cta_widget',
   'field_button_format',
 ]
 
+/**
+ * Automatically parse the strings in these fields to numbers.
+ */
 const EXPECTED_NUMBER_FIELDS = ['field_timeout']
 
 /**

--- a/src/types/drupal/node.ts
+++ b/src/types/drupal/node.ts
@@ -484,11 +484,10 @@ export interface NodeVamcSystemMedicalRecordsOffice extends DrupalNode {
   field_cc_related_links: FieldCCListOfLinkTeasers
   field_cc_react_widget: FieldCCReactWidget
   field_cc_how_we_share_records: FieldCCText
+  field_cc_faqs: ParagraphCCQaSection
 
   // field_cc_get_records_in_person?: FieldCCText
   // field_cc_get_records_mail_or_fax?: FieldCCText
-
-  // field_cc_faqs?: FieldCCText
   // field_vamc_med_records_mailing?: FieldAddress
   // field_fax_number?: string
 }


### PR DESCRIPTION
## Description

Adds the FAQs, which also involved fixing a bug in parsing the boolean value of `field_accordion_display`. 

The bug was that the `entity_field_fetch` plugin was failing to translate the `1` and `0` values from Drupal and instead transliterated it as a string value. Our formatter function expected a Drupal paragraph entity coming from the Drupal API where boolean values are transmitted as JavaScript booleans. Because the string `"0"` is truthy in JavaScript, that flag was always on. This bug seemed to exist in `content-build` as well, because it showed the FAQ section of this page as an accordion, even though in the Drupal editing interface the corresponding checkbox was unchecked. To fix it, I'm moving the parsing of these boolean values and number values to the `normalizeEntityFetchedParagraphs`, whose purpose is to undo the `entity_field_fetch` mutilation.

## Ticket

Closes https://github.com/department-of-veterans-affairs/va.gov-cms/issues/21981

## Testing Steps

http://localhost:3999/boston-health-care/medical-records-office/

## Screenshots

<img width="1624" height="1056" alt="Screenshot 2025-10-03 at 10 22 56 AM" src="https://github.com/user-attachments/assets/36e1067c-6868-46d4-b57b-bb23bcb9460f" />
