### PR TITLE
VACMS-22304: missing analytics

### DIFF
--- a/src/lib/utils/getHtmlFromDrupalContent.ts
+++ b/src/lib/utils/getHtmlFromDrupalContent.ts
@@ -1,10 +1,17 @@
-import { drupalToVaPath, newlinesToBr, addH2Ids, addH3Ids } from './helpers'
+import {
+  drupalToVaPath,
+  newlinesToBr,
+  addH2Ids,
+  addH3Ids,
+  convertActionLinks,
+} from './helpers'
 import { createPhoneLinks } from './createPhoneLinks'
 
 export type GetHtmlFromDrupalContentOptions = {
   convertNewlines?: boolean
   addH2Ids?: boolean
   addH3Ids?: boolean
+  convertActionLinks?: boolean
 }
 
 /**
@@ -14,7 +21,10 @@ export type GetHtmlFromDrupalContentOptions = {
  */
 export const getHtmlFromDrupalContent = (
   content: string,
-  options: GetHtmlFromDrupalContentOptions = { addH2Ids: true }
+  options: GetHtmlFromDrupalContentOptions = {
+    addH2Ids: true,
+    convertActionLinks: true,
+  }
 ): string => {
   const transformers = [createPhoneLinks, drupalToVaPath]
   if (options.convertNewlines) {
@@ -25,6 +35,9 @@ export const getHtmlFromDrupalContent = (
   }
   if (options.addH3Ids) {
     transformers.push(addH3Ids)
+  }
+  if (options.convertActionLinks) {
+    transformers.push(convertActionLinks)
   }
   return transformers.reduce(
     (contentToTransform, transformFn) => transformFn(contentToTransform),

--- a/src/lib/utils/helpers.test.ts
+++ b/src/lib/utils/helpers.test.ts
@@ -13,6 +13,7 @@ import {
   addHeadingIds,
   addH2Ids,
   addH3Ids,
+  convertActionLinks,
 } from './helpers'
 
 describe('truncateWordsOrChar', () => {
@@ -470,5 +471,24 @@ describe('addH3Ids', () => {
     const input = '<h3>Hello World</h3>'
     const result = addH3Ids(input)
     expect(result).toBe('<h3 id="hello-world">Hello World</h3>')
+  })
+})
+
+describe('convertActionLinks', () => {
+  test('finds and converts action links', () => {
+    const input =
+      '<p>Hello World <a class="vads-c-action-link--green" href="/pay">Pay online, by phone, or by mail</a> <a class="vads-c-action-link--blue" href="/dont-pay">Do not pay</a></p>'
+    const result = convertActionLinks(input)
+    expect(result).toBe(
+      '<p>Hello World <va-link-action href="/pay" text="Pay online, by phone, or by mail" type="primary" /> <va-link-action href="/dont-pay" text="Do not pay" type="secondary" /></p>'
+    )
+  })
+  test('leaves other links alone', () => {
+    const input =
+      '<p>Hello World <a href="/pay">Pay online, by phone, or by mail</a></p>'
+    const result = convertActionLinks(input)
+    expect(result).toBe(
+      '<p>Hello World <a href="/pay">Pay online, by phone, or by mail</a></p>'
+    )
   })
 })

--- a/src/lib/utils/helpers.test.ts
+++ b/src/lib/utils/helpers.test.ts
@@ -491,4 +491,20 @@ describe('convertActionLinks', () => {
       '<p>Hello World <a href="/pay">Pay online, by phone, or by mail</a></p>'
     )
   })
+  test('strips tags in inner text', () => {
+    const input =
+      '<a class="vads-c-action-link--blue" href="/foo"><strong>Pay</strong> <em>now</em></a>'
+    const result = convertActionLinks(input)
+    expect(result).toBe(
+      '<va-link-action href="/foo" text="Pay now" type="secondary" />'
+    )
+  })
+  test('passes attrs to component', () => {
+    const input =
+      '<a class="vads-c-action-link--blue" data-testid="test-me" href="/foo">Pay now</a>'
+    const result = convertActionLinks(input)
+    expect(result).toBe(
+      '<va-link-action data-testid="test-me" href="/foo" text="Pay now" type="secondary" />'
+    )
+  })
 })

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -224,7 +224,8 @@ export const convertActionLinks = (content: string): string => {
         .replace(/class="[^"]*vads-c-action-link--(blue|green)[^"]*"/, '')
         .trim()
       // Strip HTML tags from inner to get only the text
-      const innerText = inner.replace(/<[^>]+>/g, '').trim()
+      // Also remove any remaining angle brackets to avoid incomplete tag fragments
+      const innerText = inner.replace(/<[^>]+>/g, '').replace(/[<>]/g, '').trim()
       return `<va-link-action ${newAttrs} text="${innerText}" type="${type}" />`
     }
   )

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -225,7 +225,10 @@ export const convertActionLinks = (content: string): string => {
         .trim()
       // Strip HTML tags from inner to get only the text
       // Also remove any remaining angle brackets to avoid incomplete tag fragments
-      const innerText = inner.replace(/<[^>]+>/g, '').replace(/[<>]/g, '').trim()
+      const innerText = inner
+        .replace(/<[^>]+>/g, '')
+        .replace(/[<>]/g, '')
+        .trim()
       return `<va-link-action ${newAttrs} text="${innerText}" type="${type}" />`
     }
   )

--- a/src/lib/utils/helpers.ts
+++ b/src/lib/utils/helpers.ts
@@ -209,3 +209,23 @@ export const addHeadingIds = (content: string, level: string): string => {
     }
   )
 }
+
+/**
+ * Converts action link style defined in wysiwyg to web-component
+ */
+export const convertActionLinks = (content: string): string => {
+  if (!content) return content
+  return content.replace(
+    /<a([^>]*class="[^"]*vads-c-action-link--(blue|green)[^"]*"[^>]*)>([\s\S]*?)<\/a>/gi,
+    (match, attrs, color, inner) => {
+      const type = color === 'blue' ? 'secondary' : 'primary'
+      // Remove class attribute for either blue or green
+      const newAttrs = attrs
+        .replace(/class="[^"]*vads-c-action-link--(blue|green)[^"]*"/, '')
+        .trim()
+      // Strip HTML tags from inner to get only the text
+      const innerText = inner.replace(/<[^>]+>/g, '').trim()
+      return `<va-link-action ${newAttrs} text="${innerText}" type="${type}" />`
+    }
+  )
+}


### PR DESCRIPTION
## Notice about main branch
Until further notice, the main branch of this repo is locked. Pull requests should be made against the [integration-202510](https://github.com/department-of-veterans-affairs/next-build/tree/integration-202510) branch. 

Merges to the main branch for critical bugs or security updates are allowed. Please contact CMS Team in the [#platform-cms-team](https://dsva.slack.com/archives/CT4GZBM8F) channel if you need assistance. 

## Description

Converts action links created in Drupal wysiwyg to the web-component `va-link-action` in order to take advantage of the built in analytics. This also resolves the need to make changes in Drupal when the classes get deprecated. The conversion is optional, but on be default.

This pull request introduces a new utility function for converting specific action links in HTML content to a standardized web component format, and integrates this transformation into the `getHtmlFromDrupalContent` pipeline. It also adds comprehensive unit tests to ensure the new functionality works as intended.

**Action link conversion:**

* Added the `convertActionLinks` function to `helpers.ts`, which transforms `<a>` tags with `vads-c-action-link--blue` or `vads-c-action-link--green` classes into `<va-link-action>` web components, assigning the appropriate `type` attribute (`primary` or `secondary`).

**Integration with Drupal content processing:**

* Updated `getHtmlFromDrupalContent` in `getHtmlFromDrupalContent.ts` to support an optional `convertActionLinks` parameter, defaulting to `true`, and included `convertActionLinks` in the transformation pipeline when enabled. [[1]](diffhunk://#diff-cdf83fcb1b95d3e72a25c514ec3bbcf1a70015b3a19992ce97134598433791d3L1-R14) [[2]](diffhunk://#diff-cdf83fcb1b95d3e72a25c514ec3bbcf1a70015b3a19992ce97134598433791d3L17-R27) [[3]](diffhunk://#diff-cdf83fcb1b95d3e72a25c514ec3bbcf1a70015b3a19992ce97134598433791d3R39-R41)

**Testing improvements:**

* Added unit tests for `convertActionLinks` in `helpers.test.ts`, covering both conversion of action links and ensuring non-action links remain unchanged.
* Updated import statements in `helpers.test.ts` to include the new `convertActionLinks` function.
## Ticket

<!--
https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Closes [22304](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/22304)

## Developer Task

- [ ] PR submitted against the `main` branch of `next-build`.
- [ ] Link to the issue that this PR addresses (if applicable).
- [ ] Define all changes in your PR and note any changes that could potentially be breaking changes.
- [ ] PR includes steps to test your changes and links to these changes in the Tugboat preview (if applicable).
- [ ] Provided before and after screenshots of your changes (if applicable).
- [ ] Alerted the #next-build Slack channel to request a PR review.
- [ ] You understand that once approved, you are responsible for merging your changes into `main`. (Note that changes to `main` will move automatically into production.)

## Testing Steps

 - [ ] visit [boston-health-care/billing-and-insurance/](https://pr1375-y6rihg57zqljevfgqk86lhe3timpbl8q.tugboat.vfs.va.gov/boston-health-care/billing-and-insurance/) on tugboat
 - [ ] verify that the `Pay online, by phone, or by mail` link utilizes the `va-link-action` component


## Is this PR blocked by another PR?

- Add the `DO NOT MERGE` label
- Add links to additional PRs here:

---

## Reviewer

### Reviewing a PR

This section lists items that need to be checked or updated when making changes to this repository.

## Standard Checks

- [ ] Code Quality: Readabilty, Naming Conventions, Consistency, Reusability
- [ ] Test Coverage: 80% coverage
- [ ] Functionality: Change functions as expected with no additional bugs
- [ ] Performance: Code does not introduce performance issues
- [ ] Documentation: Changes are documented in their respective README.md files
- [ ] Security: Packages have been approved in the TRM

## Merging a Layout

When merging a layout, you must ensure that the content type has been turned on for `next-build` in the [.tugboat.env](../envs/.tugboat.env). This method mocks the CMS flag that must be turned on for a layout to be included in the build.

The layout component and matching resource type should be included in the [slug.tsx](../src/pages/[[...slug]].tsx), so that it can reviewed. Including a component in the slug.tsx does not mean a page will be viewable in production only on the tugboat for the branch.

When a layout is merged to main and approved for deployment, the prod CMS will turn the toggle on for the resource type. 

The status of layouts should be kept up to date inside [templates.md](../READMEs/templates.md). This includes QA progress, development progress, etc. A link should be provided for where testing can occur.
